### PR TITLE
docs/ Adicionando o dicionario do EAP

### DIFF
--- a/dicionarioEAP.md
+++ b/dicionarioEAP.md
@@ -1,0 +1,29 @@
+# Dicionário da EAP — SmartBudget
+
+## 1. Gerenciamento
+
+O grupo de Gerenciamento reúne as atividades responsáveis por estruturar e controlar o projeto como um todo. Inclui a elaboração da documentação inicial (termo de abertura, escopo e objetivos), a definição do cronograma com marcos e prazos, e o gerenciamento de riscos, que cobre a identificação e o plano de resposta a possíveis problemas ao longo do desenvolvimento.
+
+## 2. Requisitos
+
+Este grupo trata do levantamento e documentação de tudo que o sistema precisa fazer e como deve se comportar. Os requisitos funcionais descrevem as funcionalidades esperadas pelo usuário, os requisitos não funcionais definem critérios de qualidade como desempenho e segurança, e as regras de negócio mapeiam as restrições e lógicas que governam o comportamento da aplicação.
+
+## 3. Design / UX
+
+O grupo de Design e UX cobre todas as etapas de concepção visual e de experiência do usuário. Começa pelos wireframes, que são protótipos de baixa fidelidade para esboçar os fluxos de tela, avança para o protótipo navegável de alta fidelidade usado na validação com stakeholders, e se encerra com o guia de estilo, que padroniza cores, tipografia, ícones e componentes visuais da aplicação.
+
+## 4. Desenvolvimento
+
+É o maior grupo do projeto, contemplando a implementação de todas as funcionalidades do SmartBudget. Abrange os módulos de autenticação e perfil do usuário, gerenciamento de contas, importação de extratos bancários, integração com NF-e, categorização de gastos, geração de relatórios financeiros, previsão de despesas e sistema de notificações.
+
+## 5. Testes / QA
+
+O grupo de Testes garante a qualidade e o correto funcionamento do sistema antes da entrega. Os testes unitários validam partes isoladas do código, os testes de integração verificam a comunicação entre os módulos, e os testes de UAT (User Acceptance Testing) são conduzidos pelos próprios usuários para confirmar que as funcionalidades atendem às expectativas definidas nos requisitos.
+
+## 6. Implantação
+
+Este grupo cobre a colocação do sistema em produção. Inclui a configuração da infraestrutura de back-end com Spring Boot e PostgreSQL, o build e deploy do front-end em React, e a produção da documentação técnica com detalhes sobre a API, a arquitetura do sistema e os guias de manutenção para a equipe técnica.
+
+## 7. Treinamento
+
+O grupo de Treinamento tem como único entregável o manual do usuário, documento voltado ao público final da plataforma SmartBudget. Seu objetivo é garantir que os usuários consigam utilizar o sistema de forma autônoma, cobrindo as principais funcionalidades e fluxos da aplicação de maneira clara e acessível.


### PR DESCRIPTION
# Dicionário da EAP — SmartBudget

Dicionário solicitado na aula de atividade de extensão 2, tem o objetivo de explicar cada grupo definido no EAP.

## O que mudou

- Adicionado o arquivo `Dicionario_EAP_SmartBudget.md` com a descrição em prosa de cada um dos 7 grupos da EAP do projeto SmartBudget

## Por quê

- Entrega da atividade de extensão 2, que exige a documentação dos grupos definidos na Estrutura Analítica do Projeto

## Como testar

1. Acesse o arquivo `Dicionario_EAP_SmartBudget.md` adicionado neste commit
2. Verifique se os 7 grupos estão presentes: Gerenciamento, Requisitos, Design/UX, Desenvolvimento, Testes/QA, Implantação e Treinamento
3. Confirme que cada grupo possui exatamente um parágrafo descritivo
4. Valide se o conteúdo está coerente com o mapa EAP definido no Lucidchart

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos

- [Manutenção] O arquivo foi criado em Markdown puro para facilitar futuras edições, sem dependências de ferramentas externas. Qualquer membro da equipe pode atualizar o conteúdo diretamente pelo GitHub.
- [Risco] O dicionário foi gerado com base na imagem do mapa EAP. Caso o mapa seja alterado no Lucidchart sem atualização correspondente neste arquivo, a documentação ficará desatualizada.
- [Teste] Validação realizada manualmente: todos os 7 grupos do mapa EAP estão representados e os nomes das entregas conferem com os elementos visíveis no diagrama original.