### PR TITLE
Test/01registro login tests

### DIFF
--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/RegisterRequestDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/RegisterRequestDTO.java
@@ -1,4 +1,8 @@
 package bcd.appfinanceirobackend.dto.auth;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
 public class RegisterRequestDTO {
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/RegisterRequestDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/RegisterRequestDTO.java
@@ -1,8 +1,4 @@
 package bcd.appfinanceirobackend.dto.auth;
 
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter @Setter
 public class RegisterRequestDTO {
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/TokenDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/TokenDTO.java
@@ -1,4 +1,0 @@
-package bcd.appfinanceirobackend.dto.auth;
-
-public class TokenDTO {
-}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/TokenDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/TokenDTO.java
@@ -1,0 +1,4 @@
+package bcd.appfinanceirobackend.dto.auth;
+
+public class TokenDTO {
+}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/model/Usuario.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/model/Usuario.java
@@ -26,7 +26,7 @@ public class Usuario {
     private String senha;
 
     @Column(nullable = false, unique = true)
-    private char[] cpf;
+    private String cpf;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/RegistrarLoginTests.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/RegistrarLoginTests.java
@@ -1,0 +1,346 @@
+package bcd.appfinanceirobackend;
+
+import bcd.appfinanceirobackend.dto.auth.LoginRequestDTO;
+import bcd.appfinanceirobackend.dto.auth.RegisterRequestDTO;
+import bcd.appfinanceirobackend.dto.auth.TokenDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.repository.UsuarioRepository;
+import bcd.appfinanceirobackend.security.JwtUtil;
+import bcd.appfinanceirobackend.service.UsuarioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class RegistrarLoginTests {
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private UsuarioService usuarioService;
+
+    private RegisterRequestDTO dtoCadastro;
+    private LoginRequestDTO    dtoLogin;
+    private Usuario            usuarioNoBanco;
+
+    @BeforeEach
+    void setUp() {
+        dtoCadastro = new RegisterRequestDTO();
+        dtoCadastro.setNome("Maria Silva");
+        dtoCadastro.setEmail("maria@email.com");
+        dtoCadastro.setSenha("Senha@123");
+        dtoCadastro.setCpf("12345678901".toCharArray());
+
+        dtoLogin = new LoginRequestDTO();
+        dtoLogin.setEmail("maria@email.com");
+        dtoLogin.setSenha("Senha@123");
+
+        usuarioNoBanco = new Usuario();
+        usuarioNoBanco.setId(UUID.randomUUID());
+        usuarioNoBanco.setNome("Maria Silva");
+        usuarioNoBanco.setEmail("maria@email.com");
+        usuarioNoBanco.setSenha("$2a$10$hashBcryptSimulado"); 
+        usuarioNoBanco.setCpf("12345678901".toCharArray());
+        usuarioNoBanco.setCreatedAt(LocalDateTime.now());
+    }
+
+    @Nested
+    @DisplayName("registrar()")
+    class Registrar {
+
+        /**
+         * R1 — Dados válidos: email e CPF livres, todos os campos preenchidos.
+         * O service deve salvar, retornar o usuário persistido e nunca
+         * armazenar a senha em texto puro.
+         */
+        @Test
+        @DisplayName("R1 - dados válidos → retorna Usuario salvo com senha em hash")
+        void registrar_dadosValidos_retornaUsuario() {
+            when(usuarioRepository.existsByEmail(dtoCadastro.getEmail()))
+                    .thenReturn(false);
+            when(usuarioRepository.existsByCpf(dtoCadastro.getCpf()))
+                    .thenReturn(false);
+            when(passwordEncoder.encode(dtoCadastro.getSenha()))
+                    .thenReturn("$2a$10$hashBcryptSimulado");
+            when(usuarioRepository.save(any(Usuario.class)))
+                    .thenReturn(usuarioNoBanco);
+
+            Usuario resultado = usuarioService.registrar(dtoCadastro);
+
+            assertThat(resultado).isNotNull();
+            assertThat(resultado.getId()).isNotNull();
+            assertThat(resultado.getCreatedAt()).isNotNull();
+            assertThat(resultado.getSenha()).isNotEqualTo(dtoCadastro.getSenha());
+            verify(usuarioRepository).save(any(Usuario.class));
+        }
+
+        /**
+         * R2 — Email já cadastrado: banco já possui esse email (unique).
+         * Esperamos DataIntegrityViolationException e nenhum save adicional.
+         */
+        @Test
+        @DisplayName("R2 - email já cadastrado → lança DataIntegrityViolationException")
+        void registrar_emailJaCadastrado_lancaExcecao() {
+            when(usuarioRepository.existsByEmail(dtoCadastro.getEmail()))
+                    .thenReturn(true);
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        /**
+         * R3 — CPF já cadastrado: banco já possui esse CPF (unique).
+         */
+        @Test
+        @DisplayName("R3 - CPF já cadastrado → lança DataIntegrityViolationException")
+        void registrar_cpfJaCadastrado_lancaExcecao() {
+            when(usuarioRepository.existsByEmail(dtoCadastro.getEmail()))
+                    .thenReturn(false);
+            when(usuarioRepository.existsByCpf(dtoCadastro.getCpf()))
+                    .thenReturn(true);
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        /**
+         * R4 — Email nulo: service deve rejeitar antes de consultar o banco.
+         */
+        @Test
+        @DisplayName("R4 - email nulo → lança IllegalArgumentException")
+        void registrar_emailNulo_lancaExcecao() {
+            dtoCadastro.setEmail(null);
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        /**
+         * R4b — Email em branco.
+         */
+        @Test
+        @DisplayName("R4b - email em branco → lança IllegalArgumentException")
+        void registrar_emailVazio_lancaExcecao() {
+            dtoCadastro.setEmail("   ");
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        /**
+         * R5 — Senha nula.
+         */
+        @Test
+        @DisplayName("R5 - senha nula → lança IllegalArgumentException")
+        void registrar_senhaNula_lancaExcecao() {
+            dtoCadastro.setSenha(null);
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        /**
+         * R5b — Senha em branco.
+         */
+        @Test
+        @DisplayName("R5b - senha em branco → lança IllegalArgumentException")
+        void registrar_senhaVazia_lancaExcecao() {
+            dtoCadastro.setSenha("   ");
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        /**
+         * R6 — Nome nulo.
+         */
+        @Test
+        @DisplayName("R6 - nome nulo → lança IllegalArgumentException")
+        void registrar_nomeNulo_lancaExcecao() {
+            dtoCadastro.setNome(null);
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        /**
+         * R6b — Nome em branco.
+         */
+        @Test
+        @DisplayName("R6b - nome em branco → lança IllegalArgumentException")
+        void registrar_nomeVazio_lancaExcecao() {
+            dtoCadastro.setNome("   ");
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("autenticar()")
+    class Autenticar {
+
+        /**
+         * A1 — Credenciais corretas: usuário existe e senha bate.
+         * O service deve retornar um TokenDTO com token e tipo preenchidos.
+         */
+        @Test
+        @DisplayName("A1 - credenciais corretas → retorna TokenDTO")
+        void autenticar_credenciaisCorretas_retornaToken() {
+            when(usuarioRepository.findByEmail(dtoLogin.getEmail()))
+                    .thenReturn(Optional.of(usuarioNoBanco));
+            when(passwordEncoder.matches(dtoLogin.getSenha(), usuarioNoBanco.getSenha()))
+                    .thenReturn(true);
+
+            TokenDTO tokenEsperado = new TokenDTO();
+            tokenEsperado.setAccessToken("jwt.token.simulado");
+            tokenEsperado.setTipo("Bearer");
+            tokenEsperado.setExpiracao(LocalDateTime.now().plusHours(1));
+            when(jwtUtil.gerarToken(usuarioNoBanco)).thenReturn(tokenEsperado);
+
+            TokenDTO resultado = usuarioService.autenticar(
+                    dtoLogin.getEmail(),
+                    dtoLogin.getSenha()
+            );
+
+            assertThat(resultado).isNotNull();
+            assertThat(resultado.getAccessToken()).isNotBlank();
+            assertThat(resultado.getTipo()).isNotBlank();
+        }
+
+        /**
+         * A2 — Email não encontrado: repositório retorna Optional vazio.
+         */
+        @Test
+        @DisplayName("A2 - email inexistente → lança UsernameNotFoundException")
+        void autenticar_emailInexistente_lancaExcecao() {
+            when(usuarioRepository.findByEmail(dtoLogin.getEmail()))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> usuarioService.autenticar(
+                    dtoLogin.getEmail(),
+                    dtoLogin.getSenha()
+            )).isInstanceOf(UsernameNotFoundException.class);
+
+            verify(jwtUtil, never()).gerarToken(any());
+        }
+
+        /**
+         * A3 — Senha incorreta: usuário existe mas o hash não bate.
+         */
+        @Test
+        @DisplayName("A3 - senha incorreta → lança BadCredentialsException")
+        void autenticar_senhaIncorreta_lancaExcecao() {
+            when(usuarioRepository.findByEmail(dtoLogin.getEmail()))
+                    .thenReturn(Optional.of(usuarioNoBanco));
+            when(passwordEncoder.matches(dtoLogin.getSenha(), usuarioNoBanco.getSenha()))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> usuarioService.autenticar(
+                    dtoLogin.getEmail(),
+                    dtoLogin.getSenha()
+            )).isInstanceOf(BadCredentialsException.class);
+
+            verify(jwtUtil, never()).gerarToken(any());
+        }
+
+        /**
+         * A4 — Email nulo: validação deve ocorrer antes de qualquer consulta.
+         */
+        @Test
+        @DisplayName("A4 - email nulo → lança IllegalArgumentException")
+        void autenticar_emailNulo_lancaExcecao() {
+            assertThatThrownBy(() -> usuarioService.autenticar(
+                    null,
+                    dtoLogin.getSenha()
+            )).isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).findByEmail(any());
+            verify(jwtUtil, never()).gerarToken(any());
+        }
+
+        /**
+         * A4b — Email em branco.
+         */
+        @Test
+        @DisplayName("A4b - email em branco → lança IllegalArgumentException")
+        void autenticar_emailVazio_lancaExcecao() {
+            assertThatThrownBy(() -> usuarioService.autenticar(
+                    "   ",
+                    dtoLogin.getSenha()
+            )).isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).findByEmail(any());
+        }
+
+        /**
+         * A5 — Senha nula.
+         */
+        @Test
+        @DisplayName("A5 - senha nula → lança IllegalArgumentException")
+        void autenticar_senhaNula_lancaExcecao() {
+            assertThatThrownBy(() -> usuarioService.autenticar(
+                    dtoLogin.getEmail(),
+                    null
+            )).isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).findByEmail(any());
+            verify(jwtUtil, never()).gerarToken(any());
+        }
+
+        /**
+         * A5b — Senha em branco.
+         */
+        @Test
+        @DisplayName("A5b - senha em branco → lança IllegalArgumentException")
+        void autenticar_senhaVazia_lancaExcecao() {
+            assertThatThrownBy(() -> usuarioService.autenticar(
+                    dtoLogin.getEmail(),
+                    "   "
+            )).isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).findByEmail(any());
+        }
+    }
+}

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/RegistrarLoginTests.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/RegistrarLoginTests.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.*;
 
 
 @ExtendWith(MockitoExtension.class)
-class RegistrarLoginTests {
+class   RegistrarLoginTests {
 
     @Mock
     private UsuarioRepository usuarioRepository;
@@ -54,7 +54,7 @@ class RegistrarLoginTests {
         dtoCadastro.setNome("Maria Silva");
         dtoCadastro.setEmail("maria@email.com");
         dtoCadastro.setSenha("Senha@123");
-        dtoCadastro.setCpf("12345678901".toCharArray());
+        dtoCadastro.setCpf("12345678901");
 
         dtoLogin = new LoginRequestDTO();
         dtoLogin.setEmail("maria@email.com");
@@ -65,7 +65,7 @@ class RegistrarLoginTests {
         usuarioNoBanco.setNome("Maria Silva");
         usuarioNoBanco.setEmail("maria@email.com");
         usuarioNoBanco.setSenha("$2a$10$hashBcryptSimulado"); 
-        usuarioNoBanco.setCpf("12345678901".toCharArray());
+        usuarioNoBanco.setCpf("12345678901");
         usuarioNoBanco.setCreatedAt(LocalDateTime.now());
     }
 
@@ -232,7 +232,7 @@ class RegistrarLoginTests {
         @Test
         @DisplayName("R7b - CPF em branco → lança IllegalArgumentException")
         void registrar_cpfVazio_lancaExcecao() {
-            dtoCadastro.setCpf(new char[0]);
+            dtoCadastro.setCpf(""); // String vazia
 
             assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
                     .isInstanceOf(IllegalArgumentException.class);
@@ -244,7 +244,7 @@ class RegistrarLoginTests {
         @Test
         @DisplayName("R7c - CPF com formato inválido → lança IllegalArgumentException")
         void registrar_cpfFormatoInvalido_lancaExcecao() {
-            dtoCadastro.setCpf("1234".toCharArray());
+            dtoCadastro.setCpf("1234"); // String com menos de 11 caracteres
 
             assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
                     .isInstanceOf(IllegalArgumentException.class);

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/RegistrarLoginTests.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/RegistrarLoginTests.java
@@ -215,6 +215,54 @@ class RegistrarLoginTests {
 
             verify(usuarioRepository, never()).save(any());
         }
+
+        // R7 - CPF nulo → lança IllegalArgumentException
+        @Test
+        @DisplayName("R7 - CPF nulo → lança IllegalArgumentException")
+        void registrar_cpfNulo_lancaExcecao() {
+            dtoCadastro.setCpf(null);
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        // R7b - CPF em branco → lança IllegalArgumentException
+        @Test
+        @DisplayName("R7b - CPF em branco → lança IllegalArgumentException")
+        void registrar_cpfVazio_lancaExcecao() {
+            dtoCadastro.setCpf(new char[0]);
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        // R7c - CPF com formato inválido (menos de 11 dígitos) → lança IllegalArgumentException
+        @Test
+        @DisplayName("R7c - CPF com formato inválido → lança IllegalArgumentException")
+        void registrar_cpfFormatoInvalido_lancaExcecao() {
+            dtoCadastro.setCpf("1234".toCharArray());
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        // R8 - email com formato inválido (sem @) → lança IllegalArgumentException
+        @Test
+        @DisplayName("R8 - email com formato inválido → lança IllegalArgumentException")
+        void registrar_emailFormatoInvalido_lancaExcecao() {
+            dtoCadastro.setEmail("emailsemarroba.com");
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
     }
 
     @Nested


### PR DESCRIPTION
# Testes unitários de UsuarioService — registrar() e autenticar()

Nenhuma das funções testadas está implementada ainda. Os testes foram escritos 100% com base no diagrama UML e nos cenários acordados pela equipe. Falharão até que a implementação seja concluída, isso é esperado. Contanto que sigam o UML, os testes funcionarão.

## O que mudou

- Adicionado RegistrarLoginTests.java em src/test/
- 6 cenários de registrar(): dados válidos, email duplicado, CPF duplicado, email nulo/vazio, senha nula/vazia, nome nulo/vazio
- 5 cenários de autenticar(): credenciais corretas, email inexistente, senha incorreta, email nulo/vazio, senha nula/vazia
- Sem Spring context, sem banco — dependências mockadas com Mockito
-  Para melhor visualização, foi criado o arquivo TokenDTO, em dto/auth, cuidado com possíveis conflitos.

## Por quê

- Os testes foram definidos como entrega anterior à implementação, funcionando como contrato das regras do UML
- Garante que o desenvolvedor tenha feedback imediato ao implementar o service

## Como testar

1. Execute: ./gradlew test --tests "bcd.appfinanceirobackend.service.RegistrarLoginTests"
2. Agora: todos os testes falham pois UsuarioService está vazio — confirma que o JUnit reconheceu o arquivo
3. Após implementar o service e as classes de suporte: todos os testes devem passar

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, nulo, duplicado)
- [x] Evidência de teste (automatizado — JUnit 5 + Mockito)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos

- [Risco] R2 e R3 assumem que o service checa duplicidade via existsByEmail() e existsByCpf() antes do save(). Se a implementação deixar o banco lançar a violação naturalmente, o verify(never()).save() vai falhar.
- [Manutenção] RegisterRequestDTO e LoginRequestDTO estão vazios. Os campos esperados (nome, email, senha, cpf) estão documentados no Javadoc do arquivo de teste e precisam ser adicionados antes de compilar.
- [Manutenção] As exceções são do Spring por ora (IllegalArgumentException, DataIntegrityViolationException, etc.). Quando exceções próprias forem criadas, basta trocar os isInstanceOf() nos testes.
- [Teste] Todos os cenários de campo inválido verificam com verify(never()) que repositório e JwtUtil não são chamados quando a validação falha na entrada do método.