### PR TITLE
feat: configuração de CORS entre frontend e backend #22

### DIFF
--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/security/WebConfig.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/security/WebConfig.java
@@ -1,0 +1,18 @@
+package bcd.appfinanceirobackend.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
## O que mudou

- Criação do ficheiro `WebConfig.java` no pacote de segurança (`security`) do backend.
- Implementação da interface `WebMvcConfigurer` para permitir a origem `http://localhost:5173` (Frontend Vite).
- Libertação dos métodos HTTP necessários: GET, POST, PUT, DELETE e OPTIONS.

## Por quê

- Para permitir que o frontend comunique com a API do backend de forma fluida durante o desenvolvimento local, evitando os bloqueios causados pela política de mesma origem (CORS) dos navegadores.

## Como testar

1. Inicia a aplicação Spring Boot no backend (porta 8080).
2. Na pasta do frontend, executa o comando `npm run dev` para iniciar a aplicação na porta 5173.
3. No navegador, abre o frontend e tenta realizar uma requisição à API.
4. Verifica na consola do navegador (F12) que já não surgem erros de "CORS Policy".

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos (mínimo 3)

Use rótulos: [Risco], [Manutenção], [Teste]

- [Manutenção] A configuração do CORS foi centralizada na classe `WebConfig` implementando `WebMvcConfigurer`, o que mantém o código organizado e fácil de escalar.
- [Manutenção] Foi adicionado o suporte `.allowCredentials(true)` para preparar o terreno para futuras implementações de autenticação (como o envio de cookies ou tokens JWT na Issue #26).
- [Teste] Validado localmente. A comunicação entre as portas 5173 e 8080 está a funcionar sem rejeições por parte do navegador.