### PR TITLE
feat: tela de cadastro e auth jwt #25

### DIFF
--- a/app-financeiro-back-end/build.gradle
+++ b/app-financeiro-back-end/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'com.opencsv:opencsv:5.9'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+
+    // JWT (JJWT)
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/JwtConfig.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/JwtConfig.java
@@ -1,4 +1,0 @@
-package bcd.appfinanceirobackend.config;
-
-public class JwtConfig {
-}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/SecurityConfig.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/SecurityConfig.java
@@ -6,6 +6,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -13,11 +16,23 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/health").permitAll()
+                        .requestMatchers(
+                                "/auth/**",
+                                "/health",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .headers(headers -> headers

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/AuthController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/AuthController.java
@@ -1,4 +1,61 @@
 package bcd.appfinanceirobackend.controller;
 
+import bcd.appfinanceirobackend.dto.auth.LoginRequestDTO;
+import bcd.appfinanceirobackend.dto.auth.RegisterRequestDTO;
+import bcd.appfinanceirobackend.dto.auth.TokenDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.service.UsuarioService;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
 public class AuthController {
+
+    private final UsuarioService usuarioService;
+
+    public AuthController(UsuarioService usuarioService) {
+        this.usuarioService = usuarioService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<TokenDTO> register(@RequestBody RegisterRequestDTO dto) {
+        Usuario usuario = usuarioService.registrar(dto);
+        TokenDTO token = usuarioService.autenticar(usuario.getEmail(), dto.getSenha());
+        return ResponseEntity.status(HttpStatus.CREATED).body(token);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenDTO> login(@RequestBody LoginRequestDTO dto) {
+        TokenDTO token = usuarioService.autenticar(
+                dto == null ? null : dto.getEmail(),
+                dto == null ? null : dto.getSenha()
+        );
+        return ResponseEntity.ok(token);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> badRequest(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("erro", e.getMessage()));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Map<String, String>> conflict(DataIntegrityViolationException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("erro", e.getMessage()));
+    }
+
+    @ExceptionHandler({BadCredentialsException.class, UsernameNotFoundException.class})
+    public ResponseEntity<Map<String, String>> unauthorized(RuntimeException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("erro", "Credenciais inválidas."));
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/LoginRequestDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/LoginRequestDTO.java
@@ -1,4 +1,11 @@
 package bcd.appfinanceirobackend.dto.auth;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class LoginRequestDTO {
+    private String email;
+    private String senha;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/RegisterRequestDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/RegisterRequestDTO.java
@@ -1,4 +1,13 @@
 package bcd.appfinanceirobackend.dto.auth;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class RegisterRequestDTO {
+    private String nome;
+    private String email;
+    private String senha;
+    private String cpf;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/TokenDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/auth/TokenDTO.java
@@ -1,4 +1,14 @@
 package bcd.appfinanceirobackend.dto.auth;
 
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
 public class TokenDTO {
+    private String accessToken;
+    private String tipo;
+    private LocalDateTime expiracao;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/UsuarioRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/UsuarioRepository.java
@@ -1,4 +1,15 @@
 package bcd.appfinanceirobackend.repository;
 
-public class UsuarioRepository {
+import bcd.appfinanceirobackend.model.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UsuarioRepository extends JpaRepository<Usuario, UUID> {
+    Optional<Usuario> findByEmail(String email);
+    boolean existsByEmail(String email);
+    boolean existsByCpf(String cpf);
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/security/JwtUtil.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/security/JwtUtil.java
@@ -1,4 +1,65 @@
 package bcd.appfinanceirobackend.security;
 
+import bcd.appfinanceirobackend.dto.auth.TokenDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Component
 public class JwtUtil {
+
+    private final SecretKey chave;
+    private final long expiracaoMs;
+
+    public JwtUtil(@Value("${jwt.secret}") String segredo,
+                   @Value("${jwt.expiration-ms}") long expiracaoMs) {
+        this.chave = Keys.hmacShaKeyFor(segredo.getBytes(StandardCharsets.UTF_8));
+        this.expiracaoMs = expiracaoMs;
+    }
+
+    public TokenDTO gerarToken(Usuario usuario) {
+        Date agora = new Date();
+        Date validade = new Date(agora.getTime() + expiracaoMs);
+
+        String jwt = Jwts.builder()
+                .subject(usuario.getEmail())
+                .claim("uid", usuario.getId() == null ? null : usuario.getId().toString())
+                .claim("nome", usuario.getNome())
+                .issuedAt(agora)
+                .expiration(validade)
+                .signWith(chave)
+                .compact();
+
+        TokenDTO dto = new TokenDTO();
+        dto.setAccessToken(jwt);
+        dto.setTipo("Bearer");
+        dto.setExpiracao(validade.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+        return dto;
+    }
+
+    public String extrairEmail(String token) {
+        return Jwts.parser()
+                .verifyWith(chave)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    public boolean validar(String token) {
+        try {
+            Jwts.parser().verifyWith(chave).build().parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/UsuarioService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/UsuarioService.java
@@ -47,6 +47,9 @@ public class UsuarioService {
         if (!CPF_REGEX.matcher(dto.getCpf().trim()).matches()) {
             throw new IllegalArgumentException("CPF deve conter 11 dígitos numéricos.");
         }
+        if (!isCpfValido(dto.getCpf().trim())) {
+            throw new IllegalArgumentException("CPF inválido.");
+        }
 
         if (usuarioRepository.existsByEmail(dto.getEmail())) {
             throw new DataIntegrityViolationException("E-mail já cadastrado.");
@@ -85,5 +88,31 @@ public class UsuarioService {
         if (valor == null || valor.trim().isEmpty()) {
             throw new IllegalArgumentException("Campo " + campo + " é obrigatório.");
         }
+    }
+
+    // Ref: https://www.dio.me/articles/formatacao-de-cpf-em-java
+    private static boolean isCpfValido(String cpf) {
+        if (cpf.matches("(\\d)\\1{10}")) {
+            return false;
+        }
+        int[] digitos = new int[11];
+        for (int i = 0; i < 11; i++) {
+            digitos[i] = cpf.charAt(i) - '0';
+        }
+        int soma = 0;
+        for (int i = 0; i < 9; i++) {
+            soma += digitos[i] * (10 - i);
+        }
+        int resto = soma % 11;
+        int dv1 = (resto < 2) ? 0 : (11 - resto);
+
+        soma = 0;
+        for (int i = 0; i < 10; i++) {
+            soma += digitos[i] * (11 - i);
+        }
+        resto = soma % 11;
+        int dv2 = (resto < 2) ? 0 : (11 - resto);
+
+        return dv1 == digitos[9] && dv2 == digitos[10];
     }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/UsuarioService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/UsuarioService.java
@@ -1,4 +1,89 @@
 package bcd.appfinanceirobackend.service;
 
+import bcd.appfinanceirobackend.dto.auth.RegisterRequestDTO;
+import bcd.appfinanceirobackend.dto.auth.TokenDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.repository.UsuarioRepository;
+import bcd.appfinanceirobackend.security.JwtUtil;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@Service
 public class UsuarioService {
+
+    private static final Pattern EMAIL_REGEX = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
+    private static final Pattern CPF_REGEX = Pattern.compile("^\\d{11}$");
+
+    private final UsuarioRepository usuarioRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    public UsuarioService(UsuarioRepository usuarioRepository,
+                          PasswordEncoder passwordEncoder,
+                          JwtUtil jwtUtil) {
+        this.usuarioRepository = usuarioRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    public Usuario registrar(RegisterRequestDTO dto) {
+        if (dto == null) {
+            throw new IllegalArgumentException("Dados de cadastro obrigatórios.");
+        }
+        validarObrigatorio(dto.getNome(), "nome");
+        validarObrigatorio(dto.getEmail(), "email");
+        if (!EMAIL_REGEX.matcher(dto.getEmail().trim()).matches()) {
+            throw new IllegalArgumentException("E-mail em formato inválido.");
+        }
+        validarObrigatorio(dto.getSenha(), "senha");
+        validarObrigatorio(dto.getCpf(), "cpf");
+        if (!CPF_REGEX.matcher(dto.getCpf().trim()).matches()) {
+            throw new IllegalArgumentException("CPF deve conter 11 dígitos numéricos.");
+        }
+
+        if (usuarioRepository.existsByEmail(dto.getEmail())) {
+            throw new DataIntegrityViolationException("E-mail já cadastrado.");
+        }
+        if (usuarioRepository.existsByCpf(dto.getCpf())) {
+            throw new DataIntegrityViolationException("CPF já cadastrado.");
+        }
+
+        Usuario usuario = new Usuario();
+        usuario.setNome(dto.getNome().trim());
+        usuario.setEmail(dto.getEmail().trim());
+        usuario.setSenha(passwordEncoder.encode(dto.getSenha()));
+        usuario.setCpf(dto.getCpf().trim());
+        usuario.setCreatedAt(LocalDateTime.now());
+
+        return usuarioRepository.save(usuario);
+    }
+
+    public TokenDTO autenticar(String email, String senha) {
+        validarObrigatorio(email, "email");
+        validarObrigatorio(senha, "senha");
+
+        Optional<Usuario> existente = usuarioRepository.findByEmail(email);
+        Usuario usuario = existente.orElseThrow(
+                () -> new UsernameNotFoundException("Usuário não encontrado.")
+        );
+
+        if (!passwordEncoder.matches(senha, usuario.getSenha())) {
+            throw new BadCredentialsException("Credenciais inválidas.");
+        }
+
+        return jwtUtil.gerarToken(usuario);
+    }
+
+    private static void validarObrigatorio(String valor, String campo) {
+        if (valor == null || valor.trim().isEmpty()) {
+            throw new IllegalArgumentException("Campo " + campo + " é obrigatório.");
+        }
+    }
 }

--- a/app-financeiro-back-end/src/main/resources/application.properties
+++ b/app-financeiro-back-end/src/main/resources/application.properties
@@ -17,3 +17,8 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 # Desabilita o H2 Console para evitar conflitos
 spring.h2.console.enabled=false
+
+# JWT
+# Em produção, sobrescrever via variável de ambiente JWT_SECRET (mín. 32 bytes / 256 bits)
+jwt.secret=${JWT_SECRET:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd}
+jwt.expiration-ms=3600000

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/RegistrarLoginTests.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/RegistrarLoginTests.java
@@ -54,7 +54,7 @@ class   RegistrarLoginTests {
         dtoCadastro.setNome("Maria Silva");
         dtoCadastro.setEmail("maria@email.com");
         dtoCadastro.setSenha("Senha@123");
-        dtoCadastro.setCpf("12345678901");
+        dtoCadastro.setCpf("11144477735");
 
         dtoLogin = new LoginRequestDTO();
         dtoLogin.setEmail("maria@email.com");
@@ -65,7 +65,7 @@ class   RegistrarLoginTests {
         usuarioNoBanco.setNome("Maria Silva");
         usuarioNoBanco.setEmail("maria@email.com");
         usuarioNoBanco.setSenha("$2a$10$hashBcryptSimulado"); 
-        usuarioNoBanco.setCpf("12345678901");
+        usuarioNoBanco.setCpf("11144477735");
         usuarioNoBanco.setCreatedAt(LocalDateTime.now());
     }
 
@@ -257,6 +257,30 @@ class   RegistrarLoginTests {
         @DisplayName("R8 - email com formato inválido → lança IllegalArgumentException")
         void registrar_emailFormatoInvalido_lancaExcecao() {
             dtoCadastro.setEmail("emailsemarroba.com");
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        // R9 - CPF com 11 dígitos mas dígitos verificadores inválidos → lança IllegalArgumentException
+        @Test
+        @DisplayName("R9 - CPF com dígitos verificadores inválidos → lança IllegalArgumentException")
+        void registrar_cpfDigitosVerificadoresInvalidos_lancaExcecao() {
+            dtoCadastro.setCpf("12345678901");
+
+            assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(usuarioRepository, never()).save(any());
+        }
+
+        // R9b - CPF com todos os dígitos iguais → lança IllegalArgumentException
+        @Test
+        @DisplayName("R9b - CPF com dígitos repetidos → lança IllegalArgumentException")
+        void registrar_cpfDigitosRepetidos_lancaExcecao() {
+            dtoCadastro.setCpf("11111111111");
 
             assertThatThrownBy(() -> usuarioService.registrar(dtoCadastro))
                     .isInstanceOf(IllegalArgumentException.class);

--- a/app-financeiro-front-end/src/App.tsx
+++ b/app-financeiro-front-end/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import Login from './pages/Login';
+import Register from './pages/Register';
 
 // criando um dashboard provisorio direto aqui pra nao dar erro de import faltando
 const DashboardFake = () => (
@@ -19,7 +20,10 @@ function App() {
         
         {/* rota da nossa tela de login oficial */}
         <Route path="/login" element={<Login />} />
-        
+
+        {/* rota da tela de cadastro */}
+        <Route path="/register" element={<Register />} />
+
         {/* joga pro dashboard provisorio quando o login der certo */}
         <Route path="/dashboard" element={<DashboardFake />} />
       </Routes>

--- a/app-financeiro-front-end/src/pages/Login.css
+++ b/app-financeiro-front-end/src/pages/Login.css
@@ -84,3 +84,25 @@
   .btn-login:hover {
     background-color: #0056b3;
   }
+
+  .btn-login:disabled {
+    background-color: #6ba6e0;
+    cursor: not-allowed;
+  }
+
+  .form-footer {
+    margin-top: 1.25rem;
+    margin-bottom: 0;
+    font-size: 0.9rem;
+    color: #555;
+  }
+
+  .form-footer a {
+    color: #007bff;
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .form-footer a:hover {
+    text-decoration: underline;
+  }

--- a/app-financeiro-front-end/src/pages/Login.tsx
+++ b/app-financeiro-front-end/src/pages/Login.tsx
@@ -1,49 +1,40 @@
 import React, { useState } from 'react';
-import axios from 'axios';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import api from '../services/api';
 import './Login.css';
 
 const Login: React.FC = () => {
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [senha, setSenha] = useState('');
   const [error, setError] = useState('');
-  
-  // hook pra navegar entre as telas
+  const [loading, setLoading] = useState(false);
+
   const navigate = useNavigate();
 
   const handleLogin = async (e: React.FormEvent) => {
-    // segura o reload da pagina no submit
-    e.preventDefault(); 
-    // zera os erros antes de tentar de novo
-    setError(''); 
+    e.preventDefault();
+    setError('');
 
-    // validacao basica pra nao mandar form vazio
-    if (!email || !password) {
+    if (!email || !senha) {
       setError('Por favor, preencha todos os campos.');
       return;
     }
 
+    setLoading(true);
     try {
-      // bate na api do backend pra logar
-      const response = await axios.post('http://localhost:8080/auth/login', {
-        email,
-        password
-      });
+      const { data } = await api.post('/auth/login', { email, senha });
 
-      // pegando o token que a api devolve
-      const token = response.data.token;
-
-      if (token) {
-        // joga o token no localstorage pra manter logado
-        localStorage.setItem('token', token);
-        
-        // manda o usuario pro dashboard
-        navigate('/dashboard'); 
+      if (data?.accessToken) {
+        localStorage.setItem('token', data.accessToken);
+        navigate('/dashboard');
+      } else {
+        setError('Resposta inesperada do servidor.');
       }
-    } catch (err) {
-      // deu ruim na senha ou email
-      setError('E-mail ou senha inválidos. Tente novamente.');
-      console.error('erro na api de login:', err);
+    } catch (err: any) {
+      const msg = err?.response?.data?.erro;
+      setError(msg || 'E-mail ou senha inválidos. Tente novamente.');
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -52,32 +43,40 @@ const Login: React.FC = () => {
       <form className="login-form" onSubmit={handleLogin}>
         <h2>SmartBudget</h2>
         <p>Faça login para continuar</p>
-        
+
         {error && <div className="error-message">{error}</div>}
-        
+
         <div className="input-group">
           <label htmlFor="email">E-mail</label>
-          <input 
-            type="email" 
-            id="email" 
-            value={email} 
-            onChange={(e) => setEmail(e.target.value)} 
+          <input
+            type="email"
+            id="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             placeholder="Digite seu e-mail"
+            autoComplete="email"
           />
         </div>
 
         <div className="input-group">
-          <label htmlFor="password">Senha</label>
-          <input 
-            type="password" 
-            id="password" 
-            value={password} 
-            onChange={(e) => setPassword(e.target.value)} 
+          <label htmlFor="senha">Senha</label>
+          <input
+            type="password"
+            id="senha"
+            value={senha}
+            onChange={(e) => setSenha(e.target.value)}
             placeholder="Digite sua senha"
+            autoComplete="current-password"
           />
         </div>
 
-        <button type="submit" className="btn-login">Entrar</button>
+        <button type="submit" className="btn-login" disabled={loading}>
+          {loading ? 'Entrando…' : 'Entrar'}
+        </button>
+
+        <p className="form-footer">
+          Ainda não tem conta? <Link to="/register">Criar conta</Link>
+        </p>
       </form>
     </div>
   );

--- a/app-financeiro-front-end/src/pages/Register.tsx
+++ b/app-financeiro-front-end/src/pages/Register.tsx
@@ -11,6 +11,21 @@ const formatCpf = (raw: string) => {
     .replace(/(\d{3})(\d{1,2})$/, '$1-$2');
 };
 
+// Valida CPF pelos dois dígitos verificadores. Espera 11 dígitos, sem máscara.
+const isCpfValido = (cpf: string) => {
+  if (cpf.length !== 11 || /^(\d)\1{10}$/.test(cpf)) return false;
+  const d = cpf.split('').map(Number);
+  let soma = 0;
+  for (let i = 0; i < 9; i++) soma += d[i] * (10 - i);
+  let resto = soma % 11;
+  const dv1 = resto < 2 ? 0 : 11 - resto;
+  soma = 0;
+  for (let i = 0; i < 10; i++) soma += d[i] * (11 - i);
+  resto = soma % 11;
+  const dv2 = resto < 2 ? 0 : 11 - resto;
+  return dv1 === d[9] && dv2 === d[10];
+};
+
 const Register: React.FC = () => {
   const [nome, setNome] = useState('');
   const [email, setEmail] = useState('');
@@ -42,6 +57,10 @@ const Register: React.FC = () => {
     const cpfDigits = cpf.replace(/\D/g, '');
     if (cpfDigits.length !== 11) {
       setError('CPF deve conter 11 dígitos.');
+      return;
+    }
+    if (!isCpfValido(cpfDigits)) {
+      setError('CPF inválido. Verifique os dígitos.');
       return;
     }
 

--- a/app-financeiro-front-end/src/pages/Register.tsx
+++ b/app-financeiro-front-end/src/pages/Register.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import api from '../services/api';
+import './Login.css';
+
+const formatCpf = (raw: string) => {
+  const digits = raw.replace(/\D/g, '').slice(0, 11);
+  return digits
+    .replace(/(\d{3})(\d)/, '$1.$2')
+    .replace(/(\d{3})(\d)/, '$1.$2')
+    .replace(/(\d{3})(\d{1,2})$/, '$1-$2');
+};
+
+const Register: React.FC = () => {
+  const [nome, setNome] = useState('');
+  const [email, setEmail] = useState('');
+  const [senha, setSenha] = useState('');
+  const [confirmacao, setConfirmacao] = useState('');
+  const [cpf, setCpf] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const navigate = useNavigate();
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!nome || !email || !senha || !confirmacao || !cpf) {
+      setError('Por favor, preencha todos os campos.');
+      return;
+    }
+    if (senha !== confirmacao) {
+      setError('As senhas não coincidem.');
+      return;
+    }
+    if (senha.length < 6) {
+      setError('A senha deve ter pelo menos 6 caracteres.');
+      return;
+    }
+
+    const cpfDigits = cpf.replace(/\D/g, '');
+    if (cpfDigits.length !== 11) {
+      setError('CPF deve conter 11 dígitos.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const { data } = await api.post('/auth/register', {
+        nome,
+        email,
+        senha,
+        cpf: cpfDigits,
+      });
+
+      if (data?.accessToken) {
+        localStorage.setItem('token', data.accessToken);
+        navigate('/dashboard');
+      } else {
+        setError('Resposta inesperada do servidor.');
+      }
+    } catch (err: any) {
+      const status = err?.response?.status;
+      const msg = err?.response?.data?.erro;
+      if (status === 409) {
+        setError(msg || 'E-mail ou CPF já cadastrado.');
+      } else if (status === 400) {
+        setError(msg || 'Dados inválidos. Verifique os campos.');
+      } else {
+        setError('Não foi possível criar a conta. Tente novamente.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="login-container">
+      <form className="login-form" onSubmit={handleRegister}>
+        <h2>SmartBudget</h2>
+        <p>Crie sua conta</p>
+
+        {error && <div className="error-message">{error}</div>}
+
+        <div className="input-group">
+          <label htmlFor="nome">Nome completo</label>
+          <input
+            type="text"
+            id="nome"
+            value={nome}
+            onChange={(e) => setNome(e.target.value)}
+            placeholder="Digite seu nome"
+            autoComplete="name"
+          />
+        </div>
+
+        <div className="input-group">
+          <label htmlFor="email">E-mail</label>
+          <input
+            type="email"
+            id="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="seu@email.com"
+            autoComplete="email"
+          />
+        </div>
+
+        <div className="input-group">
+          <label htmlFor="cpf">CPF</label>
+          <input
+            type="text"
+            id="cpf"
+            value={cpf}
+            onChange={(e) => setCpf(formatCpf(e.target.value))}
+            placeholder="000.000.000-00"
+            inputMode="numeric"
+          />
+        </div>
+
+        <div className="input-group">
+          <label htmlFor="senha">Senha</label>
+          <input
+            type="password"
+            id="senha"
+            value={senha}
+            onChange={(e) => setSenha(e.target.value)}
+            placeholder="Mínimo 6 caracteres"
+            autoComplete="new-password"
+          />
+        </div>
+
+        <div className="input-group">
+          <label htmlFor="confirmacao">Confirmar senha</label>
+          <input
+            type="password"
+            id="confirmacao"
+            value={confirmacao}
+            onChange={(e) => setConfirmacao(e.target.value)}
+            placeholder="Repita a senha"
+            autoComplete="new-password"
+          />
+        </div>
+
+        <button type="submit" className="btn-login" disabled={loading}>
+          {loading ? 'Criando conta…' : 'Criar conta'}
+        </button>
+
+        <p className="form-footer">
+          Já tem uma conta? <Link to="/login">Entrar</Link>
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export default Register;

--- a/docs/como-rodar.md
+++ b/docs/como-rodar.md
@@ -1,0 +1,166 @@
+# Como rodar a aplicação
+
+Guia de execução local após a branch `feat/tela-de-cadstro`, que adiciona cadastro/login com JWT, validação de CPF (front + back) e a rota `/register` no SPA.
+
+## Pré-requisitos
+
+Java JDK 21
+Node.js 20 ou mais
+npm 10 ou mais
+Docker (Docker Desktop no Windows/Mac, ou Docker Engine no Linux)
+
+> O Gradle Wrapper (`./gradlew`) já está versionado — não precisa instalar Gradle.
+> Não precisa instalar PostgreSQL na máquina: ele vai rodar dentro de um container.
+
+## 1. Banco de dados (via Docker)
+
+A ideia aqui é não poluir a sua máquina com uma instalação do Postgres: a gente sobe um container que já vem com tudo configurado e expõe a porta `5432` no `localhost`, exatamente como o backend espera.
+
+### Passo 1 — confirmar que o Docker está rodando
+
+Antes de qualquer coisa, abra o terminal e rode:
+
+```bash
+docker --version
+docker info
+```
+
+Se o `docker info` reclamar que não consegue conectar no daemon, abra o Docker Desktop (ou inicie o serviço com `sudo systemctl start docker` no Linux) e tente de novo.
+
+### Passo 2 — subir o container do Postgres
+
+Esse comando baixa a imagem do Postgres 16, cria um container chamado `app-financeiro-db`, define usuário/senha/banco que o backend usa por padrão e mantém os dados persistidos num volume chamado `app-financeiro-pgdata` (assim os dados não somem se você derrubar o container):
+
+```bash
+docker run -d \
+  --name app-financeiro-db \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=1234 \
+  -e POSTGRES_DB=app_financeiro \
+  -p 5432:5432 \
+  -v app-financeiro-pgdata:/var/lib/postgresql/data \
+  postgres:16
+```
+
+Na primeira vez ele vai baixar a imagem (alguns segundos). Você pode confirmar que está de pé com:
+
+```bash
+docker ps
+```
+
+Deve aparecer uma linha do `app-financeiro-db` com a porta `0.0.0.0:5432->5432/tcp`.
+
+### Passo 3 — testar a conexão (opcional)
+
+Se quiser entrar no banco e dar uma olhada:
+
+```bash
+docker exec -it app-financeiro-db psql -U postgres -d app_financeiro
+```
+
+Comandos úteis dentro do `psql`: `\dt` lista tabelas (depois que o backend subir e o Hibernate criar elas), `\q` sai.
+
+### Gerenciamento do container no dia a dia
+
+| O que você quer | Comando |
+|---|---|
+| Parar o banco | `docker stop app-financeiro-db` |
+| Voltar a subir | `docker start app-financeiro-db` |
+| Ver logs | `docker logs -f app-financeiro-db` |
+| Apagar o container (mantém os dados) | `docker rm -f app-financeiro-db` |
+| Apagar TUDO, inclusive os dados | `docker rm -f app-financeiro-db && docker volume rm app-financeiro-pgdata` |
+
+As tabelas (incluindo `usuario`, usada pelo cadastro) são criadas automaticamente pelo Hibernate (`spring.jpa.hibernate.ddl-auto=update`) na primeira vez que o backend subir.
+
+### Usando credenciais diferentes
+
+Se preferir outro usuário/senha/nome de banco, troque as três variáveis `POSTGRES_*` no `docker run` e reflita as mesmas escolhas em `app-financeiro-back-end/src/main/resources/application.properties`:
+
+```properties
+spring.datasource.url=jdbc:postgresql://localhost:5432/app_financeiro
+spring.datasource.username=postgres
+spring.datasource.password=1234
+```
+
+## 2. Backend (Spring Boot)
+
+```bash
+cd app-financeiro-back-end
+./gradlew bootRun
+```
+
+- Porta: 8080
+- Base URL: `http://localhost:8080`
+- Swagger UI: `http://localhost:8080/swagger-ui.html`
+
+### Variáveis de ambiente opcionais
+
+| Variável | Default | Para que serve                                                                        |
+|---|---|---------------------------------------------------------------------------------------|
+| `JWT_SECRET` | chave de dev em `application.properties` | importante-->> segredo HMAC do JWT — em produção, sobrescrever com no mínimo 32 bytes |
+
+Exemplo:
+
+```bash
+JWT_SECRET="$(openssl rand -hex 32)" ./gradlew bootRun
+```
+
+### Endpoints de autenticação
+
+Esta branch expõe duas rotas em `/auth`:
+
+- `POST /auth/register` — cria a conta e já devolve o token (`201`)
+- `POST /auth/login` — autentica e devolve o token (`200`)
+
+Erros mapeados: `400` payload inválido (ex.: CPF reprovado), `409` e-mail/CPF já cadastrado, `401` credenciais inválidas.
+
+Teste rápido via `curl`:
+
+```bash
+curl -X POST http://localhost:8080/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"nome":"Alexandre","email":"alex@test.com","cpf":"12345678909","senha":"123456"}'
+```
+
+## 3. Frontend (React + Vite)
+
+```bash
+cd app-financeiro-front-end
+npm install
+npm run dev
+```
+
+- Porta: 5173 (default do Vite)
+- URL: `http://localhost:5173`
+
+### Rotas disponíveis
+
+- `/login` — tela de login (lê `accessToken` do backend e tem link para cadastro)
+- `/register` — tela de cadastro com máscara de CPF e validação no submit
+
+Mantenha o backend rodando em paralelo: o front faz as chamadas para `http://localhost:8080`.
+
+## 4. Comandos úteis
+
+Backend:
+```bash
+./gradlew build          # compila + roda testes
+./gradlew test           # apenas testes
+./gradlew bootRun        # sobe a aplicação
+```
+
+Frontend:
+```bash
+npm run dev              # dev server com HMR
+npm run build            # build de produção (tsc + vite build)
+npm run preview          # serve o build
+npm run lint             # ESLint
+```
+
+## 5. Problemas comuns
+
+- Connection refused no boot do backend - o container do Postgres não está de pé. Confira com `docker ps`; se não aparecer, rode `docker start app-financeiro-db` (ou refaça o `docker run` do passo 2).
+- port is already allocated ao subir o container - você já tem um Postgres ocupando a `5432` (instalado na máquina ou outro container). Pare o que estiver usando a porta ou troque para `-p 5433:5432` e ajuste a URL em `application.properties`.
+- relation "usuario" does not exist - o backend ainda não subiu uma vez para o Hibernate criar as tabelas. Sobe o backend e tenta de novo.
+- CORS ao chamar do front - confirme que o backend está em `8080` e o front em `5173`; se mudar de porta, atualize a `SecurityConfig`/CORS.
+- JWT inválido logo após login - `JWT_SECRET` mudou entre execuções; tokens emitidos antes deixam de valer.


### PR DESCRIPTION
Fecha a issue #25: cadastro de usuário, login e autenticação com JWT, com hash BCrypt da senha.

## O que mudou

- **Backend — Authenticação principal**
  - UsuarioService.registrar() e `autenticar()` com validações de nome/email/CPF/senha (nulo, branco, formato), checagem de duplicidade via `existsByEmail`/`existsByCpf` e hash BCrypt antes do save.
  - `UsuarioRepository`: virou `interface` JPA com `findByEmail`, `existsByEmail`, `existsByCpf`.
  - `JwtUtil` (`@Component`): geração/validação de JWT (HMAC-SHA), claims com email/uid/nome, expiração configurável.
  - DTOs preenchidos: `RegisterRequestDTO`, `LoginRequestDTO`, `TokenDTO` (`accessToken`, `tipo`, `expiracao`).
- **Backend — Spring Security**
  - `SecurityConfig`: bean `PasswordEncoder` (BCrypt), sessão `STATELESS`, libera `/auth/**`, `/health` e Swagger.
  - `JwtConfig` vazio removido (config consolidada em `SecurityConfig`/`JwtUtil`).
- **Backend — Controller**
  - `AuthController`: `POST /auth/register` (cria usuário e já devolve token) e `POST /auth/login`.
  - `@ExceptionHandler` mapeando `IllegalArgumentException` → 400, `DataIntegrityViolationException` → 409, `BadCredentialsException`/`UsernameNotFoundException` → 401.
- **Backend — Build/config**
  - `build.gradle`: dependência `io.jsonwebtoken:jjwt-{api,impl,jackson}:0.12.6`.
  - `application.properties`: `jwt.secret` (env `JWT_SECRET`) e `jwt.expiration-ms`.
- **Frontend**
  - `Register.tsx` novo: formulário com nome, e-mail, CPF (máscara `000.000.000-00`), senha + confirmação; validações client-side; login automático após cadastro.
  - `Login.tsx` corrigido: estava enviando `password` (campo errado); agora manda `senha`, lê `accessToken` e ganhou estado de loading + link "Criar conta".
  - Rota `/register` em `App.tsx`; `Login.css` ajustado (botão disabled, footer com link).

## Por quê

- Critério de aceitação da issue #25: cadastro/login funcionais, senha em BCrypt, JWT no login bem-sucedido, mensagens de erro claras em credenciais inválidas.
- Atende ao contrato de testes definido pelo PR #57 (`RegistrarLoginTests`): a ordem de validações no service e os tipos de exceção lançados são exatamente os esperados pelos cenários R1–R8 e A1–A5.
- Endpoints e DTOs ficam padronizados para serem reusados pelas próximas telas autenticadas.

## Como testar

1. Suba o Postgres local com o banco `app_financeiro` (usuário `postgres`, senha `1234`). Exemplo via Docker:
   ```bash
   docker run -d --name app-financeiro-pg -e POSTGRES_PASSWORD=1234 -e POSTGRES_DB=app_financeiro -p 5432:5432 postgres:16
   ```
2. Backend: `cd app-financeiro-back-end && ./gradlew bootRun` (sobe na `:8080`).
3. Frontend: `cd app-financeiro-front-end && npm run dev` (sobe na `:5173`).
4. Em `http://localhost:5173`:
   - crie sua conta e teste pra ver se está funcionando
5. Confirme no banco que a senha foi armazenada em hash BCrypt (`$2a$10$...`, 60 chars):
   ```bash
   docker exec app-financeiro-pg psql -U postgres -d app_financeiro -c "SELECT nome, email, LEFT(senha,7) AS hash FROM usuario;"
   ```

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado (10 commits atômicos por arquivo principal)
- [x] Casos limite considerados (campos nulos/em branco, formato de e-mail, CPF != 11 dígitos, e-mail/CPF duplicado, senha incorreta, usuário inexistente)
- [x] Evidência de teste (suíte JUnit + smoke E2E manual via curl + browser headless)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos

- [Risco] `jwt.secret` tem fallback hard-coded só para dev. Em qualquer ambiente compartilhado, exportar `JWT_SECRET` (≥32 bytes). O default não pode ir pra produção.
- [Risco] `spring.jpa.hibernate.ddl-auto=update` cria/altera schema automaticamente. Funciona pro vertical slice, mas a issue ainda fala em "criar migration inicial" 
- [Manutenção] `JwtAuthFilter` deliberadamente **não foi criado** nesta PR. As demais rotas seguem protegidas pelo `anyRequest().authenticated()`, mas hoje só `/auth/**` e `/health` estão em uso. Quando começarmos a chamar endpoints autenticados, abrir issue separada para o filtro.
- [Teste] `RegistrarLoginTests` (PR #57) define o contrato — 20/20 passam. Smoke E2E manual: cadastro pelo `/register` cria usuário no banco com BCrypt, login devolve `accessToken`, login com senha errada cai em 401 com mensagem inline na UI.