### PR TITLE
Feat/#62 registro manual transacao

### DIFF
--- a/app-financeiro-back-end/build.gradle
+++ b/app-financeiro-back-end/build.gradle
@@ -23,8 +23,8 @@ dependencies {
     // Core Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-web' 
-    
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
     // Banco de Dados
     implementation 'org.postgresql:postgresql:42.7.3'
     

--- a/app-financeiro-back-end/gradle/wrapper/gradle-wrapper.properties
+++ b/app-financeiro-back-end/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/app-financeiro-back-end/gradlew
+++ b/app-financeiro-back-end/gradlew
@@ -114,7 +114,7 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+CLASSPATH="\\\"\\\""
 
 
 # Determine the Java command to use to start the JVM.
@@ -213,7 +213,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
         -classpath "$CLASSPATH" \
-        org.gradle.wrapper.GradleWrapperMain \
+        -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
         "$@"
 
 # Stop when "xargs" is not available.

--- a/app-financeiro-back-end/gradlew.bat
+++ b/app-financeiro-back-end/gradlew.bat
@@ -70,11 +70,11 @@ goto fail
 :execute
 @rem Setup the command line
 
-set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+set CLASSPATH=
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/JwtAuthFilter.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/JwtAuthFilter.java
@@ -6,7 +6,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.jspecify.annotations.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,8 +28,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
-                                    @NonNull HttpServletResponse response,
-                                    @NonNull FilterChain filterChain)
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
             throws ServletException, IOException {
 
         String header = request.getHeader("Authorization");

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/JwtAuthFilter.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/JwtAuthFilter.java
@@ -1,0 +1,58 @@
+package bcd.appfinanceirobackend.config;
+
+import bcd.appfinanceirobackend.repository.UsuarioRepository;
+import bcd.appfinanceirobackend.security.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UsuarioRepository usuarioRepository;
+
+    public JwtAuthFilter(JwtUtil jwtUtil, UsuarioRepository usuarioRepository) {
+        this.jwtUtil = jwtUtil;
+        this.usuarioRepository = usuarioRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+
+            if (jwtUtil.validar(token)) {
+                String email = jwtUtil.extrairEmail(token);
+
+                usuarioRepository.findByEmail(email).ifPresent(usuario -> {
+                    UsernamePasswordAuthenticationToken auth =
+                            new UsernamePasswordAuthenticationToken(
+                                    usuario,
+                                    null,
+                                    List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                            );
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                });
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/JwtAuthFilter.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/JwtAuthFilter.java
@@ -36,8 +36,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring(7);
+            boolean valido = jwtUtil.validar(token);
 
-            if (jwtUtil.validar(token)) {
+            if (valido) {
                 String email = jwtUtil.extrairEmail(token);
 
                 usuarioRepository.findByEmail(email).ifPresent(usuario -> {
@@ -51,7 +52,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 });
             }
         }
-
         filterChain.doFilter(request, response);
     }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/SecurityConfig.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/SecurityConfig.java
@@ -10,10 +10,18 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
+        this.jwtAuthFilter = jwtAuthFilter;
+    }
+
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -35,6 +43,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .headers(headers -> headers
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)
                 );

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ContaController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ContaController.java
@@ -1,4 +1,28 @@
 package bcd.appfinanceirobackend.controller;
 
+import bcd.appfinanceirobackend.dto.conta.ContaRequestDTO;
+import bcd.appfinanceirobackend.dto.conta.ContaResponseDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.service.ContaService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/contas")
 public class ContaController {
+
+    private final ContaService contaService;
+
+    public ContaController (ContaService contaService) { this.contaService = contaService;}
+
+    @PostMapping("/registrar")
+    public ResponseEntity<ContaResponseDTO> registrarConta (@RequestBody ContaRequestDTO dto,
+                                                            @AuthenticationPrincipal Usuario usuario) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(contaService.registrar(dto, usuario));
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/GlobalExceptionHandler.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package bcd.appfinanceirobackend.controller;
+
+import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<String> handleNotFound(ResourceNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ex.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> badRequest(IllegalArgumentException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ex.getMessage());
+    }
+}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/TransacaoController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/TransacaoController.java
@@ -6,6 +6,7 @@ import bcd.appfinanceirobackend.service.TransacaoService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,7 +21,7 @@ public class TransacaoController {
     }
 
     @PostMapping("/manual")
-    public ResponseEntity<TransacaoResponseDTO> registrarTransacaoManual (TransacaoRequestDTO requestDTO) {
+    public ResponseEntity<TransacaoResponseDTO> registrarTransacaoManual (@RequestBody TransacaoRequestDTO requestDTO) {
         return ResponseEntity.status(HttpStatus.CREATED).body(transacaoService.registrarManual(requestDTO));
     }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/TransacaoController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/TransacaoController.java
@@ -2,9 +2,11 @@ package bcd.appfinanceirobackend.controller;
 
 import bcd.appfinanceirobackend.dto.transacao.TransacaoRequestDTO;
 import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
+import bcd.appfinanceirobackend.model.Usuario;
 import bcd.appfinanceirobackend.service.TransacaoService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +23,10 @@ public class TransacaoController {
     }
 
     @PostMapping("/manual")
-    public ResponseEntity<TransacaoResponseDTO> registrarTransacaoManual (@RequestBody TransacaoRequestDTO requestDTO) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(transacaoService.registrarManual(requestDTO));
+    public ResponseEntity<TransacaoResponseDTO> registrarTransacaoManual (
+            @RequestBody TransacaoRequestDTO requestDTO,
+            @AuthenticationPrincipal Usuario usuarioAutenticado) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(transacaoService.registrarManual(
+                requestDTO, usuarioAutenticado));
     }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/TransacaoController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/TransacaoController.java
@@ -1,4 +1,26 @@
 package bcd.appfinanceirobackend.controller;
 
+import bcd.appfinanceirobackend.dto.transacao.TransacaoRequestDTO;
+import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
+import bcd.appfinanceirobackend.service.TransacaoService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/transacoes")
 public class TransacaoController {
+
+    private final TransacaoService transacaoService;
+
+    public TransacaoController( TransacaoService transacaoService) {
+        this.transacaoService = transacaoService;
+    }
+
+    @PostMapping("/manual")
+    public ResponseEntity<TransacaoResponseDTO> registrarTransacaoManual (TransacaoRequestDTO requestDTO) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(transacaoService.registrarManual(requestDTO));
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/conta/ContaRequestDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/conta/ContaRequestDTO.java
@@ -1,4 +1,14 @@
 package bcd.appfinanceirobackend.dto.conta;
 
+import bcd.appfinanceirobackend.model.enums.TipoConta;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class ContaRequestDTO {
+    private String nome;
+    private TipoConta tipoConta;
+    private String banco;
+    private String descricao;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/conta/ContaResponseDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/conta/ContaResponseDTO.java
@@ -1,4 +1,17 @@
 package bcd.appfinanceirobackend.dto.conta;
 
+import bcd.appfinanceirobackend.model.enums.TipoConta;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
 public class ContaResponseDTO {
+    private UUID contaId;
+    private String nome;
+    private TipoConta tipoConta;
+    private String banco;
+    private String descricao;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/transacao/TransacaoRequestDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/transacao/TransacaoRequestDTO.java
@@ -1,4 +1,22 @@
 package bcd.appfinanceirobackend.dto.transacao;
 
+import bcd.appfinanceirobackend.model.enums.TipoPagamento;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
 public class TransacaoRequestDTO {
+    private BigDecimal valor;
+    private LocalDateTime data;
+    private String descricao;
+    private TipoTransacao tipoTransacao;
+    private TipoPagamento formaPagamento;
+    private UUID categoriaId;
+    private UUID contaId;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/transacao/TransacaoRequestDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/transacao/TransacaoRequestDTO.java
@@ -6,14 +6,14 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.UUID;
 
 @Getter
 @Setter
 public class TransacaoRequestDTO {
     private BigDecimal valor;
-    private LocalDateTime data;
+    private LocalDate data;
     private String descricao;
     private TipoTransacao tipoTransacao;
     private TipoPagamento formaPagamento;

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/transacao/TransacaoResponseDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/transacao/TransacaoResponseDTO.java
@@ -1,4 +1,22 @@
 package bcd.appfinanceirobackend.dto.transacao;
 
+import bcd.appfinanceirobackend.model.enums.TipoPagamento;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Setter
 public class TransacaoResponseDTO {
+    private BigDecimal valor;
+    private LocalDate data;
+    private String descricao;
+    private TipoTransacao tipoTransacao;
+    private TipoPagamento formaPagamento;
+    private UUID categoriaId;
+    private UUID contaId;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/transacao/TransacaoResponseDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/transacao/TransacaoResponseDTO.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 @Getter
 @Setter
 public class TransacaoResponseDTO {
+    private UUID transacaoId;
     private BigDecimal valor;
     private LocalDate data;
     private String descricao;

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/exception/ResourceNotFoundException.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/exception/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package bcd.appfinanceirobackend.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/model/Usuario.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/model/Usuario.java
@@ -3,14 +3,19 @@ package bcd.appfinanceirobackend.model;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
 @Getter
 @Setter
-public class Usuario {
+public class Usuario implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -30,5 +35,21 @@ public class Usuario {
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() { return this.senha; }
+
+    @Override
+    public String getUsername() { return this.email; }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
 
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/CartaoCreditoRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/CartaoCreditoRepository.java
@@ -1,4 +1,11 @@
 package bcd.appfinanceirobackend.repository;
 
-public class CartaoCreditoRepository {
+import bcd.appfinanceirobackend.model.CartaoCredito;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface CartaoCreditoRepository extends JpaRepository<CartaoCredito, UUID> {
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/CategoriaRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/CategoriaRepository.java
@@ -1,4 +1,11 @@
 package bcd.appfinanceirobackend.repository;
 
-public class CategoriaRepository {
+import bcd.appfinanceirobackend.model.Categoria;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface CategoriaRepository extends JpaRepository<Categoria, UUID> {
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/ContaRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/ContaRepository.java
@@ -1,4 +1,12 @@
 package bcd.appfinanceirobackend.repository;
 
-public class ContaRepository {
+import bcd.appfinanceirobackend.model.Conta;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface ContaRepository extends JpaRepository<Conta, UUID> {
+
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/FaturaRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/FaturaRepository.java
@@ -1,4 +1,11 @@
 package bcd.appfinanceirobackend.repository;
 
-public class FaturaRepository {
+import bcd.appfinanceirobackend.model.Fatura;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface FaturaRepository extends JpaRepository<Fatura, UUID> {
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/ImportacaoRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/ImportacaoRepository.java
@@ -1,4 +1,11 @@
 package bcd.appfinanceirobackend.repository;
 
-public class ImportacaoRepository {
+import bcd.appfinanceirobackend.model.Importacao;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface ImportacaoRepository extends JpaRepository<Importacao, UUID> {
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/TransacaoRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/TransacaoRepository.java
@@ -1,4 +1,12 @@
 package bcd.appfinanceirobackend.repository;
 
-public class TransacaoRepository {
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface TransacaoRepository extends JpaRepository<Transacao, UUID> {
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/security/JwtUtil.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/security/JwtUtil.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
@@ -2,14 +2,17 @@ package bcd.appfinanceirobackend.service;
 
 import bcd.appfinanceirobackend.dto.conta.ContaRequestDTO;
 import bcd.appfinanceirobackend.dto.conta.ContaResponseDTO;
-import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
 import bcd.appfinanceirobackend.model.Conta;
-import bcd.appfinanceirobackend.model.Transacao;
 import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.repository.ContaRepository;
 import org.springframework.stereotype.Service;
 
 @Service
-public class ContaService   {
+public class ContaService {
+
+    private final ContaRepository contaRepository;
+
+    public ContaService (ContaRepository contaRepository) {this.contaRepository = contaRepository;}
 
     public ContaResponseDTO registrar(ContaRequestDTO dto, Usuario usuarioAutenticado) {
         if(dto.getNome() == null ||
@@ -22,8 +25,8 @@ public class ContaService   {
         conta.setBanco(dto.getBanco());
         conta.setDescricao(dto.getDescricao());
         conta.setUsuario(usuarioAutenticado);
+        contaRepository.save(conta);
         return toResponse(conta);
-
     }
 
     public ContaResponseDTO toResponse(Conta conta) {

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
@@ -1,4 +1,10 @@
 package bcd.appfinanceirobackend.service;
 
+import bcd.appfinanceirobackend.dto.conta.ContaResponseDTO;
+import org.springframework.stereotype.Service;
+
+@Service
 public class ContaService   {
+
+    public ContaResponseDTO
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
@@ -1,10 +1,38 @@
 package bcd.appfinanceirobackend.service;
 
+import bcd.appfinanceirobackend.dto.conta.ContaRequestDTO;
 import bcd.appfinanceirobackend.dto.conta.ContaResponseDTO;
+import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.Usuario;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ContaService   {
 
-    public ContaResponseDTO
+    public ContaResponseDTO registrar(ContaRequestDTO dto, Usuario usuarioAutenticado) {
+        if(dto.getNome() == null ||
+                dto.getTipoConta() == null) throw new IllegalArgumentException(
+                "Campos obrigatórios de uma conta não informados (nome e TipoConta)");
+
+        Conta conta = new Conta();
+        conta.setTipoConta(dto.getTipoConta());
+        conta.setNome(dto.getNome());
+        conta.setBanco(dto.getBanco());
+        conta.setDescricao(dto.getDescricao());
+        conta.setUsuario(usuarioAutenticado);
+        return toResponse(conta);
+
+    }
+
+    public ContaResponseDTO toResponse(Conta conta) {
+        ContaResponseDTO responseDTO = new ContaResponseDTO();
+        responseDTO.setBanco(conta.getBanco());
+        responseDTO.setNome(conta.getNome());
+        responseDTO.setTipoConta(conta.getTipoConta());
+        responseDTO.setContaId(conta.getId());
+        responseDTO.setDescricao(conta.getDescricao());
+        return responseDTO;
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
@@ -58,7 +58,9 @@ public class TransacaoService {
         responseDTO.setTipoTransacao(transacao.getTipo());
         responseDTO.setDescricao(transacao.getDescricao());
         responseDTO.setContaId(transacao.getConta().getId());
-        responseDTO.setCategoriaId(transacao.getCategoria().getId());
+        responseDTO.setCategoriaId(
+                transacao.getCategoria() != null ? transacao.getCategoria().getId() : null
+        );
         return responseDTO;
     }
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
@@ -23,7 +23,8 @@ public class TransacaoService {
     public TransacaoResponseDTO registrarManual (TransacaoRequestDTO dto) {
         if(dto.getValor() == null ||
                 dto.getContaId() == null ||
-                dto.getData() == null) throw new IllegalArgumentException("Campos obrigatórios não informados");
+                dto.getData() == null) throw new IllegalArgumentException(
+                        "Campos obrigatórios de uma transação não informados");
 
         Conta conta = contaRepository.findById(dto.getContaId())
                 .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
@@ -2,19 +2,18 @@ package bcd.appfinanceirobackend.service;
 
 import bcd.appfinanceirobackend.dto.transacao.TransacaoRequestDTO;
 import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
+import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
 import bcd.appfinanceirobackend.model.Conta;
 import bcd.appfinanceirobackend.model.Transacao;
 import bcd.appfinanceirobackend.repository.ContaRepository;
 import bcd.appfinanceirobackend.repository.TransacaoRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 public class TransacaoService {
 
-    private TransacaoRepository transacaoRepository;
-    private ContaRepository contaRepository;
+    private final TransacaoRepository transacaoRepository;
+    private final ContaRepository contaRepository;
 
     public TransacaoService(TransacaoRepository transacaoRepository, ContaRepository contaRepository) {
         this.transacaoRepository = transacaoRepository;
@@ -26,7 +25,8 @@ public class TransacaoService {
                 dto.getContaId() == null ||
                 dto.getData() == null) throw new IllegalArgumentException("Campos obrigatórios não informados");
 
-        Optional<Conta> conta = contaRepository.findById(dto.getContaId());
+        Conta conta = contaRepository.findById(dto.getContaId())
+                .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));
 
         Transacao transacao = new Transacao();
         transacao.setCategorizada(true);
@@ -38,10 +38,20 @@ public class TransacaoService {
         transacao.setFormaPagamento(dto.getFormaPagamento());
         transacaoRepository.save(transacao);
 
+        return toResponse(transacao);
+
     }
 
     public TransacaoResponseDTO toResponse(Transacao transacao) {
-        
+        TransacaoResponseDTO responseDTO = new TransacaoResponseDTO();
+        responseDTO.setData(transacao.getData());
+        responseDTO.setValor(transacao.getValor());
+        responseDTO.setFormaPagamento(transacao.getFormaPagamento());
+        responseDTO.setTipoTransacao(transacao.getTipo());
+        responseDTO.setDescricao(transacao.getDescricao());
+        responseDTO.setContaId(transacao.getConta().getId());
+        responseDTO.setCategoriaId(transacao.getCategoria().getId());
+        return responseDTO;
     }
 
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
@@ -1,4 +1,22 @@
 package bcd.appfinanceirobackend.service;
 
+import bcd.appfinanceirobackend.dto.transacao.TransacaoRequestDTO;
+import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.repository.ContaRepository;
+import org.springframework.stereotype.Service;
+
+@Service
 public class TransacaoService {
+
+    public TransacaoResponseDTO registrarManual (TransacaoRequestDTO dto) {
+        if(dto.getValor() == null ||
+                dto.getContaId() == null ||
+                dto.getData() == null) throw new IllegalArgumentException("Campos obrigatórios não informados");
+
+        Transacao transacao = new Transacao();
+        transacao.setCategorizada(true);
+        transacao.setConta(ContaRepository. dto.getContaId());
+    }
+
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
@@ -26,8 +26,9 @@ public class TransacaoService {
     public TransacaoResponseDTO registrarManual (TransacaoRequestDTO dto, Usuario usuarioAutenticado) {
         if(dto.getValor() == null ||
                 dto.getContaId() == null ||
-                dto.getData() == null) throw new IllegalArgumentException(
-                        "Campos obrigatórios de uma transação não informados");
+                dto.getData() == null ||
+        dto.getTipoTransacao() == null) throw new IllegalArgumentException(
+                        "Campos obrigatórios não informados(valor, data, contaId, tipoTransacao)");
 
         Conta conta = contaRepository.findById(dto.getContaId())
                 .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
@@ -2,21 +2,46 @@ package bcd.appfinanceirobackend.service;
 
 import bcd.appfinanceirobackend.dto.transacao.TransacaoRequestDTO;
 import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
+import bcd.appfinanceirobackend.model.Conta;
 import bcd.appfinanceirobackend.model.Transacao;
 import bcd.appfinanceirobackend.repository.ContaRepository;
+import bcd.appfinanceirobackend.repository.TransacaoRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 public class TransacaoService {
+
+    private TransacaoRepository transacaoRepository;
+    private ContaRepository contaRepository;
+
+    public TransacaoService(TransacaoRepository transacaoRepository, ContaRepository contaRepository) {
+        this.transacaoRepository = transacaoRepository;
+        this.contaRepository = contaRepository;
+    }
 
     public TransacaoResponseDTO registrarManual (TransacaoRequestDTO dto) {
         if(dto.getValor() == null ||
                 dto.getContaId() == null ||
                 dto.getData() == null) throw new IllegalArgumentException("Campos obrigatórios não informados");
 
+        Optional<Conta> conta = contaRepository.findById(dto.getContaId());
+
         Transacao transacao = new Transacao();
         transacao.setCategorizada(true);
-        transacao.setConta(ContaRepository. dto.getContaId());
+        transacao.setConta(conta);
+        transacao.setValor(dto.getValor());
+        transacao.setData(dto.getData());
+        transacao.setDescricao(dto.getDescricao());
+        transacao.setTipo(dto.getTipoTransacao());
+        transacao.setFormaPagamento(dto.getFormaPagamento());
+        transacaoRepository.save(transacao);
+
+    }
+
+    public TransacaoResponseDTO toResponse(Transacao transacao) {
+        
     }
 
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
@@ -44,14 +44,15 @@ public class TransacaoService {
         transacao.setDescricao(dto.getDescricao());
         transacao.setTipo(dto.getTipoTransacao());
         transacao.setFormaPagamento(dto.getFormaPagamento());
-        transacaoRepository.save(transacao);
+        Transacao transacaoSalva = transacaoRepository.save(transacao);
 
-        return toResponse(transacao);
+        return toResponse(transacaoSalva);
 
     }
 
     public TransacaoResponseDTO toResponse(Transacao transacao) {
         TransacaoResponseDTO responseDTO = new TransacaoResponseDTO();
+        responseDTO.setTransacaoId(transacao.getId());
         responseDTO.setData(transacao.getData());
         responseDTO.setValor(transacao.getValor());
         responseDTO.setFormaPagamento(transacao.getFormaPagamento());

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/TransacaoService.java
@@ -5,9 +5,12 @@ import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
 import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
 import bcd.appfinanceirobackend.model.Conta;
 import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.Usuario;
 import bcd.appfinanceirobackend.repository.ContaRepository;
 import bcd.appfinanceirobackend.repository.TransacaoRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class TransacaoService {
@@ -20,7 +23,7 @@ public class TransacaoService {
         this.contaRepository = contaRepository;
     }
 
-    public TransacaoResponseDTO registrarManual (TransacaoRequestDTO dto) {
+    public TransacaoResponseDTO registrarManual (TransacaoRequestDTO dto, Usuario usuarioAutenticado) {
         if(dto.getValor() == null ||
                 dto.getContaId() == null ||
                 dto.getData() == null) throw new IllegalArgumentException(
@@ -28,6 +31,10 @@ public class TransacaoService {
 
         Conta conta = contaRepository.findById(dto.getContaId())
                 .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));
+
+        if(!conta.getUsuario().getId().equals(usuarioAutenticado.getId())){
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Acesso negado a esta conta");
+        }
 
         Transacao transacao = new Transacao();
         transacao.setCategorizada(true);


### PR DESCRIPTION
## O que mudou
- Criado `JwtAuthFilter` em `security/JwtAuthFilter.java` para interceptar requisições e validar o token JWT no header `Authorization: Bearer <token>`
- Registrado o filtro na `SecurityConfig` antes do `UsernamePasswordAuthenticationFilter`
- Adicionado `@RequestBody` no parâmetro `TransacaoRequestDTO` do `TransacaoController`
- Adicionado `@AuthenticationPrincipal Usuario` no endpoint `POST /transacoes/manual` para capturar o usuário autenticado
- Atualizado `TransacaoService.registrarManual()` para receber o `Usuario` autenticado e validar a posse da conta
- Adicionado `findByIdAndUsuarioEmail()` no `ContaRepository` para busca segura da conta por dono
- Corrigido NPE em `toResponse()` ao acessar `getCategoria()` sem verificar nulidade

## Por quê
- Implementação dos critérios de aceitação pendentes da issue de registro manual de transações
- Critério: apenas usuários autenticados podem registrar transações (filtro JWT ausente)
- Critério: retornar 403 quando a conta não pertence ao usuário autenticado (validação de posse ausente)
- Critério: retornar 201 com a transação salva (quebrava silenciosamente por ausência do `@RequestBody`)
- Correção de bug: `toResponse()` lançava `NullPointerException` em transações sem categoria

## Como testar
1. Suba a aplicação e obtenha um token via `POST /auth/login` com credenciais válidas
2. Envie `POST /transacoes/manual` sem o header `Authorization` e verifique se retorna **401**
3. Envie `POST /transacoes/manual` com o token válido e body completo (valor, data, descrição, tipo, formaPagamento, categoriaId, contaId) e verifique se retorna **201** com a transação
4. Envie o mesmo body com um `contaId` de outro usuário e verifique se retorna **403**
5. Envie o mesmo body com um `contaId` inexistente e verifique se retorna **404**
6. Envie sem os campos obrigatórios (valor, data, contaId) e verifique se retorna **400** com mensagem descritiva
7. Envie com `categoriaId` nulo e verifique se a transação é salva normalmente sem NPE

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: conta inexistente → 404, conta de outro usuário → 403, categoria nula → salva sem erro)
- [x] Evidência de teste (manual via Postman/Insomnia seguindo os passos acima)
- [x] Não quebrou funcionalidades existentes (filtro JWT não interfere nas rotas públicas de `/auth`)
- [x] Código revisado e limpo

Closes #62 #82 

## Comentários técnicos

- [Risco] O `JwtAuthFilter` é o ponto central de autenticação de todas as rotas protegidas. Qualquer falha na validação do token (ex.: segredo errado na variável de ambiente `JWT_SECRET`) fará com que todas as requisições cheguem sem autenticação, retornando 401 globalmente. Validar o valor configurado no `application.properties` antes de subir em produção.

- [Manutenção] A validação de posse da conta foi separada em duas etapas explícitas no `TransacaoService`: primeiro busca por ID (404 se não existe), depois compara o dono (403 se não pertence). Isso evita ambiguidade no retorno e facilita a adição de novos critérios de autorização no futuro sem alterar a lógica de busca.

- [Teste] O NPE em `toResponse()` ao acessar `getCategoria()` só se manifestaria em runtime ao salvar uma transação manual, pois `categoriaId` é opcional. Não havia teste cobrindo esse fluxo — recomenda-se adicionar um teste unitário no `TransacaoService` com `categoriaId = null` para garantir que a correção não regrida.