### PR TITLE
feat/registro-transacao-manual-#63

### DIFF
--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/CategoriaController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/CategoriaController.java
@@ -1,0 +1,28 @@
+package bcd.appfinanceirobackend.controller;
+
+import bcd.appfinanceirobackend.dto.transacao.CategoriaTransacaoDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.service.CategoriaService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/categorias")
+public class CategoriaController {
+
+    private final CategoriaService categoriaService;
+
+    public CategoriaController(CategoriaService categoriaService) {
+        this.categoriaService = categoriaService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CategoriaTransacaoDTO>> listar(@AuthenticationPrincipal Usuario usuario) {
+        return ResponseEntity.ok(categoriaService.listarParaUsuario(usuario));
+    }
+}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ContaController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ContaController.java
@@ -7,10 +7,13 @@ import bcd.appfinanceirobackend.service.ContaService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/contas")
@@ -19,6 +22,11 @@ public class ContaController {
     private final ContaService contaService;
 
     public ContaController (ContaService contaService) { this.contaService = contaService;}
+
+    @GetMapping
+    public ResponseEntity<List<ContaResponseDTO>> listarContas(@AuthenticationPrincipal Usuario usuario) {
+        return ResponseEntity.ok(contaService.listarPorUsuario(usuario));
+    }
 
     @PostMapping("/registrar")
     public ResponseEntity<ContaResponseDTO> registrarConta (@RequestBody ContaRequestDTO dto,

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/transacao/CategoriaTransacaoDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/transacao/CategoriaTransacaoDTO.java
@@ -1,4 +1,52 @@
 package bcd.appfinanceirobackend.dto.transacao;
 
+import java.util.UUID;
+
 public class CategoriaTransacaoDTO {
+
+    private UUID categoriaId;
+    private String nome;
+    private String icone;
+    private String cor;
+    private boolean padrao;
+
+    public UUID getCategoriaId() {
+        return categoriaId;
+    }
+
+    public void setCategoriaId(UUID categoriaId) {
+        this.categoriaId = categoriaId;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public String getIcone() {
+        return icone;
+    }
+
+    public void setIcone(String icone) {
+        this.icone = icone;
+    }
+
+    public String getCor() {
+        return cor;
+    }
+
+    public void setCor(String cor) {
+        this.cor = cor;
+    }
+
+    public boolean isPadrao() {
+        return padrao;
+    }
+
+    public void setPadrao(boolean padrao) {
+        this.padrao = padrao;
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/CategoriaRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/CategoriaRepository.java
@@ -4,8 +4,10 @@ import bcd.appfinanceirobackend.model.Categoria;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface CategoriaRepository extends JpaRepository<Categoria, UUID> {
+    List<Categoria> findByPadraoTrueOrUsuarioId(UUID usuarioId);
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/ContaRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/ContaRepository.java
@@ -4,9 +4,10 @@ import bcd.appfinanceirobackend.model.Conta;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface ContaRepository extends JpaRepository<Conta, UUID> {
-
+    List<Conta> findByUsuarioId(UUID usuarioId);
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/CategoriaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/CategoriaService.java
@@ -1,4 +1,36 @@
 package bcd.appfinanceirobackend.service;
 
+import bcd.appfinanceirobackend.dto.transacao.CategoriaTransacaoDTO;
+import bcd.appfinanceirobackend.model.Categoria;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.repository.CategoriaRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
 public class CategoriaService {
+
+    private final CategoriaRepository categoriaRepository;
+
+    public CategoriaService(CategoriaRepository categoriaRepository) {
+        this.categoriaRepository = categoriaRepository;
+    }
+
+    public List<CategoriaTransacaoDTO> listarParaUsuario(Usuario usuario) {
+        return categoriaRepository.findByPadraoTrueOrUsuarioId(usuario.getId())
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private CategoriaTransacaoDTO toResponse(Categoria categoria) {
+        CategoriaTransacaoDTO dto = new CategoriaTransacaoDTO();
+        dto.setCategoriaId(categoria.getId());
+        dto.setNome(categoria.getNome());
+        dto.setIcone(categoria.getIcone());
+        dto.setCor(categoria.getCor());
+        dto.setPadrao(categoria.isPadrao());
+        return dto;
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
@@ -7,12 +7,21 @@ import bcd.appfinanceirobackend.model.Usuario;
 import bcd.appfinanceirobackend.repository.ContaRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class ContaService {
 
     private final ContaRepository contaRepository;
 
     public ContaService (ContaRepository contaRepository) {this.contaRepository = contaRepository;}
+
+    public List<ContaResponseDTO> listarPorUsuario(Usuario usuarioAutenticado) {
+        return contaRepository.findByUsuarioId(usuarioAutenticado.getId())
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
 
     public ContaResponseDTO registrar(ContaRequestDTO dto, Usuario usuarioAutenticado) {
         if(dto.getNome() == null ||

--- a/app-financeiro-front-end/src/App.tsx
+++ b/app-financeiro-front-end/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { ProvedorAutenticacao } from './contexts/ContextoAutenticacao';
 import Login from './pages/Login';
 import Cadastro from './pages/Cadastro';
+import NovaTransacao from './pages/NovaTransacao';
 
 // Dashboard provisório — substituir pela tela oficial
 const PainelProvisorio = () => (
@@ -20,6 +21,7 @@ function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/cadastro" element={<Cadastro />} />
           <Route path="/dashboard" element={<PainelProvisorio />} />
+          <Route path="/transacoes/nova" element={<NovaTransacao />} />
         </Routes>
       </Router>
     </ProvedorAutenticacao>

--- a/app-financeiro-front-end/src/pages/NovaTransacao.tsx
+++ b/app-financeiro-front-end/src/pages/NovaTransacao.tsx
@@ -4,435 +4,423 @@ import BotaoCarregando from '../components/ui/BotaoCarregando';
 import MensagemAlerta from '../components/ui/MensagemAlerta';
 import { useAutenticacao } from '../contexts/ContextoAutenticacao';
 import {
-    listarCategorias,
-    listarContas,
-    registrarTransacaoManual,
+  listarCategorias,
+  listarContas,
+  registrarTransacaoManual,
 } from '../services/api';
 import type {
-    CategoriaResponse,
-    ContaResponse,
-    TipoPagamento,
-    TipoTransacao,
-    TransacaoResponse,
+  CategoriaResponse,
+  ContaResponse,
+  TipoPagamento,
+  TipoTransacao,
+  TransacaoResponse,
 } from '../services/api';
 
 type CamposTransacao = {
-    valor: string;
-    data: string;
-    descricao: string;
-    tipoTransacao: TipoTransacao;
-    formaPagamento: TipoPagamento;
-    categoriaId: string;
-    contaId: string;
+  valor: string;
+  data: string;
+  descricao: string;
+  tipoTransacao: TipoTransacao;
+  formaPagamento: TipoPagamento;
+  categoriaId: string;
+  contaId: string;
 };
 
 const valoresIniciais: CamposTransacao = {
-    valor: '',
-    data: new Date().toISOString().slice(0, 10),
-    descricao: '',
-    tipoTransacao: 'DEBITO',
-    formaPagamento: 'PIX',
-    categoriaId: '',
-    contaId: '',
+  valor: '',
+  data: new Date().toISOString().slice(0, 10),
+  descricao: '',
+  tipoTransacao: 'DEBITO',
+  formaPagamento: 'PIX',
+  categoriaId: '',
+  contaId: '',
 };
 
 const tiposTransacao: Array<{ valor: TipoTransacao; rotulo: string }> = [
-    { valor: 'DEBITO', rotulo: 'Saída / despesa' },
-    { valor: 'CREDITO', rotulo: 'Entrada / receita' },
-    { valor: 'PARCELAMENTO', rotulo: 'Parcelamento' },
-    { valor: 'BOLETO', rotulo: 'Boleto' },
+  { valor: 'DEBITO', rotulo: 'Saída / despesa' },
+  { valor: 'CREDITO', rotulo: 'Entrada / receita' },
+  { valor: 'PARCELAMENTO', rotulo: 'Parcelamento' },
+  { valor: 'BOLETO', rotulo: 'Boleto' },
 ];
 
 const formasPagamento: Array<{ valor: TipoPagamento; rotulo: string }> = [
-    { valor: 'PIX', rotulo: 'Pix' },
-    { valor: 'CARTAO_DEBITO', rotulo: 'Cartão de débito' },
-    { valor: 'CARTAO_CREDITO', rotulo: 'Cartão de crédito' },
-    { valor: 'DINHEIRO', rotulo: 'Dinheiro' },
-    { valor: 'BOLETO', rotulo: 'Boleto' },
-    { valor: 'TED_DOC', rotulo: 'TED/DOC' },
-];
-
-const formasPagamento: Array<{ valor: TipoPagamento; rotulo: string }> = [
-    { valor: 'PIX', rotulo: 'Pix' },
-    { valor: 'CARTAO_DEBITO', rotulo: 'Cartão de débito' },
-    { valor: 'CARTAO_CREDITO', rotulo: 'Cartão de crédito' },
-    { valor: 'DINHEIRO', rotulo: 'Dinheiro' },
-    { valor: 'BOLETO', rotulo: 'Boleto' },
-    { valor: 'TED_DOC', rotulo: 'TED/DOC' },
+  { valor: 'PIX', rotulo: 'Pix' },
+  { valor: 'CARTAO_DEBITO', rotulo: 'Cartão de débito' },
+  { valor: 'CARTAO_CREDITO', rotulo: 'Cartão de crédito' },
+  { valor: 'DINHEIRO', rotulo: 'Dinheiro' },
+  { valor: 'BOLETO', rotulo: 'Boleto' },
+  { valor: 'TED_DOC', rotulo: 'TED/DOC' },
 ];
 
 const obterRotuloTipoTransacao = (valor: TipoTransacao) =>
-    tiposTransacao.find((tipo) => tipo.valor === valor)?.rotulo || valor;
+  tiposTransacao.find((tipo) => tipo.valor === valor)?.rotulo || valor;
 
 const obterRotuloFormaPagamento = (valor?: TipoPagamento | null) =>
-    formasPagamento.find((forma) => forma.valor === valor)?.rotulo || valor || 'Não informado';
+  formasPagamento.find((forma) => forma.valor === valor)?.rotulo || valor || 'Não informado';
 
 const formatarMoeda = (valor: number | string) =>
-    Number(valor).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
-
-const formatarMoeda = (valor: number | string) =>
-    Number(valor).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  Number(valor).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
 const NovaTransacao: React.FC = () => {
-    const { estaAutenticado, sair } = useAutenticacao();
-    const [campos, setCampos] = useState<CamposTransacao>(valoresIniciais);
-    const [contas, setContas] = useState<ContaResponse[]>([]);
-    const [categorias, setCategorias] = useState<CategoriaResponse[]>([]);
-    const [transacoes, setTransacoes] = useState<TransacaoResponse[]>([]);
-    const [erros, setErros] = useState<Partial<Record<keyof CamposTransacao, string>>>({});
-    const [erroGeral, setErroGeral] = useState('');
-    const [sucesso, setSucesso] = useState('');
-    const [carregandoDados, setCarregandoDados] = useState(false);
-    const [salvando, setSalvando] = useState(false);
+  const { estaAutenticado, sair } = useAutenticacao();
+  const [campos, setCampos] = useState<CamposTransacao>(valoresIniciais);
+  const [contas, setContas] = useState<ContaResponse[]>([]);
+  const [categorias, setCategorias] = useState<CategoriaResponse[]>([]);
+  const [transacoes, setTransacoes] = useState<TransacaoResponse[]>([]);
+  const [erros, setErros] = useState<Partial<Record<keyof CamposTransacao, string>>>({});
+  const [erroGeral, setErroGeral] = useState('');
+  const [sucesso, setSucesso] = useState('');
+  const [carregandoDados, setCarregandoDados] = useState(false);
+  const [salvando, setSalvando] = useState(false);
 
-    useEffect(() => {
-        if (!estaAutenticado) return;
+  useEffect(() => {
+    if (!estaAutenticado) return;
 
-        const carregarDados = async () => {
-            setCarregandoDados(true);
-            setErroGeral('');
+    const carregarDados = async () => {
+      setCarregandoDados(true);
+      setErroGeral('');
 
-            try {
-                const [contasCarregadas, categoriasCarregadas] = await Promise.all([
-                    listarContas(),
-                    listarCategorias(),
-                ]);
+      try {
+        const [contasCarregadas, categoriasCarregadas] = await Promise.all([
+          listarContas(),
+          listarCategorias(),
+        ]);
 
-                setContas(contasCarregadas);
-                setCategorias(categoriasCarregadas);
+        setContas(contasCarregadas);
+        setCategorias(categoriasCarregadas);
 
-                setCampos((prev) => ({
-                    ...prev,
-                    contaId: prev.contaId || contasCarregadas[0]?.contaId || '',
-                    categoriaId: prev.categoriaId || categoriasCarregadas[0]?.categoriaId || '',
-                }));
-            } catch (err: any) {
-                if (err?.response?.status === 401 || err?.response?.status === 403) {
-                    setErroGeral('Sua sessão expirou. Faça login novamente.');
-                    sair();
-                    return;
-                }
+        setCampos((prev) => ({
+          ...prev,
+          contaId: prev.contaId || contasCarregadas[0]?.contaId || '',
+          categoriaId: prev.categoriaId || categoriasCarregadas[0]?.categoriaId || '',
+        }));
+      } catch (err: any) {
+        if (err?.response?.status === 401 || err?.response?.status === 403) {
+          setErroGeral('Sua sessão expirou. Faça login novamente.');
+          sair();
+          return;
+        }
 
-                setErroGeral('Não foi possível carregar contas e categorias.');
-            } finally {
-                setCarregandoDados(false);
-            }
-        };
+        setErroGeral('Não foi possível carregar contas e categorias.');
+      } finally {
+        setCarregandoDados(false);
+      }
+    };
 
-        carregarDados();
-    }, [estaAutenticado, sair]);
+    carregarDados();
+  }, [estaAutenticado, sair]);
 
-    const categoriaPorId = useMemo(
-        () => new Map(categorias.map((categoria) => [categoria.categoriaId, categoria])),
-        [categorias]
-    );
+  const categoriaPorId = useMemo(
+    () => new Map(categorias.map((categoria) => [categoria.categoriaId, categoria])),
+    [categorias]
+  );
 
-    const contaPorId = useMemo(
-        () => new Map(contas.map((conta) => [conta.contaId, conta])),
-        [contas]
-    );
+  const contaPorId = useMemo(
+    () => new Map(contas.map((conta) => [conta.contaId, conta])),
+    [contas]
+  );
 
-    if (!estaAutenticado) {
-        return <Navigate to="/login" replace />;
+  if (!estaAutenticado) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const alterarCampo = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setCampos((prev) => ({ ...prev, [name]: value }));
+    setErros((prev) => ({ ...prev, [name]: undefined }));
+  };
+
+  const validar = () => {
+    const novosErros: Partial<Record<keyof CamposTransacao, string>> = {};
+    const valorNumerico = Number(campos.valor);
+
+    if (!campos.valor) {
+      novosErros.valor = 'Valor é obrigatório.';
+    } else if (Number.isNaN(valorNumerico) || valorNumerico <= 0) {
+      novosErros.valor = 'Informe um valor positivo.';
     }
 
-    const alterarCampo = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-        const { name, value } = e.target;
-        setCampos((prev) => ({ ...prev, [name]: value }));
-        setErros((prev) => ({ ...prev, [name]: undefined }));
-    };
+    if (!campos.data) {
+      novosErros.data = 'Data é obrigatória.';
+    }
 
-    const validar = () => {
-        const novosErros: Partial<Record<keyof CamposTransacao, string>> = {};
-        const valorNumerico = Number(campos.valor);
+    if (!campos.contaId) {
+      novosErros.contaId = 'Conta é obrigatória.';
+    }
 
-        if (!campos.valor) {
-            novosErros.valor = 'Valor é obrigatório.';
-        } else if (Number.isNaN(valorNumerico) || valorNumerico <= 0) {
-            novosErros.valor = 'Informe um valor positivo.';
-        }
+    setErros(novosErros);
+    return Object.keys(novosErros).length === 0;
+  };
 
-        if (!campos.data) {
-            novosErros.data = 'Data é obrigatória.';
-        }
+  const enviar = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErroGeral('');
+    setSucesso('');
 
-        if (!campos.contaId) {
-            novosErros.contaId = 'Conta é obrigatória.';
-        }
+    if (!validar()) return;
 
-        setErros(novosErros);
-        return Object.keys(novosErros).length === 0;
-    };
+    setSalvando(true);
 
-    const enviar = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setErroGeral('');
-        setSucesso('');
+    try {
+      const transacaoSalva = await registrarTransacaoManual({
+        valor: Number(campos.valor),
+        data: campos.data,
+        descricao: campos.descricao.trim() || undefined,
+        tipoTransacao: campos.tipoTransacao,
+        formaPagamento: campos.formaPagamento,
+        categoriaId: campos.categoriaId || null,
+        contaId: campos.contaId,
+      });
 
-        if (!validar()) return;
+      setTransacoes((prev) => [transacaoSalva, ...prev]);
+      setSucesso('Transação registrada com sucesso.');
 
-        setSalvando(true);
+      setCampos((prev) => ({
+        ...valoresIniciais,
+        data: new Date().toISOString().slice(0, 10),
+        contaId: prev.contaId,
+        categoriaId: prev.categoriaId,
+      }));
+    } catch (err: any) {
+      const msg = err?.response?.data?.erro || err?.response?.data?.message;
+      setErroGeral(msg || 'Não foi possível registrar a transação.');
+    } finally {
+      setSalvando(false);
+    }
+  };
 
-        try {
-            const transacaoSalva = await registrarTransacaoManual({
-                valor: Number(campos.valor),
-                data: campos.data,
-                descricao: campos.descricao.trim() || undefined,
-                tipoTransacao: campos.tipoTransacao,
-                formaPagamento: campos.formaPagamento,
-                categoriaId: campos.categoriaId || null,
-                contaId: campos.contaId,
-            });
+  return (
+    <main className="min-vh-100 py-4" style={{ background: 'var(--sb-bg)' }}>
+      <div className="container" style={{ maxWidth: 1100 }}>
+        <div className="d-flex flex-column flex-md-row justify-content-between gap-3 align-items-md-center mb-4">
+          <div>
+            <span className="badge rounded-pill mb-2" style={{ background: 'var(--sb-primary)' }}>
+              SmartBudget
+            </span>
+            <h1 className="fw-bold mb-1" style={{ color: 'var(--sb-text)' }}>
+              Nova transação
+            </h1>
+            <p className="text-muted mb-0">
+              Registre manualmente gastos que não vieram de extrato ou nota fiscal.
+            </p>
+          </div>
 
-            setTransacoes((prev) => [transacaoSalva, ...prev]);
-            setSucesso('Transação registrada com sucesso.');
+          <Link to="/dashboard" className="btn btn-outline-secondary align-self-start align-self-md-center">
+            Voltar ao painel
+          </Link>
+        </div>
 
-            setCampos((prev) => ({
-                ...valoresIniciais,
-                data: new Date().toISOString().slice(0, 10),
-                contaId: prev.contaId,
-                categoriaId: prev.categoriaId,
-            }));
-        } catch (err: any) {
-            const msg = err?.response?.data?.erro || err?.response?.data?.message;
-            setErroGeral(msg || 'Não foi possível registrar a transação.');
-        } finally {
-            setSalvando(false);
-        }
-    };
+        <MensagemAlerta mensagem={erroGeral} tipo="danger" />
+        <MensagemAlerta mensagem={sucesso} tipo="success" />
 
-    return (
-        <main className="min-vh-100 py-4" style={{ background: 'var(--sb-bg)' }}>
-            <div className="container" style={{ maxWidth: 1100 }}>
-                <div className="d-flex flex-column flex-md-row justify-content-between gap-3 align-items-md-center mb-4">
-                    <div>
-                        <span className="badge rounded-pill mb-2" style={{ background: 'var(--sb-primary)' }}>
-                            SmartBudget
-                        </span>
-                        <h1 className="fw-bold mb-1" style={{ color: 'var(--sb-text)' }}>
-                            Nova transação
-                        </h1>
-                        <p className="text-muted mb-0">
-                            Registre manualmente gastos que não vieram de extrato ou nota fiscal.
-                        </p>
+        <div className="row g-4">
+          <section className="col-lg-7">
+            <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
+              <div className="card-body p-4">
+                <h2 className="h5 fw-bold mb-3">Dados da transação</h2>
+
+                {carregandoDados ? (
+                  <p className="text-muted mb-0">Carregando contas e categorias...</p>
+                ) : (
+                  <form onSubmit={enviar} noValidate>
+                    <div className="row g-3">
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="valor">
+                          Valor *
+                        </label>
+                        <input
+                          id="valor"
+                          name="valor"
+                          type="number"
+                          min="0.01"
+                          step="0.01"
+                          className={`form-control ${erros.valor ? 'is-invalid' : ''}`}
+                          value={campos.valor}
+                          onChange={alterarCampo}
+                          placeholder="0,00"
+                        />
+                        {erros.valor && <div className="invalid-feedback">{erros.valor}</div>}
+                      </div>
+
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="data">
+                          Data *
+                        </label>
+                        <input
+                          id="data"
+                          name="data"
+                          type="date"
+                          className={`form-control ${erros.data ? 'is-invalid' : ''}`}
+                          value={campos.data}
+                          onChange={alterarCampo}
+                        />
+                        {erros.data && <div className="invalid-feedback">{erros.data}</div>}
+                      </div>
+
+                      <div className="col-12">
+                        <label className="form-label fw-semibold small" htmlFor="descricao">
+                          Descrição
+                        </label>
+                        <input
+                          id="descricao"
+                          name="descricao"
+                          type="text"
+                          className="form-control"
+                          value={campos.descricao}
+                          onChange={alterarCampo}
+                          placeholder="Ex.: mercado, almoço, transporte..."
+                        />
+                      </div>
+
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="tipoTransacao">
+                          Tipo
+                        </label>
+                        <select
+                          id="tipoTransacao"
+                          name="tipoTransacao"
+                          className="form-select"
+                          value={campos.tipoTransacao}
+                          onChange={alterarCampo}
+                        >
+                          {tiposTransacao.map((tipo) => (
+                            <option key={tipo.valor} value={tipo.valor}>
+                              {tipo.rotulo}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="formaPagamento">
+                          Forma de pagamento
+                        </label>
+                        <select
+                          id="formaPagamento"
+                          name="formaPagamento"
+                          className="form-select"
+                          value={campos.formaPagamento}
+                          onChange={alterarCampo}
+                        >
+                          {formasPagamento.map((forma) => (
+                            <option key={forma.valor} value={forma.valor}>
+                              {forma.rotulo}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="categoriaId">
+                          Categoria
+                        </label>
+                        <select
+                          id="categoriaId"
+                          name="categoriaId"
+                          className="form-select"
+                          value={campos.categoriaId}
+                          onChange={alterarCampo}
+                        >
+                          <option value="">Sem categoria</option>
+                          {categorias.map((categoria) => (
+                            <option key={categoria.categoriaId} value={categoria.categoriaId}>
+                              {categoria.nome}
+                              {categoria.padrao ? ' (padrão)' : ''}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="contaId">
+                          Conta *
+                        </label>
+                        <select
+                          id="contaId"
+                          name="contaId"
+                          className={`form-select ${erros.contaId ? 'is-invalid' : ''}`}
+                          value={campos.contaId}
+                          onChange={alterarCampo}
+                        >
+                          <option value="">Selecione uma conta</option>
+                          {contas.map((conta) => (
+                            <option key={conta.contaId} value={conta.contaId}>
+                              {conta.nome}
+                              {conta.banco ? ` - ${conta.banco}` : ''}
+                            </option>
+                          ))}
+                        </select>
+                        {erros.contaId && <div className="invalid-feedback">{erros.contaId}</div>}
+                      </div>
                     </div>
 
-                    <Link to="/dashboard" className="btn btn-outline-secondary align-self-start align-self-md-center">
-                        Voltar ao painel
-                    </Link>
-                </div>
+                    <BotaoCarregando
+                      type="submit"
+                      carregando={salvando}
+                      textoCarregando="Salvando..."
+                      className="w-100 mt-4 py-2 fw-semibold"
+                      style={{ background: 'var(--sb-gradient)', border: 'none', borderRadius: 10 }}
+                      disabled={contas.length === 0}
+                    >
+                      Salvar transação
+                    </BotaoCarregando>
 
-                <MensagemAlerta mensagem={erroGeral} tipo="danger" />
-                <MensagemAlerta mensagem={sucesso} tipo="success" />
-
-                <div className="row g-4">
-                    <section className="col-lg-7">
-                        <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
-                            <div className="card-body p-4">
-                                <h2 className="h5 fw-bold mb-3">Dados da transação</h2>
-
-                                {carregandoDados ? (
-                                    <p className="text-muted mb-0">Carregando contas e categorias...</p>
-                                ) : (
-                                    <form onSubmit={enviar} noValidate>
-                                        <div className="row g-3">
-                                            <div className="col-md-6">
-                                                <label className="form-label fw-semibold small" htmlFor="valor">
-                                                    Valor *
-                                                </label>
-                                                <input
-                                                    id="valor"
-                                                    name="valor"
-                                                    type="number"
-                                                    min="0.01"
-                                                    step="0.01"
-                                                    className={`form-control ${erros.valor ? 'is-invalid' : ''}`}
-                                                    value={campos.valor}
-                                                    onChange={alterarCampo}
-                                                    placeholder="0,00"
-                                                />
-                                                {erros.valor && <div className="invalid-feedback">{erros.valor}</div>}
-                                            </div>
-
-                                            <div className="col-md-6">
-                                                <label className="form-label fw-semibold small" htmlFor="data">
-                                                    Data *
-                                                </label>
-                                                <input
-                                                    id="data"
-                                                    name="data"
-                                                    type="date"
-                                                    className={`form-control ${erros.data ? 'is-invalid' : ''}`}
-                                                    value={campos.data}
-                                                    onChange={alterarCampo}
-                                                />
-                                                {erros.data && <div className="invalid-feedback">{erros.data}</div>}
-                                            </div>
-
-                                            <div className="col-12">
-                                                <label className="form-label fw-semibold small" htmlFor="descricao">
-                                                    Descrição
-                                                </label>
-                                                <input
-                                                    id="descricao"
-                                                    name="descricao"
-                                                    type="text"
-                                                    className="form-control"
-                                                    value={campos.descricao}
-                                                    onChange={alterarCampo}
-                                                    placeholder="Ex.: mercado, almoço, transporte..."
-                                                />
-                                            </div>
-
-                                            <div className="col-md-6">
-                                                <label className="form-label fw-semibold small" htmlFor="tipoTransacao">
-                                                    Tipo
-                                                </label>
-                                                <select
-                                                    id="tipoTransacao"
-                                                    name="tipoTransacao"
-                                                    className="form-select"
-                                                    value={campos.tipoTransacao}
-                                                    onChange={alterarCampo}
-                                                >
-                                                    {tiposTransacao.map((tipo) => (
-                                                        <option key={tipo.valor} value={tipo.valor}>
-                                                            {tipo.rotulo}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                            </div>
-
-                                            <div className="col-md-6">
-                                                <label className="form-label fw-semibold small" htmlFor="formaPagamento">
-                                                    Forma de pagamento
-                                                </label>
-                                                <select
-                                                    id="formaPagamento"
-                                                    name="formaPagamento"
-                                                    className="form-select"
-                                                    value={campos.formaPagamento}
-                                                    onChange={alterarCampo}
-                                                >
-                                                    {formasPagamento.map((forma) => (
-                                                        <option key={forma.valor} value={forma.valor}>
-                                                            {forma.rotulo}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                            </div>
-
-                                            <div className="col-md-6">
-                                                <label className="form-label fw-semibold small" htmlFor="categoriaId">
-                                                    Categoria
-                                                </label>
-                                                <select
-                                                    id="categoriaId"
-                                                    name="categoriaId"
-                                                    className="form-select"
-                                                    value={campos.categoriaId}
-                                                    onChange={alterarCampo}
-                                                >
-                                                    <option value="">Sem categoria</option>
-                                                    {categorias.map((categoria) => (
-                                                        <option key={categoria.categoriaId} value={categoria.categoriaId}>
-                                                            {categoria.nome}
-                                                            {categoria.padrao ? ' (padrão)' : ''}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                            </div>
-
-                                            <div className="col-md-6">
-                                                <label className="form-label fw-semibold small" htmlFor="contaId">
-                                                    Conta *
-                                                </label>
-                                                <select
-                                                    id="contaId"
-                                                    name="contaId"
-                                                    className={`form-select ${erros.contaId ? 'is-invalid' : ''}`}
-                                                    value={campos.contaId}
-                                                    onChange={alterarCampo}
-                                                >
-                                                    <option value="">Selecione uma conta</option>
-                                                    {contas.map((conta) => (
-                                                        <option key={conta.contaId} value={conta.contaId}>
-                                                            {conta.nome}
-                                                            {conta.banco ? ` - ${conta.banco}` : ''}
-                                                        </option>
-                                                    ))}
-                                                </select>
-                                                {erros.contaId && <div className="invalid-feedback">{erros.contaId}</div>}
-                                            </div>
-                                        </div>
-
-                                        <BotaoCarregando
-                                            type="submit"
-                                            carregando={salvando}
-                                            textoCarregando="Salvando..."
-                                            className="w-100 mt-4 py-2 fw-semibold"
-                                            style={{ background: 'var(--sb-gradient)', border: 'none', borderRadius: 10 }}
-                                            disabled={contas.length === 0}
-                                        >
-                                            Salvar transação
-                                        </BotaoCarregando>
-
-                                        {contas.length === 0 && (
-                                            <p className="text-muted small mt-3 mb-0">
-                                                Cadastre uma conta antes de registrar transações.
-                                            </p>
-                                        )}
-                                    </form>
-                                )}
-                            </div>
-                        </div>
-                    </section>
-
-                    <section className="col-lg-5">
-                        <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
-                            <div className="card-body p-4">
-                                <h2 className="h5 fw-bold mb-3">Histórico recém-criado</h2>
-
-                                {transacoes.length === 0 ? (
-                                    <p className="text-muted mb-0">
-                                        As transações salvas nesta tela aparecerão aqui sem recarregar a página.
-                                    </p>
-                                ) : (
-                                    <div className="d-flex flex-column gap-3">
-                                        {transacoes.map((transacao) => (
-                                            <article
-                                                key={transacao.transacaoId}
-                                                className="border rounded-3 p-3 bg-light"
-                                            >
-                                                <div className="d-flex justify-content-between gap-3">
-                                                    <div>
-                                                        <strong>{transacao.descricao || 'Transação manual'}</strong>
-                                                        <div className="text-muted small">
-                                                            {contaPorId.get(transacao.contaId)?.nome || 'Conta'} •{' '}
-                                                            {transacao.categoriaId
-                                                                ? categoriaPorId.get(transacao.categoriaId)?.nome || 'Categoria'
-                                                                : 'Sem categoria'}
-                                                        </div>
-                                                    </div>
-
-                                                    <strong>{formatarMoeda(transacao.valor)}</strong>
-                                                </div>
-
-                                                <div className="text-muted small mt-2">
-                                                    {transacao.data} • {obterRotuloTipoTransacao(transacao.tipoTransacao)} •{' '}
-                                                    {obterRotuloFormaPagamento(transacao.formaPagamento)}
-                                                </div>
-                                            </article>
-                                        ))}
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    </section>
-                </div>
+                    {contas.length === 0 && (
+                      <p className="text-muted small mt-3 mb-0">
+                        Cadastre uma conta antes de registrar transações.
+                      </p>
+                    )}
+                  </form>
+                )}
+              </div>
             </div>
-        </main>
-    );
+          </section>
+
+          <section className="col-lg-5">
+            <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
+              <div className="card-body p-4">
+                <h2 className="h5 fw-bold mb-3">Histórico recém-criado</h2>
+
+                {transacoes.length === 0 ? (
+                  <p className="text-muted mb-0">
+                    As transações salvas nesta tela aparecerão aqui sem recarregar a página.
+                  </p>
+                ) : (
+                  <div className="d-flex flex-column gap-3">
+                    {transacoes.map((transacao) => (
+                      <article
+                        key={transacao.transacaoId}
+                        className="border rounded-3 p-3 bg-light"
+                      >
+                        <div className="d-flex justify-content-between gap-3">
+                          <div>
+                            <strong>{transacao.descricao || 'Transação manual'}</strong>
+                            <div className="text-muted small">
+                              {contaPorId.get(transacao.contaId)?.nome || 'Conta'} •{' '}
+                              {transacao.categoriaId
+                                ? categoriaPorId.get(transacao.categoriaId)?.nome || 'Categoria'
+                                : 'Sem categoria'}
+                            </div>
+                          </div>
+
+                          <strong>{formatarMoeda(transacao.valor)}</strong>
+                        </div>
+
+                        <div className="text-muted small mt-2">
+                          {transacao.data} • {obterRotuloTipoTransacao(transacao.tipoTransacao)} •{' '} 
+                          {obterRotuloFormaPagamento(transacao.formaPagamento)}
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
 };
 
 export default NovaTransacao;

--- a/app-financeiro-front-end/src/pages/NovaTransacao.tsx
+++ b/app-financeiro-front-end/src/pages/NovaTransacao.tsx
@@ -52,6 +52,24 @@ const formasPagamento: Array<{ valor: TipoPagamento; rotulo: string }> = [
   { valor: 'TED_DOC', rotulo: 'TED/DOC' },
 ];
 
+const formasPagamento: Array<{ valor: TipoPagamento; rotulo: string }> = [
+  { valor: 'PIX', rotulo: 'Pix' },
+  { valor: 'CARTAO_DEBITO', rotulo: 'Cartão de débito' },
+  { valor: 'CARTAO_CREDITO', rotulo: 'Cartão de crédito' },
+  { valor: 'DINHEIRO', rotulo: 'Dinheiro' },
+  { valor: 'BOLETO', rotulo: 'Boleto' },
+  { valor: 'TED_DOC', rotulo: 'TED/DOC' },
+];
+
+const obterRotuloTipoTransacao = (valor: TipoTransacao) =>
+  tiposTransacao.find((tipo) => tipo.valor === valor)?.rotulo || valor;
+
+const obterRotuloFormaPagamento = (valor?: TipoPagamento | null) =>
+  formasPagamento.find((forma) => forma.valor === valor)?.rotulo || valor || 'Não informado';
+
+const formatarMoeda = (valor: number | string) =>
+  Number(valor).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
 const formatarMoeda = (valor: number | string) =>
   Number(valor).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 

--- a/app-financeiro-front-end/src/pages/NovaTransacao.tsx
+++ b/app-financeiro-front-end/src/pages/NovaTransacao.tsx
@@ -367,7 +367,7 @@ const NovaTransacao: React.FC = () => {
 
                     {contas.length === 0 && (
                       <p className="text-muted small mt-3 mb-0">
-                        Cadastre uma conta antes de registrar transações.
+                        Cadastre-se com uma conta antes de registrar transações.
                       </p>
                     )}
                   </form>

--- a/app-financeiro-front-end/src/pages/NovaTransacao.tsx
+++ b/app-financeiro-front-end/src/pages/NovaTransacao.tsx
@@ -4,434 +4,435 @@ import BotaoCarregando from '../components/ui/BotaoCarregando';
 import MensagemAlerta from '../components/ui/MensagemAlerta';
 import { useAutenticacao } from '../contexts/ContextoAutenticacao';
 import {
-  listarCategorias,
-  listarContas,
-  registrarTransacaoManual,
+    listarCategorias,
+    listarContas,
+    registrarTransacaoManual,
 } from '../services/api';
 import type {
-  CategoriaResponse,
-  ContaResponse,
-  TipoPagamento,
-  TipoTransacao,
-  TransacaoResponse,
+    CategoriaResponse,
+    ContaResponse,
+    TipoPagamento,
+    TipoTransacao,
+    TransacaoResponse,
 } from '../services/api';
 
 type CamposTransacao = {
-  valor: string;
-  data: string;
-  descricao: string;
-  tipoTransacao: TipoTransacao;
-  formaPagamento: TipoPagamento;
-  categoriaId: string;
-  contaId: string;
+    valor: string;
+    data: string;
+    descricao: string;
+    tipoTransacao: TipoTransacao;
+    formaPagamento: TipoPagamento;
+    categoriaId: string;
+    contaId: string;
 };
 
 const valoresIniciais: CamposTransacao = {
-  valor: '',
-  data: new Date().toISOString().slice(0, 10),
-  descricao: '',
-  tipoTransacao: 'DEBITO',
-  formaPagamento: 'PIX',
-  categoriaId: '',
-  contaId: '',
+    valor: '',
+    data: new Date().toISOString().slice(0, 10),
+    descricao: '',
+    tipoTransacao: 'DEBITO',
+    formaPagamento: 'PIX',
+    categoriaId: '',
+    contaId: '',
 };
 
 const tiposTransacao: Array<{ valor: TipoTransacao; rotulo: string }> = [
-  { valor: 'DEBITO', rotulo: 'Saída / despesa' },
-  { valor: 'CREDITO', rotulo: 'Entrada / receita' },
-  { valor: 'PARCELAMENTO', rotulo: 'Parcelamento' },
-  { valor: 'BOLETO', rotulo: 'Boleto' },
+    { valor: 'DEBITO', rotulo: 'Saída / despesa' },
+    { valor: 'CREDITO', rotulo: 'Entrada / receita' },
+    { valor: 'PARCELAMENTO', rotulo: 'Parcelamento' },
+    { valor: 'BOLETO', rotulo: 'Boleto' },
 ];
 
 const formasPagamento: Array<{ valor: TipoPagamento; rotulo: string }> = [
-  { valor: 'PIX', rotulo: 'Pix' },
-  { valor: 'CARTAO_DEBITO', rotulo: 'Cartão de débito' },
-  { valor: 'CARTAO_CREDITO', rotulo: 'Cartão de crédito' },
-  { valor: 'DINHEIRO', rotulo: 'Dinheiro' },
-  { valor: 'BOLETO', rotulo: 'Boleto' },
-  { valor: 'TED_DOC', rotulo: 'TED/DOC' },
+    { valor: 'PIX', rotulo: 'Pix' },
+    { valor: 'CARTAO_DEBITO', rotulo: 'Cartão de débito' },
+    { valor: 'CARTAO_CREDITO', rotulo: 'Cartão de crédito' },
+    { valor: 'DINHEIRO', rotulo: 'Dinheiro' },
+    { valor: 'BOLETO', rotulo: 'Boleto' },
+    { valor: 'TED_DOC', rotulo: 'TED/DOC' },
 ];
 
 const formasPagamento: Array<{ valor: TipoPagamento; rotulo: string }> = [
-  { valor: 'PIX', rotulo: 'Pix' },
-  { valor: 'CARTAO_DEBITO', rotulo: 'Cartão de débito' },
-  { valor: 'CARTAO_CREDITO', rotulo: 'Cartão de crédito' },
-  { valor: 'DINHEIRO', rotulo: 'Dinheiro' },
-  { valor: 'BOLETO', rotulo: 'Boleto' },
-  { valor: 'TED_DOC', rotulo: 'TED/DOC' },
+    { valor: 'PIX', rotulo: 'Pix' },
+    { valor: 'CARTAO_DEBITO', rotulo: 'Cartão de débito' },
+    { valor: 'CARTAO_CREDITO', rotulo: 'Cartão de crédito' },
+    { valor: 'DINHEIRO', rotulo: 'Dinheiro' },
+    { valor: 'BOLETO', rotulo: 'Boleto' },
+    { valor: 'TED_DOC', rotulo: 'TED/DOC' },
 ];
 
 const obterRotuloTipoTransacao = (valor: TipoTransacao) =>
-  tiposTransacao.find((tipo) => tipo.valor === valor)?.rotulo || valor;
+    tiposTransacao.find((tipo) => tipo.valor === valor)?.rotulo || valor;
 
 const obterRotuloFormaPagamento = (valor?: TipoPagamento | null) =>
-  formasPagamento.find((forma) => forma.valor === valor)?.rotulo || valor || 'Não informado';
+    formasPagamento.find((forma) => forma.valor === valor)?.rotulo || valor || 'Não informado';
 
 const formatarMoeda = (valor: number | string) =>
-  Number(valor).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+    Number(valor).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
 const formatarMoeda = (valor: number | string) =>
-  Number(valor).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+    Number(valor).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
 const NovaTransacao: React.FC = () => {
-  const { estaAutenticado, sair } = useAutenticacao();
-  const [campos, setCampos] = useState<CamposTransacao>(valoresIniciais);
-  const [contas, setContas] = useState<ContaResponse[]>([]);
-  const [categorias, setCategorias] = useState<CategoriaResponse[]>([]);
-  const [transacoes, setTransacoes] = useState<TransacaoResponse[]>([]);
-  const [erros, setErros] = useState<Partial<Record<keyof CamposTransacao, string>>>({});
-  const [erroGeral, setErroGeral] = useState('');
-  const [sucesso, setSucesso] = useState('');
-  const [carregandoDados, setCarregandoDados] = useState(false);
-  const [salvando, setSalvando] = useState(false);
+    const { estaAutenticado, sair } = useAutenticacao();
+    const [campos, setCampos] = useState<CamposTransacao>(valoresIniciais);
+    const [contas, setContas] = useState<ContaResponse[]>([]);
+    const [categorias, setCategorias] = useState<CategoriaResponse[]>([]);
+    const [transacoes, setTransacoes] = useState<TransacaoResponse[]>([]);
+    const [erros, setErros] = useState<Partial<Record<keyof CamposTransacao, string>>>({});
+    const [erroGeral, setErroGeral] = useState('');
+    const [sucesso, setSucesso] = useState('');
+    const [carregandoDados, setCarregandoDados] = useState(false);
+    const [salvando, setSalvando] = useState(false);
 
-  useEffect(() => {
-    if (!estaAutenticado) return;
+    useEffect(() => {
+        if (!estaAutenticado) return;
 
-    const carregarDados = async () => {
-      setCarregandoDados(true);
-      setErroGeral('');
+        const carregarDados = async () => {
+            setCarregandoDados(true);
+            setErroGeral('');
 
-      try {
-        const [contasCarregadas, categoriasCarregadas] = await Promise.all([
-          listarContas(),
-          listarCategorias(),
-        ]);
+            try {
+                const [contasCarregadas, categoriasCarregadas] = await Promise.all([
+                    listarContas(),
+                    listarCategorias(),
+                ]);
 
-        setContas(contasCarregadas);
-        setCategorias(categoriasCarregadas);
+                setContas(contasCarregadas);
+                setCategorias(categoriasCarregadas);
 
-        setCampos((prev) => ({
-          ...prev,
-          contaId: prev.contaId || contasCarregadas[0]?.contaId || '',
-          categoriaId: prev.categoriaId || categoriasCarregadas[0]?.categoriaId || '',
-        }));
-      } catch (err: any) {
-        if (err?.response?.status === 401 || err?.response?.status === 403) {
-          setErroGeral('Sua sessão expirou. Faça login novamente.');
-          sair();
-          return;
-        }
+                setCampos((prev) => ({
+                    ...prev,
+                    contaId: prev.contaId || contasCarregadas[0]?.contaId || '',
+                    categoriaId: prev.categoriaId || categoriasCarregadas[0]?.categoriaId || '',
+                }));
+            } catch (err: any) {
+                if (err?.response?.status === 401 || err?.response?.status === 403) {
+                    setErroGeral('Sua sessão expirou. Faça login novamente.');
+                    sair();
+                    return;
+                }
 
-        setErroGeral('Não foi possível carregar contas e categorias.');
-      } finally {
-        setCarregandoDados(false);
-      }
+                setErroGeral('Não foi possível carregar contas e categorias.');
+            } finally {
+                setCarregandoDados(false);
+            }
+        };
+
+        carregarDados();
+    }, [estaAutenticado, sair]);
+
+    const categoriaPorId = useMemo(
+        () => new Map(categorias.map((categoria) => [categoria.categoriaId, categoria])),
+        [categorias]
+    );
+
+    const contaPorId = useMemo(
+        () => new Map(contas.map((conta) => [conta.contaId, conta])),
+        [contas]
+    );
+
+    if (!estaAutenticado) {
+        return <Navigate to="/login" replace />;
+    }
+
+    const alterarCampo = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        const { name, value } = e.target;
+        setCampos((prev) => ({ ...prev, [name]: value }));
+        setErros((prev) => ({ ...prev, [name]: undefined }));
     };
 
-    carregarDados();
-  }, [estaAutenticado, sair]);
+    const validar = () => {
+        const novosErros: Partial<Record<keyof CamposTransacao, string>> = {};
+        const valorNumerico = Number(campos.valor);
 
-  const categoriaPorId = useMemo(
-    () => new Map(categorias.map((categoria) => [categoria.categoriaId, categoria])),
-    [categorias]
-  );
+        if (!campos.valor) {
+            novosErros.valor = 'Valor é obrigatório.';
+        } else if (Number.isNaN(valorNumerico) || valorNumerico <= 0) {
+            novosErros.valor = 'Informe um valor positivo.';
+        }
 
-  const contaPorId = useMemo(
-    () => new Map(contas.map((conta) => [conta.contaId, conta])),
-    [contas]
-  );
+        if (!campos.data) {
+            novosErros.data = 'Data é obrigatória.';
+        }
 
-  if (!estaAutenticado) {
-    return <Navigate to="/login" replace />;
-  }
+        if (!campos.contaId) {
+            novosErros.contaId = 'Conta é obrigatória.';
+        }
 
-  const alterarCampo = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value } = e.target;
-    setCampos((prev) => ({ ...prev, [name]: value }));
-    setErros((prev) => ({ ...prev, [name]: undefined }));
-  };
+        setErros(novosErros);
+        return Object.keys(novosErros).length === 0;
+    };
 
-  const validar = () => {
-    const novosErros: Partial<Record<keyof CamposTransacao, string>> = {};
-    const valorNumerico = Number(campos.valor);
+    const enviar = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setErroGeral('');
+        setSucesso('');
 
-    if (!campos.valor) {
-      novosErros.valor = 'Valor é obrigatório.';
-    } else if (Number.isNaN(valorNumerico) || valorNumerico <= 0) {
-      novosErros.valor = 'Informe um valor positivo.';
-    }
+        if (!validar()) return;
 
-    if (!campos.data) {
-      novosErros.data = 'Data é obrigatória.';
-    }
+        setSalvando(true);
 
-    if (!campos.contaId) {
-      novosErros.contaId = 'Conta é obrigatória.';
-    }
+        try {
+            const transacaoSalva = await registrarTransacaoManual({
+                valor: Number(campos.valor),
+                data: campos.data,
+                descricao: campos.descricao.trim() || undefined,
+                tipoTransacao: campos.tipoTransacao,
+                formaPagamento: campos.formaPagamento,
+                categoriaId: campos.categoriaId || null,
+                contaId: campos.contaId,
+            });
 
-    setErros(novosErros);
-    return Object.keys(novosErros).length === 0;
-  };
+            setTransacoes((prev) => [transacaoSalva, ...prev]);
+            setSucesso('Transação registrada com sucesso.');
 
-  const enviar = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setErroGeral('');
-    setSucesso('');
+            setCampos((prev) => ({
+                ...valoresIniciais,
+                data: new Date().toISOString().slice(0, 10),
+                contaId: prev.contaId,
+                categoriaId: prev.categoriaId,
+            }));
+        } catch (err: any) {
+            const msg = err?.response?.data?.erro || err?.response?.data?.message;
+            setErroGeral(msg || 'Não foi possível registrar a transação.');
+        } finally {
+            setSalvando(false);
+        }
+    };
 
-    if (!validar()) return;
-
-    setSalvando(true);
-
-    try {
-      const transacaoSalva = await registrarTransacaoManual({
-        valor: Number(campos.valor),
-        data: campos.data,
-        descricao: campos.descricao.trim() || undefined,
-        tipoTransacao: campos.tipoTransacao,
-        formaPagamento: campos.formaPagamento,
-        categoriaId: campos.categoriaId || null,
-        contaId: campos.contaId,
-      });
-
-      setTransacoes((prev) => [transacaoSalva, ...prev]);
-      setSucesso('Transação registrada com sucesso.');
-
-      setCampos((prev) => ({
-        ...valoresIniciais,
-        data: new Date().toISOString().slice(0, 10),
-        contaId: prev.contaId,
-        categoriaId: prev.categoriaId,
-      }));
-    } catch (err: any) {
-      const msg = err?.response?.data?.erro || err?.response?.data?.message;
-      setErroGeral(msg || 'Não foi possível registrar a transação.');
-    } finally {
-      setSalvando(false);
-    }
-  };
-
-  return (
-    <main className="min-vh-100 py-4" style={{ background: 'var(--sb-bg)' }}>
-      <div className="container" style={{ maxWidth: 1100 }}>
-        <div className="d-flex flex-column flex-md-row justify-content-between gap-3 align-items-md-center mb-4">
-          <div>
-            <span className="badge rounded-pill mb-2" style={{ background: 'var(--sb-primary)' }}>
-              SmartBudget
-            </span>
-            <h1 className="fw-bold mb-1" style={{ color: 'var(--sb-text)' }}>
-              Nova transação
-            </h1>
-            <p className="text-muted mb-0">
-              Registre manualmente gastos que não vieram de extrato ou nota fiscal.
-            </p>
-          </div>
-
-          <Link to="/dashboard" className="btn btn-outline-secondary align-self-start align-self-md-center">
-            Voltar ao painel
-          </Link>
-        </div>
-
-        <MensagemAlerta mensagem={erroGeral} tipo="danger" />
-        <MensagemAlerta mensagem={sucesso} tipo="success" />
-
-        <div className="row g-4">
-          <section className="col-lg-7">
-            <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
-              <div className="card-body p-4">
-                <h2 className="h5 fw-bold mb-3">Dados da transação</h2>
-
-                {carregandoDados ? (
-                  <p className="text-muted mb-0">Carregando contas e categorias...</p>
-                ) : (
-                  <form onSubmit={enviar} noValidate>
-                    <div className="row g-3">
-                      <div className="col-md-6">
-                        <label className="form-label fw-semibold small" htmlFor="valor">
-                          Valor *
-                        </label>
-                        <input
-                          id="valor"
-                          name="valor"
-                          type="number"
-                          min="0.01"
-                          step="0.01"
-                          className={`form-control ${erros.valor ? 'is-invalid' : ''}`}
-                          value={campos.valor}
-                          onChange={alterarCampo}
-                          placeholder="0,00"
-                        />
-                        {erros.valor && <div className="invalid-feedback">{erros.valor}</div>}
-                      </div>
-
-                      <div className="col-md-6">
-                        <label className="form-label fw-semibold small" htmlFor="data">
-                          Data *
-                        </label>
-                        <input
-                          id="data"
-                          name="data"
-                          type="date"
-                          className={`form-control ${erros.data ? 'is-invalid' : ''}`}
-                          value={campos.data}
-                          onChange={alterarCampo}
-                        />
-                        {erros.data && <div className="invalid-feedback">{erros.data}</div>}
-                      </div>
-
-                      <div className="col-12">
-                        <label className="form-label fw-semibold small" htmlFor="descricao">
-                          Descrição
-                        </label>
-                        <input
-                          id="descricao"
-                          name="descricao"
-                          type="text"
-                          className="form-control"
-                          value={campos.descricao}
-                          onChange={alterarCampo}
-                          placeholder="Ex.: mercado, almoço, transporte..."
-                        />
-                      </div>
-
-                      <div className="col-md-6">
-                        <label className="form-label fw-semibold small" htmlFor="tipoTransacao">
-                          Tipo
-                        </label>
-                        <select
-                          id="tipoTransacao"
-                          name="tipoTransacao"
-                          className="form-select"
-                          value={campos.tipoTransacao}
-                          onChange={alterarCampo}
-                        >
-                          {tiposTransacao.map((tipo) => (
-                            <option key={tipo.valor} value={tipo.valor}>
-                              {tipo.rotulo}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-
-                      <div className="col-md-6">
-                        <label className="form-label fw-semibold small" htmlFor="formaPagamento">
-                          Forma de pagamento
-                        </label>
-                        <select
-                          id="formaPagamento"
-                          name="formaPagamento"
-                          className="form-select"
-                          value={campos.formaPagamento}
-                          onChange={alterarCampo}
-                        >
-                          {formasPagamento.map((forma) => (
-                            <option key={forma.valor} value={forma.valor}>
-                              {forma.rotulo}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-
-                      <div className="col-md-6">
-                        <label className="form-label fw-semibold small" htmlFor="categoriaId">
-                          Categoria
-                        </label>
-                        <select
-                          id="categoriaId"
-                          name="categoriaId"
-                          className="form-select"
-                          value={campos.categoriaId}
-                          onChange={alterarCampo}
-                        >
-                          <option value="">Sem categoria</option>
-                          {categorias.map((categoria) => (
-                            <option key={categoria.categoriaId} value={categoria.categoriaId}>
-                              {categoria.nome}
-                              {categoria.padrao ? ' (padrão)' : ''}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-
-                      <div className="col-md-6">
-                        <label className="form-label fw-semibold small" htmlFor="contaId">
-                          Conta *
-                        </label>
-                        <select
-                          id="contaId"
-                          name="contaId"
-                          className={`form-select ${erros.contaId ? 'is-invalid' : ''}`}
-                          value={campos.contaId}
-                          onChange={alterarCampo}
-                        >
-                          <option value="">Selecione uma conta</option>
-                          {contas.map((conta) => (
-                            <option key={conta.contaId} value={conta.contaId}>
-                              {conta.nome}
-                              {conta.banco ? ` - ${conta.banco}` : ''}
-                            </option>
-                          ))}
-                        </select>
-                        {erros.contaId && <div className="invalid-feedback">{erros.contaId}</div>}
-                      </div>
+    return (
+        <main className="min-vh-100 py-4" style={{ background: 'var(--sb-bg)' }}>
+            <div className="container" style={{ maxWidth: 1100 }}>
+                <div className="d-flex flex-column flex-md-row justify-content-between gap-3 align-items-md-center mb-4">
+                    <div>
+                        <span className="badge rounded-pill mb-2" style={{ background: 'var(--sb-primary)' }}>
+                            SmartBudget
+                        </span>
+                        <h1 className="fw-bold mb-1" style={{ color: 'var(--sb-text)' }}>
+                            Nova transação
+                        </h1>
+                        <p className="text-muted mb-0">
+                            Registre manualmente gastos que não vieram de extrato ou nota fiscal.
+                        </p>
                     </div>
 
-                    <BotaoCarregando
-                      type="submit"
-                      carregando={salvando}
-                      textoCarregando="Salvando..."
-                      className="w-100 mt-4 py-2 fw-semibold"
-                      style={{ background: 'var(--sb-gradient)', border: 'none', borderRadius: 10 }}
-                      disabled={contas.length === 0}
-                    >
-                      Salvar transação
-                    </BotaoCarregando>
+                    <Link to="/dashboard" className="btn btn-outline-secondary align-self-start align-self-md-center">
+                        Voltar ao painel
+                    </Link>
+                </div>
 
-                    {contas.length === 0 && (
-                      <p className="text-muted small mt-3 mb-0">
-                        Cadastre uma conta antes de registrar transações.
-                      </p>
-                    )}
-                  </form>
-                )}
-              </div>
-            </div>
-          </section>
+                <MensagemAlerta mensagem={erroGeral} tipo="danger" />
+                <MensagemAlerta mensagem={sucesso} tipo="success" />
 
-          <section className="col-lg-5">
-            <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
-              <div className="card-body p-4">
-                <h2 className="h5 fw-bold mb-3">Histórico recém-criado</h2>
+                <div className="row g-4">
+                    <section className="col-lg-7">
+                        <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
+                            <div className="card-body p-4">
+                                <h2 className="h5 fw-bold mb-3">Dados da transação</h2>
 
-                {transacoes.length === 0 ? (
-                  <p className="text-muted mb-0">
-                    As transações salvas nesta tela aparecerão aqui sem recarregar a página.
-                  </p>
-                ) : (
-                  <div className="d-flex flex-column gap-3">
-                    {transacoes.map((transacao) => (
-                      <article
-                        key={transacao.transacaoId}
-                        className="border rounded-3 p-3 bg-light"
-                      >
-                        <div className="d-flex justify-content-between gap-3">
-                          <div>
-                            <strong>{transacao.descricao || 'Transação manual'}</strong>
-                            <div className="text-muted small">
-                              {contaPorId.get(transacao.contaId)?.nome || 'Conta'} •{' '}
-                              {transacao.categoriaId
-                                ? categoriaPorId.get(transacao.categoriaId)?.nome || 'Categoria'
-                                : 'Sem categoria'}
+                                {carregandoDados ? (
+                                    <p className="text-muted mb-0">Carregando contas e categorias...</p>
+                                ) : (
+                                    <form onSubmit={enviar} noValidate>
+                                        <div className="row g-3">
+                                            <div className="col-md-6">
+                                                <label className="form-label fw-semibold small" htmlFor="valor">
+                                                    Valor *
+                                                </label>
+                                                <input
+                                                    id="valor"
+                                                    name="valor"
+                                                    type="number"
+                                                    min="0.01"
+                                                    step="0.01"
+                                                    className={`form-control ${erros.valor ? 'is-invalid' : ''}`}
+                                                    value={campos.valor}
+                                                    onChange={alterarCampo}
+                                                    placeholder="0,00"
+                                                />
+                                                {erros.valor && <div className="invalid-feedback">{erros.valor}</div>}
+                                            </div>
+
+                                            <div className="col-md-6">
+                                                <label className="form-label fw-semibold small" htmlFor="data">
+                                                    Data *
+                                                </label>
+                                                <input
+                                                    id="data"
+                                                    name="data"
+                                                    type="date"
+                                                    className={`form-control ${erros.data ? 'is-invalid' : ''}`}
+                                                    value={campos.data}
+                                                    onChange={alterarCampo}
+                                                />
+                                                {erros.data && <div className="invalid-feedback">{erros.data}</div>}
+                                            </div>
+
+                                            <div className="col-12">
+                                                <label className="form-label fw-semibold small" htmlFor="descricao">
+                                                    Descrição
+                                                </label>
+                                                <input
+                                                    id="descricao"
+                                                    name="descricao"
+                                                    type="text"
+                                                    className="form-control"
+                                                    value={campos.descricao}
+                                                    onChange={alterarCampo}
+                                                    placeholder="Ex.: mercado, almoço, transporte..."
+                                                />
+                                            </div>
+
+                                            <div className="col-md-6">
+                                                <label className="form-label fw-semibold small" htmlFor="tipoTransacao">
+                                                    Tipo
+                                                </label>
+                                                <select
+                                                    id="tipoTransacao"
+                                                    name="tipoTransacao"
+                                                    className="form-select"
+                                                    value={campos.tipoTransacao}
+                                                    onChange={alterarCampo}
+                                                >
+                                                    {tiposTransacao.map((tipo) => (
+                                                        <option key={tipo.valor} value={tipo.valor}>
+                                                            {tipo.rotulo}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                            </div>
+
+                                            <div className="col-md-6">
+                                                <label className="form-label fw-semibold small" htmlFor="formaPagamento">
+                                                    Forma de pagamento
+                                                </label>
+                                                <select
+                                                    id="formaPagamento"
+                                                    name="formaPagamento"
+                                                    className="form-select"
+                                                    value={campos.formaPagamento}
+                                                    onChange={alterarCampo}
+                                                >
+                                                    {formasPagamento.map((forma) => (
+                                                        <option key={forma.valor} value={forma.valor}>
+                                                            {forma.rotulo}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                            </div>
+
+                                            <div className="col-md-6">
+                                                <label className="form-label fw-semibold small" htmlFor="categoriaId">
+                                                    Categoria
+                                                </label>
+                                                <select
+                                                    id="categoriaId"
+                                                    name="categoriaId"
+                                                    className="form-select"
+                                                    value={campos.categoriaId}
+                                                    onChange={alterarCampo}
+                                                >
+                                                    <option value="">Sem categoria</option>
+                                                    {categorias.map((categoria) => (
+                                                        <option key={categoria.categoriaId} value={categoria.categoriaId}>
+                                                            {categoria.nome}
+                                                            {categoria.padrao ? ' (padrão)' : ''}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                            </div>
+
+                                            <div className="col-md-6">
+                                                <label className="form-label fw-semibold small" htmlFor="contaId">
+                                                    Conta *
+                                                </label>
+                                                <select
+                                                    id="contaId"
+                                                    name="contaId"
+                                                    className={`form-select ${erros.contaId ? 'is-invalid' : ''}`}
+                                                    value={campos.contaId}
+                                                    onChange={alterarCampo}
+                                                >
+                                                    <option value="">Selecione uma conta</option>
+                                                    {contas.map((conta) => (
+                                                        <option key={conta.contaId} value={conta.contaId}>
+                                                            {conta.nome}
+                                                            {conta.banco ? ` - ${conta.banco}` : ''}
+                                                        </option>
+                                                    ))}
+                                                </select>
+                                                {erros.contaId && <div className="invalid-feedback">{erros.contaId}</div>}
+                                            </div>
+                                        </div>
+
+                                        <BotaoCarregando
+                                            type="submit"
+                                            carregando={salvando}
+                                            textoCarregando="Salvando..."
+                                            className="w-100 mt-4 py-2 fw-semibold"
+                                            style={{ background: 'var(--sb-gradient)', border: 'none', borderRadius: 10 }}
+                                            disabled={contas.length === 0}
+                                        >
+                                            Salvar transação
+                                        </BotaoCarregando>
+
+                                        {contas.length === 0 && (
+                                            <p className="text-muted small mt-3 mb-0">
+                                                Cadastre uma conta antes de registrar transações.
+                                            </p>
+                                        )}
+                                    </form>
+                                )}
                             </div>
-                          </div>
-
-                          <strong>{formatarMoeda(transacao.valor)}</strong>
                         </div>
+                    </section>
 
-                        <div className="text-muted small mt-2">
-                          {transacao.data} • {transacao.tipoTransacao} • {transacao.formaPagamento}
+                    <section className="col-lg-5">
+                        <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
+                            <div className="card-body p-4">
+                                <h2 className="h5 fw-bold mb-3">Histórico recém-criado</h2>
+
+                                {transacoes.length === 0 ? (
+                                    <p className="text-muted mb-0">
+                                        As transações salvas nesta tela aparecerão aqui sem recarregar a página.
+                                    </p>
+                                ) : (
+                                    <div className="d-flex flex-column gap-3">
+                                        {transacoes.map((transacao) => (
+                                            <article
+                                                key={transacao.transacaoId}
+                                                className="border rounded-3 p-3 bg-light"
+                                            >
+                                                <div className="d-flex justify-content-between gap-3">
+                                                    <div>
+                                                        <strong>{transacao.descricao || 'Transação manual'}</strong>
+                                                        <div className="text-muted small">
+                                                            {contaPorId.get(transacao.contaId)?.nome || 'Conta'} •{' '}
+                                                            {transacao.categoriaId
+                                                                ? categoriaPorId.get(transacao.categoriaId)?.nome || 'Categoria'
+                                                                : 'Sem categoria'}
+                                                        </div>
+                                                    </div>
+
+                                                    <strong>{formatarMoeda(transacao.valor)}</strong>
+                                                </div>
+
+                                                <div className="text-muted small mt-2">
+                                                    {transacao.data} • {obterRotuloTipoTransacao(transacao.tipoTransacao)} •{' '}
+                                                    {obterRotuloFormaPagamento(transacao.formaPagamento)}
+                                                </div>
+                                            </article>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
                         </div>
-                      </article>
-                    ))}
-                  </div>
-                )}
-              </div>
+                    </section>
+                </div>
             </div>
-          </section>
-        </div>
-      </div>
-    </main>
-  );
+        </main>
+    );
 };
 
 export default NovaTransacao;

--- a/app-financeiro-front-end/src/pages/NovaTransacao.tsx
+++ b/app-financeiro-front-end/src/pages/NovaTransacao.tsx
@@ -1,0 +1,401 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import BotaoCarregando from '../components/ui/BotaoCarregando';
+import MensagemAlerta from '../components/ui/MensagemAlerta';
+import { useAutenticacao } from '../contexts/ContextoAutenticacao';
+import {
+  listarCategorias,
+  listarContas,
+  registrarTransacaoManual,
+} from '../services/api';
+import type {
+  CategoriaResponse,
+  ContaResponse,
+  TipoPagamento,
+  TipoTransacao,
+  TransacaoResponse,
+} from '../services/api';
+
+type CamposTransacao = {
+  valor: string;
+  data: string;
+  descricao: string;
+  tipoTransacao: TipoTransacao;
+  formaPagamento: TipoPagamento;
+  categoriaId: string;
+  contaId: string;
+};
+
+const valoresIniciais: CamposTransacao = {
+  valor: '',
+  data: new Date().toISOString().slice(0, 10),
+  descricao: '',
+  tipoTransacao: 'DEBITO',
+  formaPagamento: 'PIX',
+  categoriaId: '',
+  contaId: '',
+};
+
+const tiposTransacao: Array<{ valor: TipoTransacao; rotulo: string }> = [
+  { valor: 'DEBITO', rotulo: 'Débito / gasto' },
+  { valor: 'CREDITO', rotulo: 'Crédito / entrada' },
+  { valor: 'PARCELAMENTO', rotulo: 'Parcelamento' },
+  { valor: 'BOLETO', rotulo: 'Boleto' },
+];
+
+const formasPagamento: Array<{ valor: TipoPagamento; rotulo: string }> = [
+  { valor: 'PIX', rotulo: 'Pix' },
+  { valor: 'CARTAO_DEBITO', rotulo: 'Cartão de débito' },
+  { valor: 'CARTAO_CREDITO', rotulo: 'Cartão de crédito' },
+  { valor: 'DINHEIRO', rotulo: 'Dinheiro' },
+  { valor: 'BOLETO', rotulo: 'Boleto' },
+  { valor: 'TED_DOC', rotulo: 'TED/DOC' },
+];
+
+const formatarMoeda = (valor: number | string) =>
+  Number(valor).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+const NovaTransacao: React.FC = () => {
+  const { estaAutenticado, sair } = useAutenticacao();
+  const [campos, setCampos] = useState<CamposTransacao>(valoresIniciais);
+  const [contas, setContas] = useState<ContaResponse[]>([]);
+  const [categorias, setCategorias] = useState<CategoriaResponse[]>([]);
+  const [transacoes, setTransacoes] = useState<TransacaoResponse[]>([]);
+  const [erros, setErros] = useState<Partial<Record<keyof CamposTransacao, string>>>({});
+  const [erroGeral, setErroGeral] = useState('');
+  const [sucesso, setSucesso] = useState('');
+  const [carregandoDados, setCarregandoDados] = useState(false);
+  const [salvando, setSalvando] = useState(false);
+
+  useEffect(() => {
+    if (!estaAutenticado) return;
+
+    const carregarDados = async () => {
+      setCarregandoDados(true);
+      setErroGeral('');
+      try {
+        const [contasCarregadas, categoriasCarregadas] = await Promise.all([
+          listarContas(),
+          listarCategorias(),
+        ]);
+        setContas(contasCarregadas);
+        setCategorias(categoriasCarregadas);
+        setCampos((prev) => ({
+          ...prev,
+          contaId: prev.contaId || contasCarregadas[0]?.contaId || '',
+          categoriaId: prev.categoriaId || categoriasCarregadas[0]?.categoriaId || '',
+        }));
+      } catch (err: any) {
+        if (err?.response?.status === 401 || err?.response?.status === 403) {
+          setErroGeral('Sua sessão expirou. Faça login novamente.');
+          sair();
+          return;
+        }
+        setErroGeral('Não foi possível carregar contas e categorias.');
+      } finally {
+        setCarregandoDados(false);
+      }
+    };
+
+    carregarDados();
+  }, [estaAutenticado, sair]);
+
+  const categoriaPorId = useMemo(
+    () => new Map(categorias.map((categoria) => [categoria.categoriaId, categoria])),
+    [categorias]
+  );
+
+  const contaPorId = useMemo(
+    () => new Map(contas.map((conta) => [conta.contaId, conta])),
+    [contas]
+  );
+
+  if (!estaAutenticado) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const alterarCampo = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setCampos((prev) => ({ ...prev, [name]: value }));
+    setErros((prev) => ({ ...prev, [name]: undefined }));
+  };
+
+  const validar = () => {
+    const novosErros: Partial<Record<keyof CamposTransacao, string>> = {};
+    const valorNumerico = Number(campos.valor);
+
+    if (!campos.valor) novosErros.valor = 'Valor é obrigatório.';
+    else if (Number.isNaN(valorNumerico) || valorNumerico <= 0) {
+      novosErros.valor = 'Informe um valor positivo.';
+    }
+
+    if (!campos.data) novosErros.data = 'Data é obrigatória.';
+    if (!campos.contaId) novosErros.contaId = 'Conta é obrigatória.';
+
+    setErros(novosErros);
+    return Object.keys(novosErros).length === 0;
+  };
+
+  const enviar = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErroGeral('');
+    setSucesso('');
+
+    if (!validar()) return;
+
+    setSalvando(true);
+    try {
+      const transacaoSalva = await registrarTransacaoManual({
+        valor: Number(campos.valor),
+        data: campos.data,
+        descricao: campos.descricao.trim() || undefined,
+        tipoTransacao: campos.tipoTransacao,
+        formaPagamento: campos.formaPagamento,
+        categoriaId: campos.categoriaId || null,
+        contaId: campos.contaId,
+      });
+
+      setTransacoes((prev) => [transacaoSalva, ...prev]);
+      setSucesso('Transação registrada com sucesso.');
+      setCampos((prev) => ({
+        ...valoresIniciais,
+        data: new Date().toISOString().slice(0, 10),
+        contaId: prev.contaId,
+        categoriaId: prev.categoriaId,
+      }));
+    } catch (err: any) {
+      const msg = err?.response?.data?.erro || err?.response?.data?.message;
+      setErroGeral(msg || 'Não foi possível registrar a transação.');
+    } finally {
+      setSalvando(false);
+    }
+  };
+
+  return (
+    <main className="min-vh-100 py-4" style={{ background: 'var(--sb-bg)' }}>
+      <div className="container" style={{ maxWidth: 1100 }}>
+        <div className="d-flex flex-column flex-md-row justify-content-between gap-3 align-items-md-center mb-4">
+          <div>
+            <span className="badge rounded-pill mb-2" style={{ background: 'var(--sb-primary)' }}>
+              SmartBudget
+            </span>
+            <h1 className="fw-bold mb-1" style={{ color: 'var(--sb-text)' }}>
+              Nova transação
+            </h1>
+            <p className="text-muted mb-0">
+              Registre manualmente gastos que não vieram de extrato ou nota fiscal.
+            </p>
+          </div>
+          <Link to="/dashboard" className="btn btn-outline-secondary align-self-start align-self-md-center">
+            Voltar ao painel
+          </Link>
+        </div>
+
+        <MensagemAlerta mensagem={erroGeral} tipo="danger" />
+        <MensagemAlerta mensagem={sucesso} tipo="success" />
+
+        <div className="row g-4">
+          <section className="col-lg-7">
+            <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
+              <div className="card-body p-4">
+                <h2 className="h5 fw-bold mb-3">Dados da transação</h2>
+
+                {carregandoDados ? (
+                  <p className="text-muted mb-0">Carregando contas e categorias...</p>
+                ) : (
+                  <form onSubmit={enviar} noValidate>
+                    <div className="row g-3">
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="valor">
+                          Valor *
+                        </label>
+                        <input
+                          id="valor"
+                          name="valor"
+                          type="number"
+                          min="0.01"
+                          step="0.01"
+                          className={`form-control ${erros.valor ? 'is-invalid' : ''}`}
+                          value={campos.valor}
+                          onChange={alterarCampo}
+                          placeholder="0,00"
+                        />
+                        {erros.valor && <div className="invalid-feedback">{erros.valor}</div>}
+                      </div>
+
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="data">
+                          Data *
+                        </label>
+                        <input
+                          id="data"
+                          name="data"
+                          type="date"
+                          className={`form-control ${erros.data ? 'is-invalid' : ''}`}
+                          value={campos.data}
+                          onChange={alterarCampo}
+                        />
+                        {erros.data && <div className="invalid-feedback">{erros.data}</div>}
+                      </div>
+
+                      <div className="col-12">
+                        <label className="form-label fw-semibold small" htmlFor="descricao">
+                          Descrição
+                        </label>
+                        <input
+                          id="descricao"
+                          name="descricao"
+                          type="text"
+                          className="form-control"
+                          value={campos.descricao}
+                          onChange={alterarCampo}
+                          placeholder="Ex.: mercado, almoço, transporte..."
+                        />
+                      </div>
+
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="tipoTransacao">
+                          Tipo
+                        </label>
+                        <select
+                          id="tipoTransacao"
+                          name="tipoTransacao"
+                          className="form-select"
+                          value={campos.tipoTransacao}
+                          onChange={alterarCampo}
+                        >
+                          {tiposTransacao.map((tipo) => (
+                            <option key={tipo.valor} value={tipo.valor}>
+                              {tipo.rotulo}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="formaPagamento">
+                          Forma de pagamento
+                        </label>
+                        <select
+                          id="formaPagamento"
+                          name="formaPagamento"
+                          className="form-select"
+                          value={campos.formaPagamento}
+                          onChange={alterarCampo}
+                        >
+                          {formasPagamento.map((forma) => (
+                            <option key={forma.valor} value={forma.valor}>
+                              {forma.rotulo}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="categoriaId">
+                          Categoria
+                        </label>
+                        <select
+                          id="categoriaId"
+                          name="categoriaId"
+                          className="form-select"
+                          value={campos.categoriaId}
+                          onChange={alterarCampo}
+                        >
+                          <option value="">Sem categoria</option>
+                          {categorias.map((categoria) => (
+                            <option key={categoria.categoriaId} value={categoria.categoriaId}>
+                              {categoria.nome}{categoria.padrao ? ' (padrão)' : ''}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="col-md-6">
+                        <label className="form-label fw-semibold small" htmlFor="contaId">
+                          Conta *
+                        </label>
+                        <select
+                          id="contaId"
+                          name="contaId"
+                          className={`form-select ${erros.contaId ? 'is-invalid' : ''}`}
+                          value={campos.contaId}
+                          onChange={alterarCampo}
+                        >
+                          <option value="">Selecione uma conta</option>
+                          {contas.map((conta) => (
+                            <option key={conta.contaId} value={conta.contaId}>
+                              {conta.nome}{conta.banco ? ` - ${conta.banco}` : ''}
+                            </option>
+                          ))}
+                        </select>
+                        {erros.contaId && <div className="invalid-feedback">{erros.contaId}</div>}
+                      </div>
+                    </div>
+
+                    <BotaoCarregando
+                      type="submit"
+                      carregando={salvando}
+                      textoCarregando="Salvando..."
+                      className="w-100 mt-4 py-2 fw-semibold"
+                      style={{ background: 'var(--sb-gradient)', border: 'none', borderRadius: 10 }}
+                      disabled={contas.length === 0}
+                    >
+                      Salvar transação
+                    </BotaoCarregando>
+
+                    {contas.length === 0 && (
+                      <p className="text-muted small mt-3 mb-0">
+                        Cadastre uma conta antes de registrar transações.
+                      </p>
+                    )}
+                  </form>
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section className="col-lg-5">
+            <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
+              <div className="card-body p-4">
+                <h2 className="h5 fw-bold mb-3">Histórico recém-criado</h2>
+                {transacoes.length === 0 ? (
+                  <p className="text-muted mb-0">
+                    As transações salvas nesta tela aparecerão aqui sem recarregar a página.
+                  </p>
+                ) : (
+                  <div className="d-flex flex-column gap-3">
+                    {transacoes.map((transacao) => (
+                      <article
+                        key={transacao.transacaoId}
+                        className="border rounded-3 p-3 bg-light"
+                      >
+                        <div className="d-flex justify-content-between gap-3">
+                          <div>
+                            <strong>{transacao.descricao || 'Transação manual'}</strong>
+                            <div className="text-muted small">
+                              {contaPorId.get(transacao.contaId)?.nome || 'Conta'} •{' '}
+                              {transacao.categoriaId
+                                ? categoriaPorId.get(transacao.categoriaId)?.nome || 'Categoria'
+                                : 'Sem categoria'}
+                            </div>
+                          </div>
+                          <strong>{formatarMoeda(transacao.valor)}</strong>
+                        </div>
+                        <div className="text-muted small mt-2">
+                          {transacao.data} • {transacao.tipoTransacao} • {transacao.formaPagamento}
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default NovaTransacao;

--- a/app-financeiro-front-end/src/pages/NovaTransacao.tsx
+++ b/app-financeiro-front-end/src/pages/NovaTransacao.tsx
@@ -37,8 +37,8 @@ const valoresIniciais: CamposTransacao = {
 };
 
 const tiposTransacao: Array<{ valor: TipoTransacao; rotulo: string }> = [
-  { valor: 'DEBITO', rotulo: 'Débito / gasto' },
-  { valor: 'CREDITO', rotulo: 'Crédito / entrada' },
+  { valor: 'DEBITO', rotulo: 'Saída / despesa' },
+  { valor: 'CREDITO', rotulo: 'Entrada / receita' },
   { valor: 'PARCELAMENTO', rotulo: 'Parcelamento' },
   { valor: 'BOLETO', rotulo: 'Boleto' },
 ];
@@ -73,13 +73,16 @@ const NovaTransacao: React.FC = () => {
     const carregarDados = async () => {
       setCarregandoDados(true);
       setErroGeral('');
+
       try {
         const [contasCarregadas, categoriasCarregadas] = await Promise.all([
           listarContas(),
           listarCategorias(),
         ]);
+
         setContas(contasCarregadas);
         setCategorias(categoriasCarregadas);
+
         setCampos((prev) => ({
           ...prev,
           contaId: prev.contaId || contasCarregadas[0]?.contaId || '',
@@ -91,6 +94,7 @@ const NovaTransacao: React.FC = () => {
           sair();
           return;
         }
+
         setErroGeral('Não foi possível carregar contas e categorias.');
       } finally {
         setCarregandoDados(false);
@@ -124,13 +128,19 @@ const NovaTransacao: React.FC = () => {
     const novosErros: Partial<Record<keyof CamposTransacao, string>> = {};
     const valorNumerico = Number(campos.valor);
 
-    if (!campos.valor) novosErros.valor = 'Valor é obrigatório.';
-    else if (Number.isNaN(valorNumerico) || valorNumerico <= 0) {
+    if (!campos.valor) {
+      novosErros.valor = 'Valor é obrigatório.';
+    } else if (Number.isNaN(valorNumerico) || valorNumerico <= 0) {
       novosErros.valor = 'Informe um valor positivo.';
     }
 
-    if (!campos.data) novosErros.data = 'Data é obrigatória.';
-    if (!campos.contaId) novosErros.contaId = 'Conta é obrigatória.';
+    if (!campos.data) {
+      novosErros.data = 'Data é obrigatória.';
+    }
+
+    if (!campos.contaId) {
+      novosErros.contaId = 'Conta é obrigatória.';
+    }
 
     setErros(novosErros);
     return Object.keys(novosErros).length === 0;
@@ -144,6 +154,7 @@ const NovaTransacao: React.FC = () => {
     if (!validar()) return;
 
     setSalvando(true);
+
     try {
       const transacaoSalva = await registrarTransacaoManual({
         valor: Number(campos.valor),
@@ -157,6 +168,7 @@ const NovaTransacao: React.FC = () => {
 
       setTransacoes((prev) => [transacaoSalva, ...prev]);
       setSucesso('Transação registrada com sucesso.');
+
       setCampos((prev) => ({
         ...valoresIniciais,
         data: new Date().toISOString().slice(0, 10),
@@ -186,6 +198,7 @@ const NovaTransacao: React.FC = () => {
               Registre manualmente gastos que não vieram de extrato ou nota fiscal.
             </p>
           </div>
+
           <Link to="/dashboard" className="btn btn-outline-secondary align-self-start align-self-md-center">
             Voltar ao painel
           </Link>
@@ -305,7 +318,8 @@ const NovaTransacao: React.FC = () => {
                           <option value="">Sem categoria</option>
                           {categorias.map((categoria) => (
                             <option key={categoria.categoriaId} value={categoria.categoriaId}>
-                              {categoria.nome}{categoria.padrao ? ' (padrão)' : ''}
+                              {categoria.nome}
+                              {categoria.padrao ? ' (padrão)' : ''}
                             </option>
                           ))}
                         </select>
@@ -325,7 +339,8 @@ const NovaTransacao: React.FC = () => {
                           <option value="">Selecione uma conta</option>
                           {contas.map((conta) => (
                             <option key={conta.contaId} value={conta.contaId}>
-                              {conta.nome}{conta.banco ? ` - ${conta.banco}` : ''}
+                              {conta.nome}
+                              {conta.banco ? ` - ${conta.banco}` : ''}
                             </option>
                           ))}
                         </select>
@@ -359,6 +374,7 @@ const NovaTransacao: React.FC = () => {
             <div className="card border-0 shadow-sm" style={{ borderRadius: 18 }}>
               <div className="card-body p-4">
                 <h2 className="h5 fw-bold mb-3">Histórico recém-criado</h2>
+
                 {transacoes.length === 0 ? (
                   <p className="text-muted mb-0">
                     As transações salvas nesta tela aparecerão aqui sem recarregar a página.
@@ -380,8 +396,10 @@ const NovaTransacao: React.FC = () => {
                                 : 'Sem categoria'}
                             </div>
                           </div>
+
                           <strong>{formatarMoeda(transacao.valor)}</strong>
                         </div>
+
                         <div className="text-muted small mt-2">
                           {transacao.data} • {transacao.tipoTransacao} • {transacao.formaPagamento}
                         </div>

--- a/app-financeiro-front-end/src/services/api.ts
+++ b/app-financeiro-front-end/src/services/api.ts
@@ -16,4 +16,52 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+export type TipoTransacao = 'DEBITO' | 'CREDITO' | 'PARCELAMENTO' | 'BOLETO';
+export type TipoPagamento = 'PIX' | 'CARTAO_DEBITO' | 'CARTAO_CREDITO' | 'DINHEIRO' | 'BOLETO' | 'TED_DOC';
+
+export interface ContaResponse {
+  contaId: string;
+  nome: string;
+  tipoConta: string;
+  banco?: string;
+  descricao?: string;
+}
+
+export interface CategoriaResponse {
+  categoriaId: string;
+  nome: string;
+  icone?: string;
+  cor?: string;
+  padrao: boolean;
+}
+
+export interface TransacaoRequest {
+  valor: number;
+  data: string;
+  descricao?: string;
+  tipoTransacao: TipoTransacao;
+  formaPagamento?: TipoPagamento;
+  categoriaId?: string | null;
+  contaId: string;
+}
+
+export interface TransacaoResponse extends TransacaoRequest {
+  transacaoId: string;
+}
+
+export const listarContas = async () => {
+  const { data } = await api.get<ContaResponse[]>('/contas');
+  return data;
+};
+
+export const listarCategorias = async () => {
+  const { data } = await api.get<CategoriaResponse[]>('/categorias');
+  return data;
+};
+
+export const registrarTransacaoManual = async (transacao: TransacaoRequest) => {
+  const { data } = await api.post<TransacaoResponse>('/transacoes/manual', transacao);
+  return data;
+};
+
 export default api;


### PR DESCRIPTION
## O que mudou

- Implementado formulário de registro manual de transações no frontend  (#63) 
- Criada tela de **Nova transação**, permitindo informar:
  - valor;
  - data;
  - descrição;
  - tipo da transação;
  - forma de pagamento;
  - categoria;
  - conta.
- Integrado o formulário ao endpoint de registro manual de transações.
- Adicionado carregamento de contas do usuário autenticado via `GET /contas`.
- Adicionado carregamento de categorias via `GET /categorias`.
- Criados endpoints auxiliares no backend para listagem de contas e categorias.
- Ajustado o DTO de categoria usado na listagem para retornar os dados necessários ao frontend.
- Implementadas validações no frontend para:
  - valor obrigatório;
  - valor maior que zero;
  - data obrigatória;
  - conta obrigatória.
- Adicionado histórico local de transações recém-criadas, exibindo os registros salvos sem recarregar a página.
- Ajustados os rótulos visuais de tipo de transação para evitar confusão entre tipo e forma de pagamento:
  - `DEBITO` exibido como `Saída / despesa`;
  - `CREDITO` exibido como `Entrada / receita`.
- Ajustada a exibição do histórico para mostrar rótulos amigáveis em vez dos valores crus dos enums, como `DEBITO`, `CREDITO` e `CARTAO_DEBITO`.

## Por quê

- Esta alteração atende à issue da Sprint 2 de implementar o formulário de registro manual de transações no frontend.
- O objetivo é permitir que o usuário registre manualmente gastos ou entradas que não vieram de extrato bancário ou nota fiscal.
- A tela depende de uma conta cadastrada, pois no backend toda transação deve estar vinculada obrigatoriamente a uma conta.
- Os endpoints `GET /contas` e `GET /categorias` foram adicionados porque o formulário precisa carregar as opções dos seletores de conta e categoria.
- O histórico exibido na tela mostra apenas as transações criadas durante a sessão atual, conforme critério de aceite de exibir a transação recém-criada sem recarregar a página.
- O carregamento persistente do histórico completo de transações não foi incluído neste PR, pois depende de um endpoint específico de listagem de transações e pode ser tratado em issue futura.
- Também foi decidido não alterar os enums do backend nesta etapa, para evitar impacto em outras partes do sistema. A melhoria de nomenclatura foi feita apenas na interface.
- O tipo da conta continua sendo responsabilidade do cadastro de conta. Na tela de transação manual, o usuário apenas seleciona uma conta já cadastrada.

## Como testar

1. Subir o banco de dados novamente:

   docker start app-financeiro-db

2. Subir o backend e confirmar que a aplicação iniciou corretamente na porta `8080`.

3. Subir o frontend:

   ```bash
   cd app-financeiro-front-end
   npm run dev
   ```

4. Criar ou usar um usuário existente.

5. Fazer login no frontend.

6. Criar uma conta para o usuário autenticado, usando o fluxo existente ou via endpoint:

   ```bash
   curl -X POST http://localhost:8080/contas/registrar \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer SEU_TOKEN" \
     -d '{
       "nome": "Conta Principal",
       "tipoConta": "CORRENTE",
       "banco": "Nubank",
       "descricao": "Conta para teste de transação manual"
     }'
   ```

7. Confirmar que a conta foi criada:

   ```bash
   curl http://localhost:8080/contas \
     -H "Authorization: Bearer SEU_TOKEN"
   ```

8. Confirmar que categorias estão acessíveis:

   ```bash
   curl http://localhost:8080/categorias \
     -H "Authorization: Bearer SEU_TOKEN"
   ```

   Observação: se retornar `[]`, está tudo certo. A tela deve continuar permitindo selecionar `Sem categoria`.

9. Acessar a tela de nova transação no frontend:

   ```txt
   /transacoes/nova
   ```

10. Verificar se a conta cadastrada aparece no seletor de conta.

11. Verificar se o seletor de categoria carrega corretamente. Caso não existam categorias cadastradas, a opção `Sem categoria` deve continuar disponível.

12. Preencher o formulário com:
    - valor maior que zero;
    - data;
    - descrição;
    - tipo da transação;
    - forma de pagamento;
    - conta.

13. Salvar a transação.

14. Verificar se aparece mensagem de sucesso.

15. Verificar se a transação aparece imediatamente no histórico recém-criado, sem recarregar a página.

16. Testar uma saída/despesa:
    - Tipo: `Saída / despesa`;
    - Forma de pagamento: `Pix`, `Cartão de débito`, `Dinheiro` ou outra opção disponível.

17. Testar uma entrada/receita:
    - Tipo: `Entrada / receita`;
    - Forma de pagamento: opção disponível no formulário.

18. Verificar se o histórico mostra rótulos amigáveis, por exemplo:
    - `Saída / despesa • Pix`;
    - `Entrada / receita • Dinheiro`.

19. Testar validações:
    - tentar salvar com valor vazio;
    - tentar salvar com valor `0`;
    - tentar salvar sem data;
    - tentar salvar sem conta.

20. Reiniciar o frontend e confirmar que:
    - a conta continua aparecendo, pois vem do backend;
    - o histórico recém-criado é resetado, pois atualmente é apenas local da tela.

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste manual realizada
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos (mínimo 3)

- [Risco] O enum `TipoTransacao` do backend ainda mistura conceitos de tipo de transação e forma/condição de pagamento, como `DEBITO`, `CREDITO`, `PARCELAMENTO` e `BOLETO`. Para evitar impacto maior nesta issue, os valores do backend foram mantidos e apenas os rótulos exibidos no frontend foram ajustados.

- [Manutenção] O histórico recém-criado é mantido apenas no estado local da tela com `useState`. Isso atende ao critério de aceite de exibir a transação salva sem recarregar a página, mas não substitui uma listagem persistente de transações. Uma issue futura pode criar um endpoint `GET /transacoes` para carregar o histórico real do usuário.

- [Teste] Foram realizados testes manuais do fluxo completo: login, criação de conta, listagem de contas, acesso à tela de nova transação, preenchimento do formulário, registro de transação e exibição no histórico local.

- [Teste] Também foram testados os endpoints auxiliares `GET /contas` e `GET /categorias` com token JWT no header `Authorization: Bearer <token>`.
- 
- [Manutenção] A tela exige que o usuário tenha pelo menos uma conta cadastrada antes de registrar transações, pois a entidade `Transacao` possui relacionamento obrigatório com `Conta` no backend.

- [Manutenção] O tipo da conta não é definido na tela de transação manual. Ele pertence ao cadastro da conta. Na transação manual, o usuário apenas seleciona qual conta será vinculada ao lançamento.

- [Risco] O carregamento persistente do histórico de transações ainda não foi implementado. Ao reiniciar o frontend ou recarregar a página, o histórico local da tela é perdido, mesmo que a transação tenha sido salva no backend.