### PR TITLE
docs: documenta execução local dos testes e gate de CI (closes #92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,41 @@ curl -X POST http://localhost:8080/auth/register \
 
 Informações mais detalhadas disponível em [docs/como-rodar.md](docs/como-rodar.md)
 
+## Rodando os testes localmente
+
+Os testes automatizados estão versionados no repositório e devem passar antes de qualquer merge — o pipeline de CI executa exatamente os mesmos comandos descritos abaixo a cada pull request.
+
+Backend (JUnit + Spring Boot):
+
+```bash
+cd app-financeiro-back-end
+./gradlew test
+```
+
+O relatório HTML fica em `app-financeiro-back-end/build/reports/tests/test/index.html` e o relatório de cobertura JaCoCo em `app-financeiro-back-end/build/reports/jacoco/test/html/index.html`.
+
+Para rodar apenas uma classe específica:
+
+```bash
+./gradlew test --tests "bcd.appfinanceirobackend.RegistrarLoginTests"
+```
+
+Frontend (React + Vite):
+
+```bash
+cd app-financeiro-front-end
+npm install
+npm test --if-present
+```
+
+> O frontend ainda está construindo a sua suíte de testes; enquanto não houver script `test` no `package.json`, o comando acima é um no-op proposital, mesma forma como o CI se comporta. O passo está versionado para que a primeira suíte adicionada já entre como gate obrigatório, sem precisar mexer no workflow.
+
+## Integração contínua (CI)
+
+O workflow `.github/workflows/ci.yml` é disparado em cada pull request (`opened`, `synchronize`, `reopened`) e roda quatro jobs: build e testes do backend (com Postgres efêmero), build e testes do frontend, validação de YAML e verificação de arquivos obrigatórios. Qualquer falha derruba o check do PR e impede o merge.
+
+A proteção da branch `main` no GitHub deve marcar o job `Backend (build & test)` (e o `Frontend (build & test)` quando a suíte for adicionada) como **required status check**, garantindo que nenhum PR seja mergeado com testes vermelhos.
+
 
 -------
 ### Documentos 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ npm test --if-present
 
 O workflow `.github/workflows/ci.yml` é disparado em cada pull request (`opened`, `synchronize`, `reopened`) e roda quatro jobs: build e testes do backend (com Postgres efêmero), build e testes do frontend, validação de YAML e verificação de arquivos obrigatórios. Qualquer falha derruba o check do PR e impede o merge.
 
-A proteção da branch `main` no GitHub deve marcar o job `Backend (build & test)` (e o `Frontend (build & test)` quando a suíte for adicionada) como **required status check**, garantindo que nenhum PR seja mergeado com testes vermelhos.
+A proteção da branch `main` no GitHub já exige os quatro jobs (`Backend (build & test)`, `Frontend (build & test)`, `YAML syntax validation` e `Required files check`) como **required status checks** e exige ao menos 1 review aprovador, garantindo que nenhum PR seja mergeado com testes vermelhos.
 
 
 -------


### PR DESCRIPTION
## O que mudou

- Adicionada seção **Rodando os testes localmente** no `README.md`, com os comandos do backend (`./gradlew test`, incluindo execução de uma classe específica e caminhos dos relatórios JUnit/JaCoCo) e do frontend (`npm test --if-present`).
- Adicionada seção **Integração contínua (CI)** no `README.md`, descrevendo os quatro jobs do `ci.yml` e registrando que a branch protection da `main` já marca todos eles como required status checks, com 1 review aprovador.
- Nenhuma alteração no workflow `ci.yml` foi necessária: ele já dispara em `pull_request` (`opened`, `synchronize`, `reopened`), roda `gradle test` no backend (com Postgres efêmero) e `npm test --if-present` no frontend.

## Por quê

- Fecha a issue #92, que pede execução obrigatória dos testes automatizados no pipeline a cada PR e instruções documentadas para rodá-los localmente.
- Os critérios "testes versionados", "pipeline executa em cada PR", "falha bloqueia o merge" e "branch protection exigindo o check de testes" já estavam atendidos no repositório — confirmei via `gh api repos/.../branches/main/protection` que os quatro checks (`Backend (build & test)`, `Frontend (build & test)`, `YAML syntax validation`, `Required files check`) já são required.
- O que faltava era o critério "instruções documentadas de como executar os testes localmente" — o README mencionava um único comando solto de teste, sem cobrir frontend nem deixar claro que é o mesmo comando que o CI executa.

## Como testar

1. Abrir o `README.md` na branch e conferir que as duas novas seções aparecem logo antes do bloco "Documentos".
2. Em uma máquina limpa, seguir os passos da seção "Rodando os testes localmente":
   - `cd app-financeiro-back-end && ./gradlew test` deve rodar a suíte e gerar relatórios em `build/reports/tests/test/` e `build/reports/jacoco/test/html/`.
   - `cd app-financeiro-front-end && npm install && npm test --if-present` deve completar sem erro (no-op enquanto não houver script `test`).
3. No próprio PR, conferir que os quatro jobs do workflow CI aparecem como checks e que o botão de merge fica bloqueado até todos ficarem verdes (evidência de que a branch protection está ativa).

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado (apenas `README.md`)
- [x] Casos limite considerados (frontend sem suíte → `--if-present`; menção a relatórios HTML e execução de classe isolada)
- [x] Evidência de teste (os próprios checks deste PR servem como evidência de execução do pipeline; branch protection confirmada via `gh api`)
- [x] Não quebrou funcionalidades existentes (mudança é só de documentação)
- [x] Código revisado e limpo

## Comentários técnicos (mínimo 3)

- [Risco] A seção do README afirma que a branch protection exige os quatro jobs como required; se alguém alterar essa configuração no painel do GitHub no futuro, o texto fica desatualizado. Vale revisitar caso a política de proteção mude.
- [Manutenção] O passo de testes do frontend usa `npm test --if-present`, então quando a primeira suíte for adicionada com um script `test` no `package.json`, ela vira gate obrigatório automaticamente, sem mexer no workflow nem no README.
- [Teste] Este próprio PR funciona como teste fim-a-fim do gate: o `ci.yml` é disparado, roda `gradle test` (backend) e `npm test --if-present` (frontend), e a branch protection impede o merge até todos os checks ficarem verdes — confirmando que falha em qualquer teste bloqueia o merge.

Closes #92