### PR TITLE
Feat/#60 processamento extrato endpoint upload

### DIFF
--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ImportacaoController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ImportacaoController.java
@@ -1,4 +1,43 @@
 package bcd.appfinanceirobackend.controller;
 
+import bcd.appfinanceirobackend.dto.importacao.ImportacaoResponseDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.StatusImportacao;
+import bcd.appfinanceirobackend.service.ImportacaoService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/importacoes")
 public class ImportacaoController {
+
+    private final ImportacaoService importacaoService;
+
+    public ImportacaoController(ImportacaoService importacaoService) {
+        this.importacaoService = importacaoService;
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ImportacaoResponseDTO> importar(
+            @RequestParam("arquivo") MultipartFile arquivo,
+            @RequestParam("contaId") UUID contaId,
+            @AuthenticationPrincipal Usuario usuarioAutenticado) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(importacaoService.processar(arquivo, contaId, usuarioAutenticado));
+    }
+
+    @GetMapping("/{id}/status")
+    public ResponseEntity<StatusImportacao> status(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Usuario usuarioAutenticado) {
+
+        return ResponseEntity.ok(importacaoService.buscarStatus(id));
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ImportacaoController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ImportacaoController.java
@@ -38,6 +38,6 @@ public class ImportacaoController {
             @PathVariable UUID id,
             @AuthenticationPrincipal Usuario usuarioAutenticado) {
 
-        return ResponseEntity.ok(importacaoService.buscarStatus(id));
+        return ResponseEntity.ok(importacaoService.buscarStatus(id, usuarioAutenticado));
     }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/importacao/ImportacaoResponseDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/importacao/ImportacaoResponseDTO.java
@@ -15,4 +15,5 @@ public class ImportacaoResponseDTO {
     private int sucessos;
     private int falhas;
     private LocalDateTime importadoEm;
+    private String mensagemErro;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/importacao/ImportacaoResponseDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/importacao/ImportacaoResponseDTO.java
@@ -1,0 +1,18 @@
+package bcd.appfinanceirobackend.dto.importacao;
+
+import bcd.appfinanceirobackend.model.enums.StatusImportacao;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+public class ImportacaoResponseDTO {
+    private UUID id;
+    private StatusImportacao status;
+    private int sucessos;
+    private int falhas;
+    private LocalDateTime importadoEm;
+}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/model/Importacao.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/model/Importacao.java
@@ -46,4 +46,7 @@ public class Importacao {
 
     @Column
     private int falhas;
+
+    @Column
+    private String mensagemErro;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -53,8 +53,10 @@ public class ParserCSV implements ParserExtrato {
     }
 
     @Override
-    public List<Transacao> parsear(MultipartFile arquivo, Conta conta) {
-        List<Transacao> transacoes = new ArrayList<>();
+    public ResultadoParser parsear(MultipartFile arquivo, Conta conta) {
+        ResultadoParser resultadoParser = new ResultadoParser();
+        int linhasInvalidas = resultadoParser.getLinhasInvalidas();
+        int totalLinhas = resultadoParser.getTotalLinhas();
 
         try {
             // Lê o conteúdo bruto para detectar o delimitador
@@ -73,11 +75,19 @@ public class ParserCSV implements ParserExtrato {
 
                     // Ignora cabeçalho: primeira coluna não é uma data válida
                     LocalDate data = parsearData(linha[0].trim());
-                    if (data == null) continue;
+                    if (data == null) {
+                        linhasInvalidas++;
+                        totalLinhas++;
+                        continue;
+                    }
 
                     String descricao = linha[1].trim();
                     BigDecimal valor = parsearValor(linha[2].trim());
-                    if (valor == null) continue;
+                    if (valor == null) {
+                        linhasInvalidas++;
+                        totalLinhas++;
+                        continue;
+                    };
 
                     TipoTransacao tipo = parsearTipo(linha[3].trim(), valor);
 
@@ -90,14 +100,16 @@ public class ParserCSV implements ParserExtrato {
                     transacao.setTipo(tipo);
                     transacao.setCategorizada(false);
 
-                    transacoes.add(transacao);
+                    resultadoParser.getTransacoes().add(transacao);
+                    resultadoParser.setLinhasInvalidas(linhasInvalidas);
+                    resultadoParser.setTotalLinhas(totalLinhas);
                 }
             }
         } catch (Exception e) {
             throw new RuntimeException("Erro ao processar arquivo CSV: " + e.getMessage(), e);
         }
 
-        return transacoes;
+        return resultadoParser;
     }
 
     /**

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -54,6 +54,7 @@ public class ParserCSV implements ParserExtrato {
 
     @Override
     public ResultadoParser parsear(MultipartFile arquivo, Conta conta) {
+        List<Transacao> transacoes = new ArrayList<>();
         ResultadoParser resultadoParser = new ResultadoParser();
         int linhasInvalidas = resultadoParser.getLinhasInvalidas();
         int totalLinhas = resultadoParser.getTotalLinhas();
@@ -102,15 +103,15 @@ public class ParserCSV implements ParserExtrato {
                     transacao.setTipo(tipo);
                     transacao.setCategorizada(false);
 
-                    resultadoParser.getTransacoes().add(transacao);
-                    resultadoParser.setLinhasInvalidas(linhasInvalidas);
-                    resultadoParser.setTotalLinhas(totalLinhas);
+                    transacoes.add(transacao);
                 }
             }
         } catch (Exception e) {
             throw new RuntimeException("Erro ao processar arquivo CSV: " + e.getMessage(), e);
         }
-
+        resultadoParser.setTransacoes(transacoes);
+        resultadoParser.setLinhasInvalidas(linhasInvalidas);
+        resultadoParser.setTotalLinhas(totalLinhas);
         return resultadoParser;
     }
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -1,4 +1,167 @@
 package bcd.appfinanceirobackend.parser;
 
-public class ParserCSV {
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import com.opencsv.CSVParserBuilder;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStreamReader;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parser para extratos bancários no formato CSV.
+ *
+ * Detecta automaticamente o delimitador (vírgula, ponto e vírgula ou tabulação)
+ * lendo a primeira linha do arquivo antes de processá-lo.
+ *
+ * Formato esperado das colunas (ordem obrigatória):
+ *   data | descricao | valor | tipo
+ *
+ * Exemplos de linha válida:
+ *   2024-01-15;Supermercado Extra;-150,00;DEBITO
+ *   2024-01-20,Salário,5000.00,CREDITO
+ *
+ * Regras de interpretação:
+ * - Valores negativos são sempre tratados como DEBITO, independente do campo tipo
+ * - Datas aceitas: yyyy-MM-dd, dd/MM/yyyy, dd-MM-yyyy
+ * - Separador decimal aceito: ponto ou vírgula
+ * - Linhas de cabeçalho são ignoradas automaticamente (detecção por ausência de data válida)
+ */
+@Component
+public class ParserCSV implements ParserExtrato {
+
+    private static final List<DateTimeFormatter> FORMATADORES = List.of(
+            DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+            DateTimeFormatter.ofPattern("dd/MM/yyyy"),
+            DateTimeFormatter.ofPattern("dd-MM-yyyy")
+    );
+
+    @Override
+    public boolean aceita(MultipartFile arquivo) {
+        String nome = arquivo.getOriginalFilename();
+        return nome != null && nome.toLowerCase().endsWith(".csv");
+    }
+
+    @Override
+    public List<Transacao> parsear(MultipartFile arquivo, Conta conta) {
+        List<Transacao> transacoes = new ArrayList<>();
+
+        try {
+            // Lê o conteúdo bruto para detectar o delimitador
+            byte[] bytes = arquivo.getBytes();
+            String conteudo = new String(bytes, StandardCharsets.UTF_8);
+            char delimitador = detectarDelimitador(conteudo);
+
+            try (CSVReader reader = new CSVReaderBuilder(
+                    new InputStreamReader(arquivo.getInputStream(), StandardCharsets.UTF_8))
+                    .withCSVParser(new CSVParserBuilder().withSeparator(delimitador).build())
+                    .build()) {
+
+                String[] linha;
+                while ((linha = reader.readNext()) != null) {
+                    if (linha.length < 4) continue;
+
+                    // Ignora cabeçalho: primeira coluna não é uma data válida
+                    LocalDate data = parsearData(linha[0].trim());
+                    if (data == null) continue;
+
+                    String descricao = linha[1].trim();
+                    BigDecimal valor = parsearValor(linha[2].trim());
+                    if (valor == null) continue;
+
+                    TipoTransacao tipo = parsearTipo(linha[3].trim(), valor);
+
+                    // Valor sempre positivo na entidade; o tipo indica a direção
+                    Transacao transacao = new Transacao();
+                    transacao.setConta(conta);
+                    transacao.setData(data);
+                    transacao.setDescricao(descricao);
+                    transacao.setValor(valor.abs());
+                    transacao.setTipo(tipo);
+                    transacao.setCategorizada(false);
+
+                    transacoes.add(transacao);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao processar arquivo CSV: " + e.getMessage(), e);
+        }
+
+        return transacoes;
+    }
+
+    /**
+     * Detecta o delimitador mais provável analisando a primeira linha do arquivo.
+     * Prioridade: ponto e vírgula > vírgula > tabulação.
+     */
+    private char detectarDelimitador(String conteudo) {
+        String primeiraLinha = conteudo.split("\n")[0];
+        if (primeiraLinha.contains(";")) return ';';
+        if (primeiraLinha.contains(",")) return ',';
+        return '\t';
+    }
+
+    /**
+     * Tenta parsear a data nos formatos suportados.
+     * Retorna null se nenhum formato for compatível (indica cabeçalho ou linha inválida).
+     */
+    private LocalDate parsearData(String valor) {
+        for (DateTimeFormatter fmt : FORMATADORES) {
+            try {
+                return LocalDate.parse(valor, fmt);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parseia o valor monetário aceitando ponto ou vírgula como separador decimal.
+     * Retorna null se o valor não puder ser interpretado.
+     */
+    private BigDecimal parsearValor(String valor) {
+        try {
+            // Remove separadores de milhar e normaliza o decimal
+            String normalizado = valor
+                    .replace("R$", "")
+                    .replace(" ", "")
+                    .trim();
+
+            // Se tiver vírgula e ponto, o ponto é separador de milhar (ex: 1.500,00)
+            if (normalizado.contains(",") && normalizado.contains(".")) {
+                normalizado = normalizado.replace(".", "").replace(",", ".");
+            } else {
+                normalizado = normalizado.replace(",", ".");
+            }
+
+            return new BigDecimal(normalizado);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Determina o TipoTransacao. Valores negativos são sempre DEBITO.
+     * Para valores positivos, tenta interpretar o campo tipo do CSV.
+     */
+    private TipoTransacao parsearTipo(String tipoStr, BigDecimal valor) {
+        if (valor.compareTo(BigDecimal.ZERO) < 0) return TipoTransacao.DEBITO;
+
+        try {
+            return TipoTransacao.valueOf(tipoStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            // Fallback: positivo sem tipo reconhecido é CREDITO
+            return TipoTransacao.CREDITO;
+        }
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -71,13 +71,16 @@ public class ParserCSV implements ParserExtrato {
 
                 String[] linha;
                 while ((linha = reader.readNext()) != null) {
-                    if (linha.length < 4) continue;
+                    totalLinhas++;
+                    if (linha.length < 4) {
+                        linhasInvalidas++;
+                        continue;
+                    }
 
                     // Ignora cabeçalho: primeira coluna não é uma data válida
                     LocalDate data = parsearData(linha[0].trim());
                     if (data == null) {
                         linhasInvalidas++;
-                        totalLinhas++;
                         continue;
                     }
 
@@ -85,7 +88,6 @@ public class ParserCSV implements ParserExtrato {
                     BigDecimal valor = parsearValor(linha[2].trim());
                     if (valor == null) {
                         linhasInvalidas++;
-                        totalLinhas++;
                         continue;
                     };
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserExtrato.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserExtrato.java
@@ -30,8 +30,8 @@ public interface ParserExtrato {
      *
      * @param arquivo arquivo recebido via upload
      * @param conta   conta à qual as transações serão vinculadas
-     * @return lista de transações extraídas do arquivo
+     * @return um objeto da classe resultadoParser
      * @throws RuntimeException se o arquivo estiver corrompido ou em formato inválido
      */
-    List<Transacao> parsear(MultipartFile arquivo, Conta conta);
+    ResultadoParser parsear(MultipartFile arquivo, Conta conta);
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserExtrato.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserExtrato.java
@@ -1,4 +1,37 @@
 package bcd.appfinanceirobackend.parser;
 
-public class ParserExtrato {
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Transacao;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * Interface Strategy para parsers de extrato.
+ * Cada implementação é responsável por detectar se aceita o arquivo
+ * e por converter seu conteúdo em uma lista de transações.
+ */
+public interface ParserExtrato {
+
+    /**
+     * Verifica se este parser é capaz de processar o arquivo informado.
+     * A detecção deve ser baseada na extensão e/ou no conteúdo do arquivo,
+     * nunca apenas no Content-Type enviado pelo cliente.
+     *
+     * @param arquivo arquivo recebido via upload
+     * @return true se este parser aceita processar o arquivo
+     */
+    boolean aceita(MultipartFile arquivo);
+
+    /**
+     * Converte o conteúdo do arquivo em uma lista de transações prontas
+     * para persistência. As transações retornadas NÃO devem ter importacao,
+     * conta ou categorizada definidos — isso é responsabilidade do ImportacaoService.
+     *
+     * @param arquivo arquivo recebido via upload
+     * @param conta   conta à qual as transações serão vinculadas
+     * @return lista de transações extraídas do arquivo
+     * @throws RuntimeException se o arquivo estiver corrompido ou em formato inválido
+     */
+    List<Transacao> parsear(MultipartFile arquivo, Conta conta);
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserNFe.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserNFe.java
@@ -93,22 +93,31 @@ public class ParserNFe implements ParserExtrato {
             String cnpjEmitente = primeiroTexto(doc, "CNPJ");
             String descricao = montarDescricao(nomeEmitente, cnpjEmitente);
 
-            // Extrai valor total da nota
-            BigDecimal valorTotal = extrairValorTotal(doc);
-            if (valorTotal == null || valorTotal.compareTo(BigDecimal.ZERO) <= 0) {
-                throw new RuntimeException("Campo <vNF> não encontrado ou inválido na NF-e.");
+            // Itera sobre os itens da nota (<det>) gerando uma transação por produto
+            NodeList itens = doc.getElementsByTagName("det");
+
+            if (itens.getLength() == 0) {
+                throw new RuntimeException("Nenhum item <det> encontrado na NF-e.");
             }
 
-            // Uma NF-e = uma transação de DEBITO
-            Transacao transacao = new Transacao();
-            transacao.setConta(conta);
-            transacao.setData(dataEmissao);
-            transacao.setDescricao(descricao);
-            transacao.setValor(valorTotal);
-            transacao.setTipo(TipoTransacao.DEBITO);
-            transacao.setCategorizada(false);
+            for (int i = 0; i < itens.getLength(); i++) {
+                Element item = (Element) itens.item(i);
 
-            transacoes.add(transacao);
+                String descricaoProduto = primeiroTextoElemento(item, "xProd");
+                BigDecimal valorProduto = parsearBigDecimal(primeiroTextoElemento(item, "vProd"));
+
+                if (valorProduto == null || valorProduto.compareTo(BigDecimal.ZERO) <= 0) continue;
+
+                Transacao transacao = new Transacao();
+                transacao.setConta(conta);
+                transacao.setData(dataEmissao);
+                transacao.setDescricao(descricaoProduto.isBlank() ? "Item NF-e #" + (i + 1) : descricaoProduto);
+                transacao.setValor(valorProduto);
+                transacao.setTipo(TipoTransacao.DEBITO);
+                transacao.setCategorizada(false);
+
+                transacoes.add(transacao);
+            }
 
         } catch (RuntimeException e) {
             throw e;
@@ -144,26 +153,13 @@ public class ParserNFe implements ParserExtrato {
         }
     }
 
-    /**
-     * Extrai o valor total da nota a partir de <ICMSTot>/<vNF>.
-     * Se não encontrar via ICMSTot, tenta buscar <vNF> diretamente.
-     */
-    private BigDecimal extrairValorTotal(Document doc) {
-        // Tenta via ICMSTot primeiro (estrutura padrão)
-        NodeList icmsTot = doc.getElementsByTagName("ICMSTot");
-        if (icmsTot.getLength() > 0) {
-            Element el = (Element) icmsTot.item(0);
-            NodeList vnf = el.getElementsByTagName("vNF");
-            if (vnf.getLength() > 0) {
-                return parsearBigDecimal(vnf.item(0).getTextContent().trim());
-            }
-        }
-
-        // Fallback: busca <vNF> diretamente no documento
-        String vNF = primeiroTexto(doc, "vNF");
-        return parsearBigDecimal(vNF);
+    /** Extrai o texto de uma tag filha dentro de um Element específico. */
+    private String primeiroTextoElemento(Element elemento, String tag) {
+        NodeList nos = elemento.getElementsByTagName(tag);
+        if (nos.getLength() == 0) return "";
+        return nos.item(0).getTextContent().trim();
     }
-
+    
     /** Busca o texto do primeiro elemento com a tag informada no documento. */
     private String primeiroTexto(Document doc, String tag) {
         NodeList nos = doc.getElementsByTagName(tag);

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserNFe.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserNFe.java
@@ -1,4 +1,186 @@
 package bcd.appfinanceirobackend.parser;
 
-public class ParserNFe {
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parser para Nota Fiscal Eletrônica (NF-e) no padrão SEFAZ (XML).
+ *
+ * Detecta arquivos NF-e pela presença das tags <nfeProc> ou <NFe> no início
+ * do conteúdo. Suporta NF-e com ou sem o envelope <nfeProc>.
+ *
+ * Estratégia de extração:
+ * - Uma NF-e representa uma única compra, gerada como uma transação do tipo DEBITO
+ *   cujo valor total é o campo <vNF> (valor total da nota)
+ * - A descrição é composta pelo CNPJ do emitente + razão social (xNome)
+ * - A data é extraída do campo <dhEmi> (data de emissão)
+ * - Os itens individuais (<det>) são ignorados por padrão para não inflar o extrato;
+ *   se o projeto evoluir para categorização por item, esse comportamento pode ser
+ *   alterado via configuração
+ *
+ * Tags SEFAZ utilizadas:
+ *   <ide>/<dhEmi>     → data de emissão
+ *   <emit>/<xNome>    → razão social do emitente
+ *   <emit>/<CNPJ>     → CNPJ do emitente
+ *   <total>/<ICMSTot>/<vNF> → valor total da nota
+ */
+@Component
+public class ParserNFe implements ParserExtrato {
+
+    private static final DateTimeFormatter FORMATO_NFE =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX");
+    private static final DateTimeFormatter FORMATO_NFE_SEM_TZ =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+    @Override
+    public boolean aceita(MultipartFile arquivo) {
+        String nome = arquivo.getOriginalFilename();
+        if (nome == null) return false;
+
+        String nomeLower = nome.toLowerCase();
+        // Aceita .xml e .nfe
+        if (!nomeLower.endsWith(".xml") && !nomeLower.endsWith(".nfe")) return false;
+
+        // Confirma pelo conteúdo que é uma NF-e
+        try (InputStream is = arquivo.getInputStream()) {
+            byte[] preview = is.readNBytes(500);
+            String inicio = new String(preview).toLowerCase();
+            return inicio.contains("nfeproc") || inicio.contains("<nfe");
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public List<Transacao> parsear(MultipartFile arquivo, Conta conta) {
+        List<Transacao> transacoes = new ArrayList<>();
+
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            // Namespace-aware para processar NF-e corretamente
+            factory.setNamespaceAware(true);
+            // Proteção contra XXE
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(arquivo.getInputStream());
+            doc.getDocumentElement().normalize();
+
+            // Extrai data de emissão
+            LocalDate dataEmissao = extrairDataEmissao(doc);
+            if (dataEmissao == null) {
+                throw new RuntimeException("Campo <dhEmi> não encontrado ou em formato inválido na NF-e.");
+            }
+
+            // Extrai emitente
+            String nomeEmitente = primeiroTexto(doc, "xNome");
+            String cnpjEmitente = primeiroTexto(doc, "CNPJ");
+            String descricao = montarDescricao(nomeEmitente, cnpjEmitente);
+
+            // Extrai valor total da nota
+            BigDecimal valorTotal = extrairValorTotal(doc);
+            if (valorTotal == null || valorTotal.compareTo(BigDecimal.ZERO) <= 0) {
+                throw new RuntimeException("Campo <vNF> não encontrado ou inválido na NF-e.");
+            }
+
+            // Uma NF-e = uma transação de DEBITO
+            Transacao transacao = new Transacao();
+            transacao.setConta(conta);
+            transacao.setData(dataEmissao);
+            transacao.setDescricao(descricao);
+            transacao.setValor(valorTotal);
+            transacao.setTipo(TipoTransacao.DEBITO);
+            transacao.setCategorizada(false);
+
+            transacoes.add(transacao);
+
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao processar NF-e: " + e.getMessage(), e);
+        }
+
+        return transacoes;
+    }
+
+    /**
+     * Extrai a data de emissão do campo <dhEmi>.
+     * O padrão SEFAZ usa ISO 8601 com timezone (2024-01-15T10:30:00-03:00).
+     * Fallback para formato sem timezone para NF-e malformadas.
+     */
+    private LocalDate extrairDataEmissao(Document doc) {
+        String dhEmi = primeiroTexto(doc, "dhEmi");
+        if (dhEmi == null || dhEmi.isBlank()) return null;
+
+        try {
+            return LocalDate.parse(dhEmi, FORMATO_NFE);
+        } catch (Exception e1) {
+            try {
+                return LocalDate.parse(dhEmi, FORMATO_NFE_SEM_TZ);
+            } catch (Exception e2) {
+                // Último fallback: tenta extrair só a data (primeiros 10 chars)
+                try {
+                    return LocalDate.parse(dhEmi.substring(0, 10));
+                } catch (Exception e3) {
+                    return null;
+                }
+            }
+        }
+    }
+
+    /**
+     * Extrai o valor total da nota a partir de <ICMSTot>/<vNF>.
+     * Se não encontrar via ICMSTot, tenta buscar <vNF> diretamente.
+     */
+    private BigDecimal extrairValorTotal(Document doc) {
+        // Tenta via ICMSTot primeiro (estrutura padrão)
+        NodeList icmsTot = doc.getElementsByTagName("ICMSTot");
+        if (icmsTot.getLength() > 0) {
+            Element el = (Element) icmsTot.item(0);
+            NodeList vnf = el.getElementsByTagName("vNF");
+            if (vnf.getLength() > 0) {
+                return parsearBigDecimal(vnf.item(0).getTextContent().trim());
+            }
+        }
+
+        // Fallback: busca <vNF> diretamente no documento
+        String vNF = primeiroTexto(doc, "vNF");
+        return parsearBigDecimal(vNF);
+    }
+
+    /** Busca o texto do primeiro elemento com a tag informada no documento. */
+    private String primeiroTexto(Document doc, String tag) {
+        NodeList nos = doc.getElementsByTagName(tag);
+        if (nos.getLength() == 0) return "";
+        return nos.item(0).getTextContent().trim();
+    }
+
+    private BigDecimal parsearBigDecimal(String valor) {
+        if (valor == null || valor.isBlank()) return null;
+        try {
+            return new BigDecimal(valor.replace(",", "."));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private String montarDescricao(String nome, String cnpj) {
+        if (nome == null || nome.isBlank()) return "NF-e importada";
+        if (cnpj == null || cnpj.isBlank()) return nome;
+        return nome + " (CNPJ: " + cnpj + ")";
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserNFe.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserNFe.java
@@ -3,6 +3,7 @@ package bcd.appfinanceirobackend.parser;
 import bcd.appfinanceirobackend.model.Conta;
 import bcd.appfinanceirobackend.model.Transacao;
 import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.w3c.dom.Document;
@@ -40,6 +41,7 @@ import java.util.List;
  *   <total>/<ICMSTot>/<vNF> → valor total da nota
  */
 @Component
+@Order(1)
 public class ParserNFe implements ParserExtrato {
 
     private static final DateTimeFormatter FORMATO_NFE =

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserNFe.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserNFe.java
@@ -104,13 +104,13 @@ public class ParserNFe implements ParserExtrato {
 
             for (int i = 0; i < itens.getLength(); i++) {
                 Element item = (Element) itens.item(i);
+                totalLinhas++;
 
                 String descricaoProduto = primeiroTextoElemento(item, "xProd");
                 BigDecimal valorProduto = parsearBigDecimal(primeiroTextoElemento(item, "vProd"));
 
                 if (valorProduto == null || valorProduto.compareTo(BigDecimal.ZERO) <= 0) {
                     linhasInvalidas++;
-                    totalLinhas++;
                     continue;
                 }
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserNFe.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserNFe.java
@@ -69,8 +69,10 @@ public class ParserNFe implements ParserExtrato {
     }
 
     @Override
-    public List<Transacao> parsear(MultipartFile arquivo, Conta conta) {
+    public ResultadoParser parsear(MultipartFile arquivo, Conta conta) {
         List<Transacao> transacoes = new ArrayList<>();
+        int linhasInvalidas = 0;
+        int totalLinhas = 0;
 
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -106,7 +108,11 @@ public class ParserNFe implements ParserExtrato {
                 String descricaoProduto = primeiroTextoElemento(item, "xProd");
                 BigDecimal valorProduto = parsearBigDecimal(primeiroTextoElemento(item, "vProd"));
 
-                if (valorProduto == null || valorProduto.compareTo(BigDecimal.ZERO) <= 0) continue;
+                if (valorProduto == null || valorProduto.compareTo(BigDecimal.ZERO) <= 0) {
+                    linhasInvalidas++;
+                    totalLinhas++;
+                    continue;
+                }
 
                 Transacao transacao = new Transacao();
                 transacao.setConta(conta);
@@ -125,7 +131,11 @@ public class ParserNFe implements ParserExtrato {
             throw new RuntimeException("Erro ao processar NF-e: " + e.getMessage(), e);
         }
 
-        return transacoes;
+        ResultadoParser resultado = new ResultadoParser();
+        resultado.setTotalLinhas(totalLinhas);
+        resultado.setTransacoes(transacoes);
+        resultado.setLinhasInvalidas(linhasInvalidas);
+        return resultado;
     }
 
     /**

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserTXT.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserTXT.java
@@ -1,0 +1,183 @@
+package bcd.appfinanceirobackend.parser;
+
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parser para extratos bancários no formato TXT (texto simples / posicional).
+ *
+ * Muitos bancos brasileiros exportam extratos em TXT com layout posicional ou
+ * colunar separado por espaços. Este parser adota duas estratégias em sequência:
+ *
+ * 1. Detecção por regex de padrão data + valor na linha (estratégia flexível).
+ *    Funciona para a maioria dos formatos colunares e semi-estruturados.
+ *
+ * 2. Fallback para split por múltiplos espaços, cobrindo formatos tabulares
+ *    onde os campos são alinhados com espaçamento fixo.
+ *
+ * Padrão reconhecido pela estratégia 1 (regex):
+ *   [data] [qualquer texto] [valor]
+ *   Exemplo: "15/01/2024   Supermercado Extra         -150,00"
+ *
+ * Padrão reconhecido pela estratégia 2 (split):
+ *   data<TAB>descricao<TAB>valor
+ *   Exemplo: "15/01/2024\tSupermercado\t-150,00"
+ *
+ * Linhas que não encaixam em nenhum padrão são ignoradas silenciosamente.
+ */
+@Component
+public class ParserTXT implements ParserExtrato {
+
+    /**
+     * Regex que captura:
+     * Grupo 1: data (dd/MM/yyyy, yyyy-MM-dd ou dd-MM-yyyy)
+     * Grupo 2: descrição (qualquer texto no meio)
+     * Grupo 3: valor monetário (com ou sem sinal, vírgula ou ponto decimal)
+     */
+    private static final Pattern PADRAO_LINHA = Pattern.compile(
+            "^(\\d{2}[/\\-]\\d{2}[/\\-]\\d{2,4}|\\d{4}[/\\-]\\d{2}[/\\-]\\d{2})" // data
+                    + "\\s+(.+?)\\s+"                                                // descricao
+                    + "([+-]?\\d{1,3}(?:[.,]\\d{3})*(?:[.,]\\d{2})?)\\s*$"         // valor
+    );
+
+    private static final List<DateTimeFormatter> FORMATADORES = List.of(
+            DateTimeFormatter.ofPattern("dd/MM/yyyy"),
+            DateTimeFormatter.ofPattern("dd-MM-yyyy"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+            DateTimeFormatter.ofPattern("dd/MM/yy")
+    );
+
+    @Override
+    public boolean aceita(MultipartFile arquivo) {
+        String nome = arquivo.getOriginalFilename();
+        return nome != null && nome.toLowerCase().endsWith(".txt");
+    }
+
+    @Override
+    public List<Transacao> parsear(MultipartFile arquivo, Conta conta) {
+        List<Transacao> transacoes = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(arquivo.getInputStream(), StandardCharsets.UTF_8))) {
+
+            String linha;
+            while ((linha = reader.readLine()) != null) {
+                linha = linha.trim();
+                if (linha.isBlank()) continue;
+
+                Transacao transacao = parsearPorRegex(linha, conta);
+
+                // Fallback: tenta split por múltiplos espaços ou tabulação
+                if (transacao == null) {
+                    transacao = parsearPorSplit(linha, conta);
+                }
+
+                if (transacao != null) {
+                    transacoes.add(transacao);
+                }
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao processar arquivo TXT: " + e.getMessage(), e);
+        }
+
+        return transacoes;
+    }
+
+    /** Estratégia 1: extrai campos via regex. */
+    private Transacao parsearPorRegex(String linha, Conta conta) {
+        Matcher matcher = PADRAO_LINHA.matcher(linha);
+        if (!matcher.matches()) return null;
+
+        LocalDate data = parsearData(matcher.group(1));
+        if (data == null) return null;
+
+        String descricao = matcher.group(2).trim();
+        BigDecimal valor = parsearValor(matcher.group(3));
+        if (valor == null) return null;
+
+        return montarTransacao(conta, data, descricao, valor);
+    }
+
+    /** Estratégia 2: split por tabulação ou múltiplos espaços. */
+    private Transacao parsearPorSplit(String linha, Conta conta) {
+        // Divide por TAB ou por 2+ espaços consecutivos
+        String[] partes = linha.split("\t|\\s{2,}");
+
+        if (partes.length < 3) return null;
+
+        LocalDate data = parsearData(partes[0].trim());
+        if (data == null) return null;
+
+        // Valor é sempre o último campo; descrição é tudo no meio
+        BigDecimal valor = parsearValor(partes[partes.length - 1].trim());
+        if (valor == null) return null;
+
+        StringBuilder desc = new StringBuilder();
+        for (int i = 1; i < partes.length - 1; i++) {
+            if (!partes[i].isBlank()) {
+                if (desc.length() > 0) desc.append(" ");
+                desc.append(partes[i].trim());
+            }
+        }
+        String descricao = desc.toString().isBlank() ? "Importado via TXT" : desc.toString();
+
+        return montarTransacao(conta, data, descricao, valor);
+    }
+
+    private Transacao montarTransacao(Conta conta, LocalDate data,
+                                      String descricao, BigDecimal valor) {
+        TipoTransacao tipo = valor.compareTo(BigDecimal.ZERO) < 0
+                ? TipoTransacao.DEBITO
+                : TipoTransacao.CREDITO;
+
+        Transacao transacao = new Transacao();
+        transacao.setConta(conta);
+        transacao.setData(data);
+        transacao.setDescricao(descricao);
+        transacao.setValor(valor.abs());
+        transacao.setTipo(tipo);
+        transacao.setCategorizada(false);
+        return transacao;
+    }
+
+    private LocalDate parsearData(String valor) {
+        for (DateTimeFormatter fmt : FORMATADORES) {
+            try {
+                return LocalDate.parse(valor.trim(), fmt);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+        return null;
+    }
+
+    private BigDecimal parsearValor(String valor) {
+        if (valor == null || valor.isBlank()) return null;
+        try {
+            String normalizado = valor.replace("R$", "").replace(" ", "").trim();
+            if (normalizado.contains(",") && normalizado.contains(".")) {
+                normalizado = normalizado.replace(".", "").replace(",", ".");
+            } else {
+                normalizado = normalizado.replace(",", ".");
+            }
+            return new BigDecimal(normalizado);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserTXT.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserTXT.java
@@ -80,11 +80,9 @@ public class ParserTXT implements ParserExtrato {
             String linha;
             while ((linha = reader.readLine()) != null) {
                 linha = linha.trim();
-                if (linha.isBlank()) {
-                    totalLinhas++;
-                    linhasInvalidas++;
-                    continue;
-                };
+                if (linha.isBlank()) continue;
+
+                totalLinhas++;
 
                 Transacao transacao = parsearPorRegex(linha, conta);
 
@@ -96,13 +94,20 @@ public class ParserTXT implements ParserExtrato {
                 if (transacao != null) {
                     transacoes.add(transacao);
                 }
+                else {
+                    linhasInvalidas++;
+                }
             }
 
         } catch (Exception e) {
             throw new RuntimeException("Erro ao processar arquivo TXT: " + e.getMessage(), e);
         }
 
-        return transacoes;
+        ResultadoParser resultado = new ResultadoParser();
+        resultado.setLinhasInvalidas(linhasInvalidas);
+        resultado.setTotalLinhas(totalLinhas);
+        resultado.setTransacoes(transacoes);
+        return resultado;
     }
 
     /** Estratégia 1: extrai campos via regex. */

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserTXT.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserTXT.java
@@ -69,8 +69,10 @@ public class ParserTXT implements ParserExtrato {
     }
 
     @Override
-    public List<Transacao> parsear(MultipartFile arquivo, Conta conta) {
+    public ResultadoParser parsear(MultipartFile arquivo, Conta conta) {
         List<Transacao> transacoes = new ArrayList<>();
+        int totalLinhas = 0;
+        int linhasInvalidas = 0;
 
         try (BufferedReader reader = new BufferedReader(
                 new InputStreamReader(arquivo.getInputStream(), StandardCharsets.UTF_8))) {
@@ -78,7 +80,11 @@ public class ParserTXT implements ParserExtrato {
             String linha;
             while ((linha = reader.readLine()) != null) {
                 linha = linha.trim();
-                if (linha.isBlank()) continue;
+                if (linha.isBlank()) {
+                    totalLinhas++;
+                    linhasInvalidas++;
+                    continue;
+                };
 
                 Transacao transacao = parsearPorRegex(linha, conta);
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserXML.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserXML.java
@@ -3,6 +3,7 @@ package bcd.appfinanceirobackend.parser;
 import bcd.appfinanceirobackend.model.Conta;
 import bcd.appfinanceirobackend.model.Transacao;
 import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import org.w3c.dom.Document;
@@ -41,6 +42,7 @@ import java.util.List;
  * Tags alternativas também aceitas: <lancamento>, <movimento>, <entry>
  */
 @Component
+@Order(2)
 public class ParserXML implements ParserExtrato {
 
     private static final List<String> TAGS_TRANSACAO = List.of(

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserXML.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserXML.java
@@ -1,4 +1,168 @@
 package bcd.appfinanceirobackend.parser;
 
-public class ParserXML {
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parser para extratos bancários no formato XML genérico (não NF-e).
+ *
+ * Este parser trata extratos exportados por bancos no formato XML próprio,
+ * diferenciando-se do ParserNFe que trata o padrão SEFAZ.
+ *
+ * A detecção é feita pela extensão .xml combinada com a ausência da tag
+ * raiz <nfeProc> ou <NFe>, que caracteriza uma NF-e.
+ *
+ * Estrutura XML esperada:
+ * <extrato>
+ *   <transacao>
+ *     <data>2024-01-15</data>
+ *     <descricao>Supermercado</descricao>
+ *     <valor>-150.00</valor>
+ *     <tipo>DEBITO</tipo>           <!-- opcional -->
+ *   </transacao>
+ * </extrato>
+ *
+ * Tags alternativas também aceitas: <lancamento>, <movimento>, <entry>
+ */
+@Component
+public class ParserXML implements ParserExtrato {
+
+    private static final List<String> TAGS_TRANSACAO = List.of(
+            "transacao", "lancamento", "movimento", "entry"
+    );
+
+    private static final List<DateTimeFormatter> FORMATADORES = List.of(
+            DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+            DateTimeFormatter.ofPattern("dd/MM/yyyy"),
+            DateTimeFormatter.ofPattern("dd-MM-yyyy")
+    );
+
+    @Override
+    public boolean aceita(MultipartFile arquivo) {
+        String nome = arquivo.getOriginalFilename();
+        if (nome == null || !nome.toLowerCase().endsWith(".xml")) return false;
+
+        // Lê os primeiros bytes para verificar se NÃO é uma NF-e
+        try (InputStream is = arquivo.getInputStream()) {
+            byte[] preview = is.readNBytes(500);
+            String inicio = new String(preview).toLowerCase();
+            // NF-e é tratada pelo ParserNFe — este parser rejeita
+            return !inicio.contains("nfeproc") && !inicio.contains("<nfe");
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public List<Transacao> parsear(MultipartFile arquivo, Conta conta) {
+        List<Transacao> transacoes = new ArrayList<>();
+
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            // Desativa DTD externo para evitar XXE
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(arquivo.getInputStream());
+            doc.getDocumentElement().normalize();
+
+            // Tenta cada tag conhecida até encontrar elementos
+            NodeList nos = null;
+            for (String tag : TAGS_TRANSACAO) {
+                nos = doc.getElementsByTagName(tag);
+                if (nos.getLength() > 0) break;
+            }
+
+            if (nos == null || nos.getLength() == 0) {
+                throw new RuntimeException("Nenhuma tag de transação reconhecida no XML. " +
+                        "Tags suportadas: " + TAGS_TRANSACAO);
+            }
+
+            for (int i = 0; i < nos.getLength(); i++) {
+                Element el = (Element) nos.item(i);
+
+                LocalDate data = parsearData(texto(el, "data"));
+                if (data == null) continue;
+
+                BigDecimal valor = parsearValor(texto(el, "valor"));
+                if (valor == null) continue;
+
+                String descricao = texto(el, "descricao");
+                TipoTransacao tipo = parsearTipo(texto(el, "tipo"), valor);
+
+                Transacao transacao = new Transacao();
+                transacao.setConta(conta);
+                transacao.setData(data);
+                transacao.setDescricao(descricao);
+                transacao.setValor(valor.abs());
+                transacao.setTipo(tipo);
+                transacao.setCategorizada(false);
+
+                transacoes.add(transacao);
+            }
+
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao processar arquivo XML: " + e.getMessage(), e);
+        }
+
+        return transacoes;
+    }
+
+    /** Extrai o texto de uma tag filha pelo nome, retornando "" se ausente. */
+    private String texto(Element elemento, String tag) {
+        NodeList nos = elemento.getElementsByTagName(tag);
+        if (nos.getLength() == 0) return "";
+        return nos.item(0).getTextContent().trim();
+    }
+
+    private LocalDate parsearData(String valor) {
+        for (DateTimeFormatter fmt : FORMATADORES) {
+            try {
+                return LocalDate.parse(valor, fmt);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+        return null;
+    }
+
+    private BigDecimal parsearValor(String valor) {
+        if (valor == null || valor.isBlank()) return null;
+        try {
+            String normalizado = valor.replace("R$", "").replace(" ", "").trim();
+            if (normalizado.contains(",") && normalizado.contains(".")) {
+                normalizado = normalizado.replace(".", "").replace(",", ".");
+            } else {
+                normalizado = normalizado.replace(",", ".");
+            }
+            return new BigDecimal(normalizado);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private TipoTransacao parsearTipo(String tipoStr, BigDecimal valor) {
+        if (valor.compareTo(BigDecimal.ZERO) < 0) return TipoTransacao.DEBITO;
+        try {
+            return TipoTransacao.valueOf(tipoStr.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return TipoTransacao.CREDITO;
+        }
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserXML.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserXML.java
@@ -72,8 +72,10 @@ public class ParserXML implements ParserExtrato {
     }
 
     @Override
-    public List<Transacao> parsear(MultipartFile arquivo, Conta conta) {
+    public ResultadoParser parsear(MultipartFile arquivo, Conta conta) {
         List<Transacao> transacoes = new ArrayList<>();
+        int linhasInvalidas = 0;
+        int totalLinhas = 0;
 
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -99,10 +101,18 @@ public class ParserXML implements ParserExtrato {
                 Element el = (Element) nos.item(i);
 
                 LocalDate data = parsearData(texto(el, "data"));
-                if (data == null) continue;
+                if (data == null) {
+                    linhasInvalidas++;
+                    totalLinhas++;
+                    continue;
+                }
 
                 BigDecimal valor = parsearValor(texto(el, "valor"));
-                if (valor == null) continue;
+                if (valor == null) {
+                    linhasInvalidas++;
+                    totalLinhas++;
+                    continue;
+                }
 
                 String descricao = texto(el, "descricao");
                 TipoTransacao tipo = parsearTipo(texto(el, "tipo"), valor);
@@ -123,8 +133,11 @@ public class ParserXML implements ParserExtrato {
         } catch (Exception e) {
             throw new RuntimeException("Erro ao processar arquivo XML: " + e.getMessage(), e);
         }
-
-        return transacoes;
+        ResultadoParser resultado = new ResultadoParser();
+        resultado.setLinhasInvalidas(linhasInvalidas);
+        resultado.setTransacoes(transacoes);
+        resultado.setTotalLinhas(totalLinhas);
+        return resultado;
     }
 
     /** Extrai o texto de uma tag filha pelo nome, retornando "" se ausente. */

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserXML.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserXML.java
@@ -98,19 +98,18 @@ public class ParserXML implements ParserExtrato {
             }
 
             for (int i = 0; i < nos.getLength(); i++) {
+                totalLinhas++;
                 Element el = (Element) nos.item(i);
 
                 LocalDate data = parsearData(texto(el, "data"));
                 if (data == null) {
                     linhasInvalidas++;
-                    totalLinhas++;
                     continue;
                 }
 
                 BigDecimal valor = parsearValor(texto(el, "valor"));
                 if (valor == null) {
                     linhasInvalidas++;
-                    totalLinhas++;
                     continue;
                 }
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ResultadoParser.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ResultadoParser.java
@@ -1,0 +1,15 @@
+package bcd.appfinanceirobackend.parser;
+
+import bcd.appfinanceirobackend.model.Transacao;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ResultadoParser {
+    private List<Transacao> transacoes;
+    private int linhasInvalidas;
+    private int totalLinhas;
+}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ResultadoParser.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ResultadoParser.java
@@ -4,12 +4,13 @@ import bcd.appfinanceirobackend.model.Transacao;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Setter
 public class ResultadoParser {
-    private List<Transacao> transacoes;
+    private List<Transacao> transacoes = new ArrayList<>();
     private int linhasInvalidas;
     private int totalLinhas;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -55,15 +55,7 @@ public class ImportacaoService {
 
         boolean verificaNFe = false;
 
-        try (InputStream is = arquivo.getInputStream()) {
-            byte[] preview = is.readNBytes(500);
-            String inicio = new String(preview).toLowerCase();
-            if(inicio.contains("nfeproc") || inicio.contains("<nfe")){
-                verificaNFe = true;
-            }
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Conteúdo do arquivo inválido");
-        }
+
 
 
         String nome = arquivo.getOriginalFilename();

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -9,9 +9,12 @@ import bcd.appfinanceirobackend.model.Usuario;
 import bcd.appfinanceirobackend.model.enums.FormatoArquivo;
 import bcd.appfinanceirobackend.model.enums.StatusImportacao;
 import bcd.appfinanceirobackend.parser.ParserExtrato;
+import bcd.appfinanceirobackend.parser.ResultadoParser;
 import bcd.appfinanceirobackend.repository.ContaRepository;
 import bcd.appfinanceirobackend.repository.ImportacaoRepository;
 import bcd.appfinanceirobackend.repository.TransacaoRepository;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -87,14 +90,15 @@ public class ImportacaoService {
 
         int sucessos = 0, falhas = 0;
         try {
-            List<Transacao> transacoes = parser.parsear(arquivo, conta);
-            for (Transacao t : transacoes) {
+            ResultadoParser resultado = parser.parsear(arquivo, conta);
+            falhas = resultado.getLinhasInvalidas();
+            for (Transacao t: resultado.getTransacoes()){
                 try {
                     t.setImportacao(importacao);
                     t.setCategorizada(false);
                     transacaoRepository.save(t);
                     sucessos++;
-                } catch (Exception e) {
+                }catch (Exception e){
                     falhas++;
                 }
             }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -55,7 +55,15 @@ public class ImportacaoService {
 
         boolean verificaNFe = false;
 
-
+        try (InputStream is = arquivo.getInputStream()) {
+            byte[] preview = is.readNBytes(500);
+            String inicio = new String(preview).toLowerCase();
+            if(inicio.contains("nfeproc") || inicio.contains("<nfe")){
+                verificaNFe = true;
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Conteúdo do arquivo inválido");
+        }
 
 
         String nome = arquivo.getOriginalFilename();

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -85,6 +85,8 @@ public class ImportacaoService {
         importacao.setStatusImportacao(StatusImportacao.PROCESSANDO);
         importacaoRepository.save(importacao);
 
+        String mensagemDeErro = "";
+
         int sucessos = 0, falhas = 0;
         try {
             List<Transacao> transacoes = parser.parsear(arquivo, conta);
@@ -101,13 +103,14 @@ public class ImportacaoService {
             importacao.setStatusImportacao(StatusImportacao.CONCLUIDO);
         } catch (Exception e) {
             importacao.setStatusImportacao(StatusImportacao.ERRO);
+            mensagemDeErro = e.getMessage();
         }
 
         importacao.setSucessos(sucessos);
         importacao.setFalhas(falhas);
         importacaoRepository.save(importacao);
 
-        return toResponse(importacao);
+        return toResponse(importacao, mensagemDeErro);
     }
 
     private FormatoArquivo detectarFormato(String nomeArquivo, boolean verificaNfe) {
@@ -138,13 +141,14 @@ public class ImportacaoService {
 
 
 
-    private ImportacaoResponseDTO toResponse(Importacao importacao) {
+    private ImportacaoResponseDTO toResponse(Importacao importacao, String mensagemDeErro) {
         ImportacaoResponseDTO dto = new ImportacaoResponseDTO();
         dto.setId(importacao.getId());
         dto.setStatus(importacao.getStatusImportacao());
         dto.setSucessos(importacao.getSucessos());
         dto.setFalhas(importacao.getFalhas());
         dto.setImportadoEm(importacao.getImportado_em());
+        dto.setMensagemErro(mensagemDeErro);
         return dto;
     }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -126,9 +126,12 @@ public class ImportacaoService {
 
     }
 
-    public StatusImportacao buscarStatus(UUID importacaoID) {
+    public StatusImportacao buscarStatus(UUID importacaoID, Usuario usuarioAutenticado) {
         Importacao importacao = importacaoRepository.findById(importacaoID).
                 orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Importação não encontrada"));
+        if (!importacao.getUsuario().getId().equals(usuarioAutenticado.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Importação não pertence ao usuário autenticado");
+        }
         return importacao.getStatusImportacao();
     }
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -85,8 +85,6 @@ public class ImportacaoService {
         importacao.setStatusImportacao(StatusImportacao.PROCESSANDO);
         importacaoRepository.save(importacao);
 
-        String mensagemDeErro = "";
-
         int sucessos = 0, falhas = 0;
         try {
             List<Transacao> transacoes = parser.parsear(arquivo, conta);
@@ -103,14 +101,14 @@ public class ImportacaoService {
             importacao.setStatusImportacao(StatusImportacao.CONCLUIDO);
         } catch (Exception e) {
             importacao.setStatusImportacao(StatusImportacao.ERRO);
-            mensagemDeErro = e.getMessage();
+            importacao.setMensagemErro(e.getMessage());
         }
 
         importacao.setSucessos(sucessos);
         importacao.setFalhas(falhas);
         importacaoRepository.save(importacao);
 
-        return toResponse(importacao, mensagemDeErro);
+        return toResponse(importacao);
     }
 
     private FormatoArquivo detectarFormato(String nomeArquivo, boolean verificaNfe) {
@@ -141,14 +139,14 @@ public class ImportacaoService {
 
 
 
-    private ImportacaoResponseDTO toResponse(Importacao importacao, String mensagemDeErro) {
+    private ImportacaoResponseDTO toResponse(Importacao importacao) {
         ImportacaoResponseDTO dto = new ImportacaoResponseDTO();
         dto.setId(importacao.getId());
         dto.setStatus(importacao.getStatusImportacao());
         dto.setSucessos(importacao.getSucessos());
         dto.setFalhas(importacao.getFalhas());
         dto.setImportadoEm(importacao.getImportado_em());
-        dto.setMensagemErro(mensagemDeErro);
+        dto.setMensagemErro(importacao.getMensagemErro());
         return dto;
     }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -47,6 +47,10 @@ public class ImportacaoService {
         Conta conta = contaRepository.findById(contaId)
                 .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));
 
+        if (!conta.getUsuario().getId().equals(usuarioAutenticado.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Conta não pertence ao usuário autenticado");
+        }
+
         if(arquivo.isEmpty()) throw new IllegalArgumentException("Arquivo vazio");
 
         boolean verificaNFe = false;

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -102,6 +102,7 @@ public class ImportacaoService {
                     falhas++;
                 }
             }
+            importacao.setTotal_linhas(resultado.getTotalLinhas());
             importacao.setStatusImportacao(StatusImportacao.CONCLUIDO);
         } catch (Exception e) {
             importacao.setStatusImportacao(StatusImportacao.ERRO);

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -1,4 +1,57 @@
 package bcd.appfinanceirobackend.service;
 
+import bcd.appfinanceirobackend.dto.importacao.ImportacaoResponseDTO;
+import bcd.appfinanceirobackend.model.Importacao;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.StatusImportacao;
+import bcd.appfinanceirobackend.parser.ParserExtrato;
+import bcd.appfinanceirobackend.repository.ContaRepository;
+import bcd.appfinanceirobackend.repository.ImportacaoRepository;
+import bcd.appfinanceirobackend.repository.TransacaoRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
 public class ImportacaoService {
+
+    private final List<ParserExtrato> parsers;
+    private final ImportacaoRepository importacaoRepository;
+    private final TransacaoRepository transacaoRepository;
+    private final ContaRepository contaRepository;
+
+    public ImportacaoService(List<ParserExtrato> parsers,
+                             ImportacaoRepository importacaoRepository,
+                             TransacaoRepository transacaoRepository,
+                             ContaRepository contaRepository){
+        this.contaRepository = contaRepository;
+        this.transacaoRepository = transacaoRepository;
+        this.parsers = parsers;
+        this.importacaoRepository = importacaoRepository;
+    }
+
+    public ImportacaoResponseDTO processar(MultipartFile arquivo,
+                                           UUID contaId,
+                                           Usuario usuarioAutenticado) {
+        
+    }
+
+    public StatusImportacao buscarStatus() {
+
+    }
+
+
+
+
+    private ImportacaoResponseDTO toResponse(Importacao importacao) {
+        ImportacaoResponseDTO dto = new ImportacaoResponseDTO();
+        dto.setId(importacao.getId());
+        dto.setStatus(importacao.getStatusImportacao());
+        dto.setSucessos(importacao.getSucessos());
+        dto.setFalhas(importacao.getFalhas());
+        dto.setImportadoEm(importacao.getImportado_em());
+        return dto;
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -6,6 +6,7 @@ import bcd.appfinanceirobackend.model.Conta;
 import bcd.appfinanceirobackend.model.Importacao;
 import bcd.appfinanceirobackend.model.Transacao;
 import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.FormatoArquivo;
 import bcd.appfinanceirobackend.model.enums.StatusImportacao;
 import bcd.appfinanceirobackend.parser.ParserExtrato;
 import bcd.appfinanceirobackend.repository.ContaRepository;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -44,7 +46,27 @@ public class ImportacaoService {
 
         Conta conta = contaRepository.findById(contaId)
                 .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));
+
+        if(arquivo.isEmpty()) throw new IllegalArgumentException("Arquivo vazio");
+
+        boolean verificaNFe = false;
+
+        try (InputStream is = arquivo.getInputStream()) {
+            byte[] preview = is.readNBytes(500);
+            String inicio = new String(preview).toLowerCase();
+            if(inicio.contains("nfeproc") || inicio.contains("<nfe")){
+                verificaNFe = true;
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Conteúdo do arquivo inválido");
+        }
+
+
+        String nome = arquivo.getOriginalFilename();
+        if(nome==null) throw new IllegalArgumentException("Nome do arquivo inválido");
         Importacao importacao = new Importacao();
+        importacao.setNome_arquivo(arquivo.getOriginalFilename());
+        importacao.setFormatoArquivo(detectarFormato(nome));
         importacao.setUsuario(usuarioAutenticado);
         importacao.setStatusImportacao(StatusImportacao.PENDENTE);
         importacao.setImportado_em(LocalDateTime.now());
@@ -82,6 +104,18 @@ public class ImportacaoService {
         importacaoRepository.save(importacao);
 
         return toResponse(importacao);
+    }
+
+    private FormatoArquivo detectarFormato(String nomeArquivo) {
+        String extensaoArquivo = nomeArquivo.toLowerCase();
+        if(extensaoArquivo.endsWith(".csv")){
+            return FormatoArquivo.CSV;
+        } else if (extensaoArquivo.endsWith(".txt")) {
+            return FormatoArquivo.TXT;
+        } else if (extensaoArquivo.endsWith(".xml")) {
+
+        }
+
     }
 
     public StatusImportacao buscarStatus(UUID importacaoID) {

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -70,7 +70,7 @@ public class ImportacaoService {
         if(nome==null) throw new IllegalArgumentException("Nome do arquivo inválido");
         Importacao importacao = new Importacao();
         importacao.setNome_arquivo(arquivo.getOriginalFilename());
-        importacao.setFormatoArquivo(detectarFormato(nome));
+        importacao.setFormatoArquivo(detectarFormato(nome, verificaNFe));
         importacao.setUsuario(usuarioAutenticado);
         importacao.setStatusImportacao(StatusImportacao.PENDENTE);
         importacao.setImportado_em(LocalDateTime.now());
@@ -110,15 +110,19 @@ public class ImportacaoService {
         return toResponse(importacao);
     }
 
-    private FormatoArquivo detectarFormato(String nomeArquivo) {
+    private FormatoArquivo detectarFormato(String nomeArquivo, boolean verificaNfe) {
         String extensaoArquivo = nomeArquivo.toLowerCase();
         if(extensaoArquivo.endsWith(".csv")){
             return FormatoArquivo.CSV;
-        } else if (extensaoArquivo.endsWith(".txt")) {
-            return FormatoArquivo.TXT;
-        } else if (extensaoArquivo.endsWith(".xml")) {
-
         }
+        if (extensaoArquivo.endsWith(".txt")) {
+            return FormatoArquivo.TXT;
+        }
+        if (extensaoArquivo.endsWith(".xml")) {
+            return verificaNfe ? FormatoArquivo.NFE : FormatoArquivo.XML;
+        }
+
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Formato do Arquivo não suportado");
 
     }
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -1,16 +1,22 @@
 package bcd.appfinanceirobackend.service;
 
 import bcd.appfinanceirobackend.dto.importacao.ImportacaoResponseDTO;
+import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
+import bcd.appfinanceirobackend.model.Conta;
 import bcd.appfinanceirobackend.model.Importacao;
+import bcd.appfinanceirobackend.model.Transacao;
 import bcd.appfinanceirobackend.model.Usuario;
 import bcd.appfinanceirobackend.model.enums.StatusImportacao;
 import bcd.appfinanceirobackend.parser.ParserExtrato;
 import bcd.appfinanceirobackend.repository.ContaRepository;
 import bcd.appfinanceirobackend.repository.ImportacaoRepository;
 import bcd.appfinanceirobackend.repository.TransacaoRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -35,11 +41,53 @@ public class ImportacaoService {
     public ImportacaoResponseDTO processar(MultipartFile arquivo,
                                            UUID contaId,
                                            Usuario usuarioAutenticado) {
-        
+
+        Conta conta = contaRepository.findById(contaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));
+        Importacao importacao = new Importacao();
+        importacao.setUsuario(usuarioAutenticado);
+        importacao.setStatusImportacao(StatusImportacao.PENDENTE);
+        importacao.setImportado_em(LocalDateTime.now());
+        importacaoRepository.save(importacao);
+
+        ParserExtrato parser = parsers.stream()
+                .filter(p -> p.aceita(arquivo))
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST, "Formato de arquivo não suportado"));
+
+        importacao.setStatusImportacao(StatusImportacao.PROCESSANDO);
+        importacaoRepository.save(importacao);
+
+        int sucessos = 0, falhas = 0;
+        try {
+            List<Transacao> transacoes = parser.parsear(arquivo, conta);
+            for (Transacao t : transacoes) {
+                try {
+                    t.setImportacao(importacao);
+                    t.setCategorizada(false);
+                    transacaoRepository.save(t);
+                    sucessos++;
+                } catch (Exception e) {
+                    falhas++;
+                }
+            }
+            importacao.setStatusImportacao(StatusImportacao.CONCLUIDO);
+        } catch (Exception e) {
+            importacao.setStatusImportacao(StatusImportacao.ERRO);
+        }
+
+        importacao.setSucessos(sucessos);
+        importacao.setFalhas(falhas);
+        importacaoRepository.save(importacao);
+
+        return toResponse(importacao);
     }
 
-    public StatusImportacao buscarStatus() {
-
+    public StatusImportacao buscarStatus(UUID importacaoID) {
+        Importacao importacao = importacaoRepository.findById(importacaoID).
+                orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Importação não encontrada"));
+        return importacao.getStatusImportacao();
     }
 
 

--- a/app-financeiro-back-end/src/main/resources/application.properties
+++ b/app-financeiro-back-end/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.port=8080
 # O banco 'app_financeiro' foi detectado no seu pgAdmin 4
 spring.datasource.url=jdbc:postgresql://localhost:5432/app_financeiro
 spring.datasource.username=postgres
-spring.datasource.password=1234
+spring.datasource.password=Dragons2013.
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # Configurações do Hibernate / JPA

--- a/app-financeiro-back-end/src/main/resources/application.properties
+++ b/app-financeiro-back-end/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.port=8080
 # O banco 'app_financeiro' foi detectado no seu pgAdmin 4
 spring.datasource.url=jdbc:postgresql://localhost:5432/app_financeiro
 spring.datasource.username=postgres
-spring.datasource.password=Dragons2013.
+spring.datasource.password=senha123
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # Configurações do Hibernate / JPA

--- a/app-financeiro-back-end/src/main/resources/application.properties
+++ b/app-financeiro-back-end/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.port=8080
 # O banco 'app_financeiro' foi detectado no seu pgAdmin 4
 spring.datasource.url=jdbc:postgresql://localhost:5432/app_financeiro
 spring.datasource.username=postgres
-spring.datasource.password=senha123
+spring.datasource.password=123456
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # Configurações do Hibernate / JPA

--- a/app-financeiro-back-end/src/main/resources/application.properties
+++ b/app-financeiro-back-end/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.port=8080
 # O banco 'app_financeiro' foi detectado no seu pgAdmin 4
 spring.datasource.url=jdbc:postgresql://localhost:5432/app_financeiro
 spring.datasource.username=postgres
-spring.datasource.password=123456
+spring.datasource.password=1234
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # Configurações do Hibernate / JPA


### PR DESCRIPTION
Closes #60 

## O que mudou
- Criada interface `ParserExtrato` em `parser/ParserExtrato.java` definindo o contrato Strategy com os métodos `aceita()` e `parsear()`
- Implementado `ParserCSV` com detecção automática de delimitador (`;`, `,` ou `TAB`) e suporte a múltiplos formatos de data e separador decimal
- Implementado `ParserXML` para extratos bancários no formato XML genérico, com rejeição automática de NF-e e proteção contra XXE
- Implementado `ParserNFe` para Nota Fiscal Eletrônica no padrão SEFAZ, gerando uma transação DEBITO por nota com descrição composta por razão social e CNPJ do emitente
- Implementado `ParserTXT` com duas estratégias em cascata: regex para formatos colunares e split por tabulação/múltiplos espaços como fallback
- Implementado `ImportacaoService` orquestrando a seleção de parser via Strategy, o ciclo de status (`PENDENTE → PROCESSANDO → CONCLUIDO / ERRO`) e a persistência das transações com os contadores de `sucessos` e `falhas`
- Implementado `ImportacaoController` com os endpoints `POST /importacoes` para upload e processamento e `GET /importacoes/{id}/status` para consulta do resultado

## Por quê
- Implementação das tarefas técnicas da issue de upload e processamento de extratos bancários e NF-e — funcionalidade central do SmartBudget e ponto de maior risco técnico do projeto (R01)
- O `ImportacaoService` depende da interface `ParserExtrato` para selecionar dinamicamente o parser correto, completando o fluxo de importação de ponta a ponta

## Como testar
1. Suba a aplicação e autentique-se via `POST /auth/login` para obter um token
2. Envie `POST /importacoes` com um arquivo `.csv` válido e um `contaId` existente — verifique se retorna 201 com status `CONCLUIDO` e os contadores de `sucessos` e `falhas` preenchidos
3. Consulte `GET /importacoes/{id}/status` com o `id` retornado no passo anterior — verifique se o status está correto
4. Repita o passo 2 com arquivos `.xml` de extrato bancário, `.xml` de NF-e e `.txt` — verifique se o parser correto é selecionado em cada caso
5. Envie com um `contaId` de outro usuário — verifique se retorna 403
6. Envie com um `contaId` inexistente — verifique se retorna 404
7. Envie um arquivo com extensão não suportada (ex: `.pdf`) — verifique se retorna 400 com mensagem descritiva
8. Envie um arquivo corrompido — verifique se a importação é salva com status `ERRO` e não quebra o fluxo
9. Envie sem token — verifique se retorna 401

## Auto-review (checklist)
- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (arquivo corrompido → ERRO; formato inválido → 400; conta de outro usuário → 403; conta inexistente → 404; sem token → 401; linha inválida no CSV/TXT → ignorada silenciosamente)
- [ ] Evidência de teste (manual ou automatizado) — testes unitários por parser pendentes conforme indicado na issue
- [x] Não quebrou funcionalidades existentes (parsers e serviço de importação são componentes novos, sem alteração em classes existentes)
- [x] Código revisado e limpo

## Comentários técnicos

- [Risco] O `ParserXML` e o `ParserNFe` compartilham a extensão `.xml` — a distinção é feita lendo os primeiros 500 bytes do arquivo para detectar as tags `<nfeProc>` ou `<NFe>`. Se uma NF-e malformada não contiver essas tags no início do arquivo, o `ParserXML` será selecionado incorretamente e vai falhar ao não encontrar as tags de transação esperadas. Recomenda-se adicionar um teste com NF-e sem o envelope `<nfeProc>` para validar o comportamento.

- [Manutenção] Todos os parsers são `@Component` e implementam `ParserExtrato`, o que permite que o Spring injete automaticamente a lista completa no `ImportacaoService` via `List<ParserExtrato>`. Adicionar suporte a um novo formato no futuro exige apenas criar uma nova classe com `@Component` — nenhuma alteração no service ou no controller é necessária.

