### PR TITLE
chore/#123-docker-compose-postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,62 @@ curl -X POST http://localhost:8080/auth/register \
 
 Informações mais detalhadas disponíveis em [docs/como-rodar.md](docs/como-rodar.md).
 
+## Banco de dados local com Docker
+
+O projeto possui um arquivo `docker-compose.yml` na raiz para subir um banco PostgreSQL local usado pelo backend.
+
+### Configurações do banco
+
+- Banco: `app_financeiro`
+- Usuário: `postgres`
+- Senha: `1234`
+- Porta: `5432`
+- Imagem Docker: `postgres:16`
+
+### Subir o banco
+
+Na raiz do projeto, execute:
+
+```bash
+docker compose up -d
+```
+
+### Verificar se o banco está rodando
+
+```bash
+docker compose ps
+```
+
+O serviço `postgres` deve aparecer como iniciado. Após alguns segundos, o status de saúde deve ficar como `healthy`.
+
+### Acessar o banco pelo terminal
+
+```bash
+docker exec -it smartbudget-postgres psql -U postgres -d app_financeiro
+```
+
+Para sair do PostgreSQL:
+
+```sql
+\q
+```
+
+### Parar o banco
+
+```bash
+docker compose down
+```
+
+### Apagar os dados locais do banco
+
+Use este comando apenas se quiser remover também o volume com os dados persistidos:
+
+```bash
+docker compose down -v
+```
+
+Depois disso, ao subir novamente com `docker compose up -d`, o banco será recriado do zero.
+
 ## Migrations e versionamento do banco
 
 O projeto utiliza Flyway para controlar as versões do banco de dados.

--- a/README.md
+++ b/README.md
@@ -64,16 +64,28 @@ cd app-financeiro-back-end
 Para rodar banco de dados:
 
 ```bash
-docker run -d \
-  --name app-financeiro-db \
-  -e POSTGRES_USER=postgres \
-  -e POSTGRES_PASSWORD=1234 \
-  -e POSTGRES_DB=app_financeiro \
-  -p 5432:5432 \
-  -v app-financeiro-pgdata:/var/lib/postgresql/data \
-  postgres:16
+docker compose up -d
 ```
 
+O banco PostgreSQL será iniciado com as configurações definidas no `docker-compose.yml` da raiz do projeto:
+
+- Banco: `app_financeiro`
+- Usuário: `postgres`
+- Senha: `1234`
+- Porta: `5432`
+- Container: `smartbudget-postgres`
+
+Para parar o banco:
+
+```bash
+docker compose down
+```
+
+Para apagar os dados locais do banco:
+
+```bash
+docker compose down -v
+```
 Para rodar front-end:
 
 ```bash
@@ -104,62 +116,6 @@ curl -X POST http://localhost:8080/auth/register \
 ```
 
 Informações mais detalhadas disponíveis em [docs/como-rodar.md](docs/como-rodar.md).
-
-## Banco de dados local com Docker
-
-O projeto possui um arquivo `docker-compose.yml` na raiz para subir um banco PostgreSQL local usado pelo backend.
-
-### Configurações do banco
-
-- Banco: `app_financeiro`
-- Usuário: `postgres`
-- Senha: `1234`
-- Porta: `5432`
-- Imagem Docker: `postgres:16`
-
-### Subir o banco
-
-Na raiz do projeto, execute:
-
-```bash
-docker compose up -d
-```
-
-### Verificar se o banco está rodando
-
-```bash
-docker compose ps
-```
-
-O serviço `postgres` deve aparecer como iniciado. Após alguns segundos, o status de saúde deve ficar como `healthy`.
-
-### Acessar o banco pelo terminal
-
-```bash
-docker exec -it smartbudget-postgres psql -U postgres -d app_financeiro
-```
-
-Para sair do PostgreSQL:
-
-```sql
-\q
-```
-
-### Parar o banco
-
-```bash
-docker compose down
-```
-
-### Apagar os dados locais do banco
-
-Use este comando apenas se quiser remover também o volume com os dados persistidos:
-
-```bash
-docker compose down -v
-```
-
-Depois disso, ao subir novamente com `docker compose up -d`, o banco será recriado do zero.
 
 ## Migrations e versionamento do banco
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,4 @@ services:
 
 volumes:
   postgres_data:
+    name: app-financeiro-pgdata

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: smartbudget-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: app_financeiro
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: "1234"
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d app_financeiro"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/docs/como-rodar.md
+++ b/docs/como-rodar.md
@@ -179,15 +179,6 @@ Regras importantes:
 - Toda alteração de schema deve possuir uma migration versionada
 - Migrations já aplicadas não devem ser editadas depois de enviadas ao repositório
 
-### Usando credenciais diferentes
-
-Se preferir outro usuário, senha ou nome de banco, troque as três variáveis `POSTGRES_*` no `docker run` e reflita as mesmas escolhas em `app-financeiro-back-end/src/main/resources/application.properties`:
-
-```properties
-spring.datasource.url=jdbc:postgresql://localhost:5432/app_financeiro
-spring.datasource.username=postgres
-spring.datasource.password=1234
-```
 
 ## 3. Backend (Spring Boot)
 

--- a/docs/como-rodar.md
+++ b/docs/como-rodar.md
@@ -275,6 +275,30 @@ npm test
 
 ## 6. Problemas comuns
 
+### Connection refused no boot do backend
+
+O container do PostgreSQL provavelmente não está em execução ou ainda não terminou de inicializar.
+
+Confira o status com:
+
+```bash
+docker compose ps
+```
+
+Se o serviço `postgres` não estiver rodando, suba o banco novamente pela raiz do projeto:
+
+```bash
+docker compose up -d
+```
+
+Se o container estiver rodando, mas ainda aparecer erro de conexão, aguarde alguns segundos e verifique os logs:
+
+```bash
+docker compose logs -f postgres
+```
+
+O backend deve conseguir conectar quando o PostgreSQL estiver pronto para aceitar conexões na porta `5432`.
+
 ### port is already allocated ao subir o container
 
 Você já tem um PostgreSQL ocupando a porta `5432`, seja instalado na máquina ou em outro container.

--- a/docs/como-rodar.md
+++ b/docs/como-rodar.md
@@ -254,13 +254,7 @@ npm run dev
 
 - `/login` - tela de login
 - `/register` - tela de cadastro com máscara de CPF e validação no submit
-- `/categorias` - lista todas as categorias do sistema (avalia o usuário logado para mostrar categorias de usuários)
-- `/contas` - lista todas as contas do usuário autenticado
 - `/contas/registrar` - tela de cadastro de conta para o usuário autenticado
-- `/importacoes` - tela de importações de extratos bancarios e notas fiscais
-- `/importacoes/{id}/status` - tela que verifica o status de uma importação, valida se ela pertence ao usuário autenticado
-- `/transacoes/manual` - tela de registro manual de uma transação
-- `/transacoes/{transacaoId}/categoria` - tela de categorização de uma transação que pertence ao usuário autenticado.
 
 Mantenha o backend rodando em paralelo. O frontend faz chamadas para:
 

--- a/docs/como-rodar.md
+++ b/docs/como-rodar.md
@@ -21,11 +21,13 @@ O projeto possui:
 >
 > Não precisa instalar PostgreSQL na máquina: ele vai rodar dentro de um container Docker.
 
-## 1. Banco de dados (via Docker)
+## 1. Banco de dados (via Docker Compose)
 
-A ideia aqui é não poluir a sua máquina com uma instalação local do PostgreSQL. O projeto utiliza um container que já vem com tudo configurado e expõe a porta `5432` no `localhost`, exatamente como o backend espera.
+A ideia aqui é não poluir a sua máquina com uma instalação local do PostgreSQL. O projeto utiliza o arquivo `docker-compose.yml`, localizado na raiz do repositório, para subir um container PostgreSQL já configurado com as credenciais esperadas pelo backend.
 
-### Passo 1 — confirmar que o Docker está rodando
+O banco fica disponível em `localhost:5432` e os dados são mantidos em um volume Docker, então eles não somem ao parar o container.
+
+### Passo 1: confirmar que o Docker está rodando
 
 Antes de qualquer coisa, abra o terminal e rode:
 
@@ -42,37 +44,36 @@ sudo systemctl start docker
 
 Depois tente novamente.
 
-### Passo 2 — subir o container do PostgreSQL
+### Passo 2: subir o PostgreSQL
 
-Esse comando baixa a imagem do PostgreSQL 16, cria um container chamado `app-financeiro-db`, define usuário, senha e banco que o backend usa por padrão e mantém os dados persistidos em um volume chamado `app-financeiro-pgdata`.
-
-Assim, os dados não somem se você derrubar o container.
+Na raiz do projeto, execute:
 
 ```bash
-docker run -d \
-  --name app-financeiro-db \
-  -e POSTGRES_USER=postgres \
-  -e POSTGRES_PASSWORD=1234 \
-  -e POSTGRES_DB=app_financeiro \
-  -p 5432:5432 \
-  -v app-financeiro-pgdata:/var/lib/postgresql/data \
-  postgres:16
+docker compose up -d
 ```
 
-Na primeira vez ele vai baixar a imagem. Você pode confirmar que o container está rodando com:
+Esse comando baixa a imagem do PostgreSQL 16, cria o container definido no `docker-compose.yml` e sobe o banco com as configurações usadas pelo backend:
+
+- Banco: `app_financeiro`
+- Usuário: `postgres`
+- Senha: `1234`
+- Porta: `5432`
+- Container: `smartbudget-postgres`
+
+Você pode confirmar que o container está rodando com:
 
 ```bash
-docker ps
+docker compose ps
 ```
 
-Deve aparecer uma linha do `app-financeiro-db` com a porta `0.0.0.0:5432->5432/tcp`.
+O serviço `postgres` deve aparecer como iniciado. Após alguns segundos, o status de saúde deve ficar como `healthy`.
 
-### Passo 3 — testar a conexão (opcional)
+### Passo 3: testar a conexão opcionalmente
 
 Se quiser entrar no banco e dar uma olhada:
 
 ```bash
-docker exec -it app-financeiro-db psql -U postgres -d app_financeiro
+docker exec -it smartbudget-postgres psql -U postgres -d app_financeiro
 ```
 
 Comandos úteis dentro do `psql`:
@@ -91,15 +92,17 @@ Sai do `psql`.
 
 As tabelas aparecerão depois que o backend subir e o Flyway executar as migrations.
 
-### Gerenciamento do container no dia a dia
+### Gerenciamento do banco no dia a dia
 
 | O que você quer | Comando |
 |---|---|
-| Parar o banco | `docker stop app-financeiro-db` |
-| Voltar a subir | `docker start app-financeiro-db` |
-| Ver logs | `docker logs -f app-financeiro-db` |
-| Apagar o container, mantendo os dados | `docker rm -f app-financeiro-db` |
-| Apagar tudo, inclusive os dados | `docker rm -f app-financeiro-db && docker volume rm app-financeiro-pgdata` |
+| Subir o banco | `docker compose up -d` |
+| Verificar o status | `docker compose ps` |
+| Ver logs | `docker compose logs -f postgres` |
+| Parar o banco | `docker compose down` |
+| Parar e apagar os dados locais | `docker compose down -v` |
+
+Atenção: o comando `docker compose down -v` remove o volume Docker e apaga os dados locais do banco.
 
 ## 2. Versionamento de banco de dados com Flyway
 

--- a/docs/como-rodar.md
+++ b/docs/como-rodar.md
@@ -290,24 +290,6 @@ npm test
 
 ## 6. Problemas comuns
 
-### Connection refused no boot do backend
-
-O container do PostgreSQL provavelmente não está de pé.
-
-Confira com:
-
-```bash
-docker ps
-```
-
-Se não aparecer, rode:
-
-```bash
-docker start app-financeiro-db
-```
-
-Ou refaça o comando `docker run` do passo 2.
-
 ### port is already allocated ao subir o container
 
 Você já tem um PostgreSQL ocupando a porta `5432`, seja instalado na máquina ou em outro container.
@@ -370,60 +352,3 @@ Se mudar de porta, atualize a configuração de CORS no backend.
 O `JWT_SECRET` pode ter mudado entre execuções.
 
 Tokens emitidos antes deixam de valer quando o segredo muda.
-
-## 7. Subindo o banco de dados com Docker
-
-Na raiz do projeto, execute:
-
-```
-docker compose up -d
-```
-
-Esse comando sobe um container PostgreSQL 16 com as configurações esperadas pelo backend.
-
-Configurações do banco:
-
-- Banco: `app_financeiro`
-- Usuário: `postgres`
-- Senha: `1234`
-- Porta: `5432`
-
-Para verificar se o banco está rodando:
-
-```bsh
-docker compose ps
-```
-
-O serviço `postgres` deve estar iniciado. Após alguns segundos, o container deve ficar saudável.
-
-Caso queira acessar o PostgreSQL pelo terminal:
-
-```
-docker exec -it smartbudget-postgres psql -U postgres -d app_financeiro
-```
-
-Para sair:
-
-```sql
-\q
-```
-
-Para parar o container do banco:
-
-```
-docker compose down
-```
-
-aso precise apagar todos os dados locais do banco, execute:
-
-```
-docker compose down -v
-```
-
-Depois suba novamente:
-
-```
-docker compose up -d
-```
-
-Atenção: o comando `docker compose down -v` remove o volume do banco e apaga os dados locais.

--- a/docs/como-rodar.md
+++ b/docs/como-rodar.md
@@ -367,3 +367,60 @@ Se mudar de porta, atualize a configuração de CORS no backend.
 O `JWT_SECRET` pode ter mudado entre execuções.
 
 Tokens emitidos antes deixam de valer quando o segredo muda.
+
+## 7. Subindo o banco de dados com Docker
+
+Na raiz do projeto, execute:
+
+```
+docker compose up -d
+```
+
+Esse comando sobe um container PostgreSQL 16 com as configurações esperadas pelo backend.
+
+Configurações do banco:
+
+- Banco: `app_financeiro`
+- Usuário: `postgres`
+- Senha: `1234`
+- Porta: `5432`
+
+Para verificar se o banco está rodando:
+
+```bsh
+docker compose ps
+```
+
+O serviço `postgres` deve estar iniciado. Após alguns segundos, o container deve ficar saudável.
+
+Caso queira acessar o PostgreSQL pelo terminal:
+
+```
+docker exec -it smartbudget-postgres psql -U postgres -d app_financeiro
+```
+
+Para sair:
+
+```sql
+\q
+```
+
+Para parar o container do banco:
+
+```
+docker compose down
+```
+
+aso precise apagar todos os dados locais do banco, execute:
+
+```
+docker compose down -v
+```
+
+Depois suba novamente:
+
+```
+docker compose up -d
+```
+
+Atenção: o comando `docker compose down -v` remove o volume do banco e apaga os dados locais.


### PR DESCRIPTION
## O que mudou

- Adicionado arquivo `docker-compose.yml` na raiz do projeto para subir um banco PostgreSQL local.
- Configurado PostgreSQL 16 com banco `app_financeiro`, usuário `postgres`, senha `1234` e porta `5432`.
- Adicionado volume persistente para manter os dados locais do banco entre reinicializações.
- Adicionado `healthcheck` para validar se o banco está pronto para uso.
- Atualizada a documentação com instruções para subir, verificar, parar e remover o banco local com Docker Compose.

## Por quê

- Resolve a issue #123.
- Facilita a configuração do ambiente local para desenvolvimento.
- Evita que cada pessoa da equipe precise instalar e configurar o PostgreSQL manualmente.
- Padroniza as credenciais e o nome do banco usados pelo backend.
- Melhora a documentação para novos integrantes conseguirem rodar o projeto com menos atrito.

## Como testar

1. Na raiz do projeto, execute `docker compose up -d`.
2. Verifique se o container foi iniciado com `docker compose ps`.
3. Confirme se o banco está acessível com `docker exec -it smartbudget-postgres psql -U postgres -d app_financeiro`.
4. Dentro do PostgreSQL, saia com `\q`.
5. Acesse a pasta do backend com `cd app-financeiro-back-end`.
6. Execute o backend com `./gradlew bootRun`.
7. No Windows, execute com `gradlew.bat bootRun`.
8. Verifique se a aplicação inicia sem erro de conexão com o banco.
9. Para parar o banco, volte para a raiz do projeto e execute `docker compose down`.

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos (mínimo 3)

- [Risco] Caso o desenvolvedor já tenha outro PostgreSQL rodando localmente na porta `5432`, será necessário parar o serviço local ou alterar a porta exposta no `docker-compose.yml`.
- [Manutenção] O uso do `docker-compose.yml` centraliza a configuração do banco local e reduz divergências de ambiente entre os integrantes da equipe.
- [Teste] O fluxo principal de teste é subir o container com `docker compose up -d`, validar com `docker compose ps` e iniciar o backend para confirmar a conexão com o banco.
- [Manutenção] O volume `postgres_data` mantém os dados persistidos entre reinicializações, evitando perda acidental ao parar o container.
- [Teste] O comando `docker compose down -v` pode ser usado quando for necessário apagar os dados locais e recriar o banco do zero.

Closes #123 