### PR TITLE
Test/162 backend editar excluir transacao

### DIFF
--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/controller/TransacaoEdicaoExclusaoControllerTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/controller/TransacaoEdicaoExclusaoControllerTest.java
@@ -4,6 +4,7 @@ import bcd.appfinanceirobackend.config.JwtAuthFilter;
 import bcd.appfinanceirobackend.config.SecurityConfig;
 import bcd.appfinanceirobackend.dto.transacao.TransacaoRequestDTO;
 import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
+import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
 import bcd.appfinanceirobackend.model.Usuario;
 import bcd.appfinanceirobackend.model.enums.TipoPagamento;
 import bcd.appfinanceirobackend.model.enums.TipoTransacao;
@@ -21,8 +22,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -32,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -145,6 +149,60 @@ class TransacaoEdicaoExclusaoControllerTest {
         }
 
         @Test
+        @DisplayName("Retorna 404 quando transação não existe")
+        void deveRetornar404QuandoTransacaoNaoExiste() throws Exception {
+            when(transacaoService.editar(eq(transacaoId), any(TransacaoRequestDTO.class), any(Usuario.class)))
+                    .thenThrow(new ResourceNotFoundException("Transação não encontrada"));
+
+            mockMvc.perform(put("/transacoes/{transacaoId}", transacaoId)
+                            .with(user(usuarioAutenticado))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(requestValido)))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("Retorna 403 quando transação pertence a outro usuário")
+        void deveRetornar403QuandoTransacaoPertenceAOutroUsuario() throws Exception {
+            when(transacaoService.editar(eq(transacaoId), any(TransacaoRequestDTO.class), any(Usuario.class)))
+                    .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Acesso negado a essa transação"));
+
+            mockMvc.perform(put("/transacoes/{transacaoId}", transacaoId)
+                            .with(user(usuarioAutenticado))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(requestValido)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("Retorna 403 quando nova conta pertence a outro usuário")
+        void deveRetornar403QuandoNovaContaPertenceAOutroUsuario() throws Exception {
+            when(transacaoService.editar(eq(transacaoId), any(TransacaoRequestDTO.class), any(Usuario.class)))
+                    .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Acesso negado a esta conta"));
+
+            mockMvc.perform(put("/transacoes/{transacaoId}", transacaoId)
+                            .with(user(usuarioAutenticado))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(requestValido)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("Retorna 400 quando payload é inválido")
+        void deveRetornar400QuandoPayloadInvalido() throws Exception {
+            when(transacaoService.editar(eq(transacaoId), any(TransacaoRequestDTO.class), any(Usuario.class)))
+                    .thenThrow(new IllegalArgumentException("Campos obrigatórios não informados"));
+
+            requestValido.setFormaPagamento(null);
+
+            mockMvc.perform(put("/transacoes/{transacaoId}", transacaoId)
+                            .with(user(usuarioAutenticado))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(requestValido)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
         @DisplayName("Retorna 401 ou 403 quando usuário não está autenticado")
         void deveRetornar401Ou403QuandoNaoAutenticado() throws Exception {
             mockMvc.perform(put("/transacoes/{transacaoId}", transacaoId)
@@ -181,6 +239,28 @@ class TransacaoEdicaoExclusaoControllerTest {
 
             verify(transacaoService).excluir(eq(transacaoId), usuarioCaptor.capture());
             assertThat(usuarioCaptor.getValue()).isEqualTo(usuarioAutenticado);
+        }
+
+        @Test
+        @DisplayName("Retorna 404 quando transação não existe")
+        void deveRetornar404QuandoTransacaoNaoExiste() throws Exception {
+            doThrow(new ResourceNotFoundException("Transação não encontrada"))
+                    .when(transacaoService).excluir(eq(transacaoId), any(Usuario.class));
+
+            mockMvc.perform(delete("/transacoes/{transacaoId}", transacaoId)
+                            .with(user(usuarioAutenticado)))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("Retorna 403 quando transação pertence a outro usuário")
+        void deveRetornar403QuandoTransacaoPertenceAOutroUsuario() throws Exception {
+            doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Acesso negado a essa transação"))
+                    .when(transacaoService).excluir(eq(transacaoId), any(Usuario.class));
+
+            mockMvc.perform(delete("/transacoes/{transacaoId}", transacaoId)
+                            .with(user(usuarioAutenticado)))
+                    .andExpect(status().isForbidden());
         }
 
         @Test

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/controller/TransacaoEdicaoExclusaoControllerTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/controller/TransacaoEdicaoExclusaoControllerTest.java
@@ -1,0 +1,195 @@
+package bcd.appfinanceirobackend.controller;
+
+import bcd.appfinanceirobackend.config.JwtAuthFilter;
+import bcd.appfinanceirobackend.config.SecurityConfig;
+import bcd.appfinanceirobackend.dto.transacao.TransacaoRequestDTO;
+import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.TipoPagamento;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import bcd.appfinanceirobackend.repository.UsuarioRepository;
+import bcd.appfinanceirobackend.security.JwtUtil;
+import bcd.appfinanceirobackend.service.TransacaoService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TransacaoController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+@DisplayName("TransacaoController - editar e excluir")
+class TransacaoEdicaoExclusaoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TransacaoService transacaoService;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private Usuario usuarioAutenticado;
+    private UUID transacaoId;
+    private TransacaoRequestDTO requestValido;
+    private TransacaoResponseDTO responseValido;
+
+    @BeforeEach
+    void setUp() {
+        usuarioAutenticado = new Usuario();
+        usuarioAutenticado.setId(UUID.randomUUID());
+        usuarioAutenticado.setNome("João Silva");
+        usuarioAutenticado.setEmail("joao@email.com");
+        usuarioAutenticado.setSenha("hash");
+        usuarioAutenticado.setCpf("12345678900");
+
+        transacaoId = UUID.randomUUID();
+
+        requestValido = new TransacaoRequestDTO();
+        requestValido.setValor(new BigDecimal("250.00"));
+        requestValido.setData(LocalDate.of(2026, 6, 1));
+        requestValido.setDescricao("Transação atualizada");
+        requestValido.setTipoTransacao(TipoTransacao.DEBITO);
+        requestValido.setFormaPagamento(TipoPagamento.PIX);
+        requestValido.setContaId(UUID.randomUUID());
+        requestValido.setCategoriaId(UUID.randomUUID());
+
+        responseValido = new TransacaoResponseDTO();
+        responseValido.setTransacaoId(transacaoId);
+        responseValido.setValor(requestValido.getValor());
+        responseValido.setData(requestValido.getData());
+        responseValido.setDescricao(requestValido.getDescricao());
+        responseValido.setTipoTransacao(requestValido.getTipoTransacao());
+        responseValido.setFormaPagamento(requestValido.getFormaPagamento());
+        responseValido.setContaId(requestValido.getContaId());
+        responseValido.setCategoriaId(requestValido.getCategoriaId());
+        responseValido.setCategorizada(true);
+    }
+
+    @Nested
+    @DisplayName("PUT /transacoes/{transacaoId}")
+    class EditarTransacao {
+
+        @Test
+        @DisplayName("Retorna 200 com transação editada")
+        void deveRetornar200ComTransacaoEditada() throws Exception {
+            when(transacaoService.editar(eq(transacaoId), any(TransacaoRequestDTO.class), any(Usuario.class)))
+                    .thenReturn(responseValido);
+
+            mockMvc.perform(put("/transacoes/{transacaoId}", transacaoId)
+                            .with(user(usuarioAutenticado))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(requestValido)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.transacaoId").value(transacaoId.toString()))
+                    .andExpect(jsonPath("$.valor").value(250.00))
+                    .andExpect(jsonPath("$.data").value("2026-06-01"))
+                    .andExpect(jsonPath("$.descricao").value("Transação atualizada"))
+                    .andExpect(jsonPath("$.tipoTransacao").value("DEBITO"))
+                    .andExpect(jsonPath("$.formaPagamento").value("PIX"))
+                    .andExpect(jsonPath("$.contaId").value(requestValido.getContaId().toString()))
+                    .andExpect(jsonPath("$.categoriaId").value(requestValido.getCategoriaId().toString()))
+                    .andExpect(jsonPath("$.categorizada").value(true));
+        }
+
+        @Test
+        @DisplayName("Delega edição para o service usando id, request e usuário autenticado")
+        void deveDelegarParaServiceComIdRequestEUsuario() throws Exception {
+            ArgumentCaptor<TransacaoRequestDTO> dtoCaptor = ArgumentCaptor.forClass(TransacaoRequestDTO.class);
+            ArgumentCaptor<Usuario> usuarioCaptor = ArgumentCaptor.forClass(Usuario.class);
+
+            when(transacaoService.editar(eq(transacaoId), any(TransacaoRequestDTO.class), any(Usuario.class)))
+                    .thenReturn(responseValido);
+
+            mockMvc.perform(put("/transacoes/{transacaoId}", transacaoId)
+                            .with(user(usuarioAutenticado))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(requestValido)))
+                    .andExpect(status().isOk());
+
+            verify(transacaoService).editar(eq(transacaoId), dtoCaptor.capture(), usuarioCaptor.capture());
+            assertThat(dtoCaptor.getValue().getValor()).isEqualByComparingTo(requestValido.getValor());
+            assertThat(dtoCaptor.getValue().getContaId()).isEqualTo(requestValido.getContaId());
+            assertThat(usuarioCaptor.getValue()).isEqualTo(usuarioAutenticado);
+        }
+
+        @Test
+        @DisplayName("Retorna 401 ou 403 quando usuário não está autenticado")
+        void deveRetornar401Ou403QuandoNaoAutenticado() throws Exception {
+            mockMvc.perform(put("/transacoes/{transacaoId}", transacaoId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(mapper.writeValueAsString(requestValido)))
+                    .andExpect(status().is4xxClientError());
+
+            verify(transacaoService, never()).editar(any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /transacoes/{transacaoId}")
+    class ExcluirTransacao {
+
+        @Test
+        @DisplayName("Retorna 204 ao excluir transação")
+        void deveRetornar204AoExcluirTransacao() throws Exception {
+            doNothing().when(transacaoService).excluir(eq(transacaoId), any(Usuario.class));
+
+            mockMvc.perform(delete("/transacoes/{transacaoId}", transacaoId)
+                            .with(user(usuarioAutenticado)))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("Delega exclusão para o service usando id e usuário autenticado")
+        void deveDelegarParaServiceComIdEUsuario() throws Exception {
+            ArgumentCaptor<Usuario> usuarioCaptor = ArgumentCaptor.forClass(Usuario.class);
+
+            mockMvc.perform(delete("/transacoes/{transacaoId}", transacaoId)
+                            .with(user(usuarioAutenticado)))
+                    .andExpect(status().isNoContent());
+
+            verify(transacaoService).excluir(eq(transacaoId), usuarioCaptor.capture());
+            assertThat(usuarioCaptor.getValue()).isEqualTo(usuarioAutenticado);
+        }
+
+        @Test
+        @DisplayName("Retorna 401 ou 403 quando usuário não está autenticado")
+        void deveRetornar401Ou403QuandoNaoAutenticado() throws Exception {
+            mockMvc.perform(delete("/transacoes/{transacaoId}", transacaoId))
+                    .andExpect(status().is4xxClientError());
+
+            verify(transacaoService, never()).excluir(any(), any());
+        }
+    }
+}

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/TransacaoEdicaoExclusaoServiceTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/TransacaoEdicaoExclusaoServiceTest.java
@@ -1,0 +1,302 @@
+package bcd.appfinanceirobackend.service;
+
+import bcd.appfinanceirobackend.dto.transacao.TransacaoRequestDTO;
+import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
+import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
+import bcd.appfinanceirobackend.model.Categoria;
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.TipoPagamento;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import bcd.appfinanceirobackend.repository.CategoriaRepository;
+import bcd.appfinanceirobackend.repository.ContaRepository;
+import bcd.appfinanceirobackend.repository.TransacaoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TransacaoService - editar e excluir")
+class TransacaoEdicaoExclusaoServiceTest {
+
+    @Mock
+    private TransacaoRepository transacaoRepository;
+
+    @Mock
+    private ContaRepository contaRepository;
+
+    @Mock
+    private CategoriaRepository categoriaRepository;
+
+    @InjectMocks
+    private TransacaoService transacaoService;
+
+    private Usuario usuarioDono;
+    private Usuario outroUsuario;
+    private Conta contaAtual;
+    private Conta novaConta;
+    private Transacao transacao;
+    private TransacaoRequestDTO dtoValido;
+
+    @BeforeEach
+    void setUp() {
+        usuarioDono = new Usuario();
+        usuarioDono.setId(UUID.randomUUID());
+        usuarioDono.setNome("João Silva");
+        usuarioDono.setEmail("joao@email.com");
+        usuarioDono.setSenha("hash");
+        usuarioDono.setCpf("12345678900");
+
+        outroUsuario = new Usuario();
+        outroUsuario.setId(UUID.randomUUID());
+        outroUsuario.setNome("Outro Usuário");
+        outroUsuario.setEmail("outro@email.com");
+        outroUsuario.setSenha("hash");
+        outroUsuario.setCpf("99988877766");
+
+        contaAtual = new Conta();
+        contaAtual.setId(UUID.randomUUID());
+        contaAtual.setNome("Conta atual");
+        contaAtual.setUsuario(usuarioDono);
+
+        novaConta = new Conta();
+        novaConta.setId(UUID.randomUUID());
+        novaConta.setNome("Nova conta");
+        novaConta.setUsuario(usuarioDono);
+
+        transacao = new Transacao();
+        transacao.setId(UUID.randomUUID());
+        transacao.setConta(contaAtual);
+        transacao.setValor(new BigDecimal("100.00"));
+        transacao.setData(LocalDate.of(2026, 5, 30));
+        transacao.setDescricao("Descrição antiga");
+        transacao.setTipo(TipoTransacao.DEBITO);
+        transacao.setFormaPagamento(TipoPagamento.PIX);
+        transacao.setCategorizada(false);
+        transacao.setFutura(false);
+
+        dtoValido = new TransacaoRequestDTO();
+        dtoValido.setValor(new BigDecimal("250.00"));
+        dtoValido.setData(LocalDate.now());
+        dtoValido.setDescricao("Descrição atualizada");
+        dtoValido.setTipoTransacao(TipoTransacao.CREDITO);
+        dtoValido.setFormaPagamento(TipoPagamento.PIX);
+        dtoValido.setContaId(novaConta.getId());
+    }
+
+    @Nested
+    @DisplayName("Edição")
+    class Edicao {
+
+        @Test
+        @DisplayName("Edita transação própria com dados válidos")
+        void deveEditarTransacaoPropriaComDadosValidos() {
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.of(transacao));
+            when(contaRepository.findById(novaConta.getId())).thenReturn(Optional.of(novaConta));
+            when(transacaoRepository.save(any(Transacao.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            TransacaoResponseDTO response = transacaoService.editar(transacao.getId(), dtoValido, usuarioDono);
+
+            assertThat(response.getTransacaoId()).isEqualTo(transacao.getId());
+            assertThat(response.getValor()).isEqualByComparingTo(dtoValido.getValor());
+            assertThat(response.getData()).isEqualTo(dtoValido.getData());
+            assertThat(response.getDescricao()).isEqualTo(dtoValido.getDescricao());
+            assertThat(response.getTipoTransacao()).isEqualTo(dtoValido.getTipoTransacao());
+            assertThat(response.getFormaPagamento()).isEqualTo(dtoValido.getFormaPagamento());
+            assertThat(response.getContaId()).isEqualTo(novaConta.getId());
+        }
+
+        @Test
+        @DisplayName("Persiste a transação editada")
+        void devePersistirTransacaoEditada() {
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.of(transacao));
+            when(contaRepository.findById(novaConta.getId())).thenReturn(Optional.of(novaConta));
+            when(transacaoRepository.save(any(Transacao.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            ArgumentCaptor<Transacao> captor = ArgumentCaptor.forClass(Transacao.class);
+
+            transacaoService.editar(transacao.getId(), dtoValido, usuarioDono);
+
+            verify(transacaoRepository).save(captor.capture());
+            assertThat(captor.getValue().getConta()).isEqualTo(novaConta);
+            assertThat(captor.getValue().getValor()).isEqualByComparingTo("250.00");
+            assertThat(captor.getValue().getDescricao()).isEqualTo("Descrição atualizada");
+        }
+
+        @Test
+        @DisplayName("Remove categoria quando categoriaId é nulo")
+        void deveRemoverCategoriaQuandoCategoriaIdNulo() {
+            Categoria categoriaAntiga = new Categoria();
+            categoriaAntiga.setId(UUID.randomUUID());
+            categoriaAntiga.setPadrao(true);
+
+            transacao.setCategoria(categoriaAntiga);
+            transacao.setCategorizada(true);
+            dtoValido.setCategoriaId(null);
+
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.of(transacao));
+            when(contaRepository.findById(novaConta.getId())).thenReturn(Optional.of(novaConta));
+            when(transacaoRepository.save(any(Transacao.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            TransacaoResponseDTO response = transacaoService.editar(transacao.getId(), dtoValido, usuarioDono);
+
+            assertThat(response.getCategoriaId()).isNull();
+            assertThat(response.isCategorizada()).isFalse();
+            assertThat(transacao.getCategoria()).isNull();
+            assertThat(transacao.getCategorizada()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Edita categoria quando categoriaId é informado")
+        void deveEditarCategoriaQuandoCategoriaIdInformado() {
+            Categoria categoria = new Categoria();
+            categoria.setId(UUID.randomUUID());
+            categoria.setNome("Alimentação");
+            categoria.setPadrao(true);
+
+            dtoValido.setCategoriaId(categoria.getId());
+
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.of(transacao));
+            when(contaRepository.findById(novaConta.getId())).thenReturn(Optional.of(novaConta));
+            when(categoriaRepository.findById(categoria.getId())).thenReturn(Optional.of(categoria));
+            when(transacaoRepository.save(any(Transacao.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            TransacaoResponseDTO response = transacaoService.editar(transacao.getId(), dtoValido, usuarioDono);
+
+            assertThat(response.getCategoriaId()).isEqualTo(categoria.getId());
+            assertThat(response.isCategorizada()).isTrue();
+            assertThat(transacao.getCategoria()).isEqualTo(categoria);
+        }
+
+        @Test
+        @DisplayName("Lança 404 quando transação não existe")
+        void deveLancarNotFoundQuandoTransacaoNaoExiste() {
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> transacaoService.editar(transacao.getId(), dtoValido, usuarioDono))
+                    .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("Transação não encontrada");
+
+            verifyNoInteractions(contaRepository, categoriaRepository);
+            verify(transacaoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Lança 403 quando transação pertence a outro usuário")
+        void deveLancarForbiddenQuandoTransacaoPertenceAOutroUsuario() {
+            contaAtual.setUsuario(outroUsuario);
+
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.of(transacao));
+
+            assertThatThrownBy(() -> transacaoService.editar(transacao.getId(), dtoValido, usuarioDono))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Acesso negado a essa transação");
+
+            verifyNoInteractions(contaRepository, categoriaRepository);
+            verify(transacaoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Lança 403 quando nova conta pertence a outro usuário")
+        void deveLancarForbiddenQuandoNovaContaPertenceAOutroUsuario() {
+            novaConta.setUsuario(outroUsuario);
+
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.of(transacao));
+            when(contaRepository.findById(novaConta.getId())).thenReturn(Optional.of(novaConta));
+
+            assertThatThrownBy(() -> transacaoService.editar(transacao.getId(), dtoValido, usuarioDono))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Acesso negado a esta conta");
+
+            verify(transacaoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Lança exceção quando valor é inválido")
+        void deveLancarExcecaoQuandoValorInvalido() {
+            dtoValido.setValor(BigDecimal.ZERO);
+
+            assertThatThrownBy(() -> transacaoService.editar(transacao.getId(), dtoValido, usuarioDono))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("O valor informado deve ser maior que zero");
+
+            verify(transacaoRepository, never()).findById(any());
+            verify(transacaoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Lança exceção quando formaPagamento é nula")
+        void deveLancarExcecaoQuandoFormaPagamentoNula() {
+            dtoValido.setFormaPagamento(null);
+
+            assertThatThrownBy(() -> transacaoService.editar(transacao.getId(), dtoValido, usuarioDono))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Campos obrigatórios não informados");
+
+            verify(transacaoRepository, never()).findById(any());
+            verify(transacaoRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Exclusão")
+    class Exclusao {
+
+        @Test
+        @DisplayName("Exclui transação própria")
+        void deveExcluirTransacaoPropria() {
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.of(transacao));
+
+            transacaoService.excluir(transacao.getId(), usuarioDono);
+
+            verify(transacaoRepository).delete(transacao);
+        }
+
+        @Test
+        @DisplayName("Lança 404 quando transação não existe")
+        void deveLancarNotFoundQuandoTransacaoNaoExiste() {
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> transacaoService.excluir(transacao.getId(), usuarioDono))
+                    .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("Transação não encontrada");
+
+            verify(transacaoRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("Lança 403 quando transação pertence a outro usuário")
+        void deveLancarForbiddenQuandoTransacaoPertenceAOutroUsuario() {
+            contaAtual.setUsuario(outroUsuario);
+
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.of(transacao));
+
+            assertThatThrownBy(() -> transacaoService.excluir(transacao.getId(), usuarioDono))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Acesso negado a essa transação");
+
+            verify(transacaoRepository, never()).delete(any());
+        }
+    }
+}

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/TransacaoEdicaoExclusaoServiceTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/TransacaoEdicaoExclusaoServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
@@ -255,6 +256,29 @@ class TransacaoEdicaoExclusaoServiceTest {
                     .hasMessageContaining("Campos obrigatórios não informados");
 
             verify(transacaoRepository, never()).findById(any());
+            verify(transacaoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Lança 403 quando categoria personalizada pertence a outro usuário")
+        void deveLancarForbiddenQuandoCategoriaPersonalizadaPertenceAOutroUsuario() {
+            Categoria categoriaDeOutroUsuario = new Categoria();
+            categoriaDeOutroUsuario.setId(UUID.randomUUID());
+            categoriaDeOutroUsuario.setNome("Categoria privada");
+            categoriaDeOutroUsuario.setPadrao(false);
+            categoriaDeOutroUsuario.setUsuario(outroUsuario);
+
+            dtoValido.setCategoriaId(categoriaDeOutroUsuario.getId());
+
+            when(transacaoRepository.findById(transacao.getId())).thenReturn(Optional.of(transacao));
+            when(contaRepository.findById(novaConta.getId())).thenReturn(Optional.of(novaConta));
+            when(categoriaRepository.findById(categoriaDeOutroUsuario.getId()))
+                    .thenReturn(Optional.of(categoriaDeOutroUsuario));
+
+            assertThatThrownBy(() -> transacaoService.editar(transacao.getId(), dtoValido, usuarioDono))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasFieldOrPropertyWithValue("statusCode", HttpStatus.FORBIDDEN);
+
             verify(transacaoRepository, never()).save(any());
         }
     }


### PR DESCRIPTION
## O que mudou

- Adicionados testes unitários para edição de transações no `TransacaoService`.
- Adicionados testes unitários para exclusão de transações no `TransacaoService`.
- Adicionados testes de controller para os endpoints:
  - `PUT /transacoes/{transacaoId}`
  - `DELETE /transacoes/{transacaoId}`
- Cobertos cenários de sucesso, transação inexistente, acesso a transação de outro usuário, conta de outro usuário e payload inválido.

## Por quê

- Implementa a issue #162.
- A edição e exclusão de transações já foram implementadas, mas ainda precisavam de cobertura automatizada.
- Como esses fluxos alteram dados financeiros, os testes ajudam a evitar regressões em regras de autorização e validação.

## Como testar

1. Entre na pasta do backend:

   ```bash
   cd app-financeiro-back-end
   ```

2. Rode os testes específicos da issue:

   ```bash
   ./gradlew test --tests "bcd.appfinanceirobackend.service.TransacaoEdicaoExclusaoServiceTest" \
     --tests "bcd.appfinanceirobackend.controller.TransacaoEdicaoExclusaoControllerTest"
   ```

3. Rode a suíte completa do backend:

   ```bash
   ./gradlew test
   ```

4. Verifique se todos os testes passam sem falhas.

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos (mínimo 3)

- [Risco] Os testes cobrem bloqueio de edição e exclusão de transações pertencentes a outro usuário, reduzindo risco de vazamento ou alteração indevida de dados financeiros.
- [Risco] A edição também valida o cenário em que a nova conta informada pertence a outro usuário, garantindo que a transação não possa ser associada a uma conta indevida.
- [Manutenção] Os testes foram separados por camada, com cobertura no service para regra de negócio e no controller para status HTTP e delegação correta.
- [Teste] Foram adicionados cenários de sucesso para editar e excluir transações.
- [Teste] Foram adicionados cenários de erro para transação inexistente, usuário não autenticado, payload inválido e tentativa de acesso a dados de outro usuário.

closes #162 