### PR TITLE
test(#158): testes de resumo por pagamento e gestão de contas (direto na dev)

### DIFF
--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/ContaServiceTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/ContaServiceTest.java
@@ -2,10 +2,12 @@ package bcd.appfinanceirobackend.service;
 
 import bcd.appfinanceirobackend.dto.conta.ContaRequestDTO;
 import bcd.appfinanceirobackend.dto.conta.ContaResponseDTO;
+import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
 import bcd.appfinanceirobackend.model.Conta;
 import bcd.appfinanceirobackend.model.Usuario;
 import bcd.appfinanceirobackend.model.enums.TipoConta;
 import bcd.appfinanceirobackend.repository.ContaRepository;
+import bcd.appfinanceirobackend.repository.TransacaoRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -15,8 +17,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,6 +38,9 @@ class ContaServiceTest {
 
     @Mock
     private ContaRepository contaRepository;
+
+    @Mock
+    private TransacaoRepository transacaoRepository;
 
     @InjectMocks
     private ContaService contaService;
@@ -255,6 +264,73 @@ class ContaServiceTest {
             assertThat(response.getTipoConta()).isEqualTo(conta.getTipoConta());
             assertThat(response.getBanco()).isEqualTo(conta.getBanco());
             assertThat(response.getDescricao()).isEqualTo(conta.getDescricao());
+        }
+    }
+
+    @Nested
+    @DisplayName("Remoção de conta")
+    class RemocaoConta {
+
+        @Test
+        @DisplayName("Remove conta própria sem transações vinculadas")
+        void deveRemoverContaPropriaSemTransacoes() {
+            Conta conta = criarConta("Conta Corrente", TipoConta.CORRENTE, "Banco A", "Principal");
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(transacaoRepository.existsByContaId(conta.getId())).thenReturn(false);
+
+            contaService.removerConta(usuarioAutenticado, conta.getId());
+
+            verify(contaRepository).delete(conta);
+        }
+
+        @Test
+        @DisplayName("Lança 404 quando a conta não existe")
+        void deveLancarNotFoundQuandoContaNaoExiste() {
+            UUID id = UUID.randomUUID();
+            when(contaRepository.findById(id)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> contaService.removerConta(usuarioAutenticado, id))
+                    .isInstanceOf(ResourceNotFoundException.class)
+                    .hasMessageContaining("Conta não encontrada");
+
+            verify(contaRepository, never()).delete(any(Conta.class));
+            verifyNoInteractions(transacaoRepository);
+        }
+
+        @Test
+        @DisplayName("Lança 403 ao tentar remover conta de outro usuário")
+        void deveLancarForbiddenQuandoContaDeOutroUsuario() {
+            Usuario outroUsuario = new Usuario();
+            outroUsuario.setId(UUID.randomUUID());
+
+            Conta conta = criarConta("Conta Alheia", TipoConta.CORRENTE, "Banco B", "De outro");
+            conta.setUsuario(outroUsuario);
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+
+            assertThatThrownBy(() -> contaService.removerConta(usuarioAutenticado, conta.getId()))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Acesso negado a esta conta")
+                    .extracting(excecao -> ((ResponseStatusException) excecao).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN);
+
+            verify(contaRepository, never()).delete(any(Conta.class));
+            verify(transacaoRepository, never()).existsByContaId(any());
+        }
+
+        @Test
+        @DisplayName("Lança 409 ao tentar remover conta com transações vinculadas")
+        void deveLancarConflictQuandoContaPossuiTransacoes() {
+            Conta conta = criarConta("Conta Movimentada", TipoConta.CORRENTE, "Banco C", "Com histórico");
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(transacaoRepository.existsByContaId(conta.getId())).thenReturn(true);
+
+            assertThatThrownBy(() -> contaService.removerConta(usuarioAutenticado, conta.getId()))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .hasMessageContaining("Não é possível remover uma conta com transações vinculadas")
+                    .extracting(excecao -> ((ResponseStatusException) excecao).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+
+            verify(contaRepository, never()).delete(any(Conta.class));
         }
     }
 

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/ResumoServiceTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/ResumoServiceTest.java
@@ -1,0 +1,204 @@
+package bcd.appfinanceirobackend.service;
+
+import bcd.appfinanceirobackend.dto.resumo.GrupoPagamentoDTO;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.TipoPagamento;
+import bcd.appfinanceirobackend.repository.TransacaoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ResumoService - agruparFormaPagamento")
+class ResumoServiceTest {
+
+    @Mock
+    private TransacaoRepository transacaoRepository;
+
+    @InjectMocks
+    private ResumoService resumoService;
+
+    private Usuario usuario;
+
+    @BeforeEach
+    void setUp() {
+        usuario = new Usuario();
+        usuario.setId(UUID.randomUUID());
+        usuario.setNome("João Silva");
+        usuario.setEmail("joao@email.com");
+    }
+
+    private Transacao transacao(TipoPagamento formaPagamento, String valor) {
+        Transacao transacao = new Transacao();
+        transacao.setFormaPagamento(formaPagamento);
+        transacao.setValor(new BigDecimal(valor));
+        return transacao;
+    }
+
+    private GrupoPagamentoDTO grupoPor(List<GrupoPagamentoDTO> grupos, TipoPagamento forma) {
+        return grupos.stream()
+                .filter(grupo -> grupo.getFormaPagamento() == forma)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @Nested
+    @DisplayName("Usuário inválido")
+    class UsuarioInvalido {
+
+        @Test
+        @DisplayName("Lança AccessDenied quando o usuário é nulo")
+        void deveLancarQuandoUsuarioNulo() {
+            assertThatThrownBy(() -> resumoService.agruparFormaPagamento(null))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessageContaining("Usuário autenticado não encontrado");
+
+            verifyNoInteractions(transacaoRepository);
+        }
+
+        @Test
+        @DisplayName("Lança AccessDenied quando o usuário não possui id")
+        void deveLancarQuandoUsuarioSemId() {
+            Usuario semId = new Usuario();
+
+            assertThatThrownBy(() -> resumoService.agruparFormaPagamento(semId))
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verifyNoInteractions(transacaoRepository);
+        }
+    }
+
+    @Nested
+    @DisplayName("Sem dados relevantes")
+    class SemDados {
+
+        @Test
+        @DisplayName("Retorna lista vazia quando o usuário não possui transações")
+        void deveRetornarVazioSemTransacoes() {
+            when(transacaoRepository.findAllByContaUsuarioId(usuario.getId()))
+                    .thenReturn(List.of());
+
+            assertThat(resumoService.agruparFormaPagamento(usuario)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Retorna lista vazia quando o total geral é zero")
+        void deveRetornarVazioQuandoTotalGeralZero() {
+            when(transacaoRepository.findAllByContaUsuarioId(usuario.getId()))
+                    .thenReturn(List.of(transacao(TipoPagamento.PIX, "0")));
+
+            assertThat(resumoService.agruparFormaPagamento(usuario)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Agrupamento por forma de pagamento")
+    class Agrupamento {
+
+        @Test
+        @DisplayName("Calcula total, quantidade e percentual de cada grupo")
+        void deveCalcularTotaisPorGrupo() {
+            when(transacaoRepository.findAllByContaUsuarioId(usuario.getId()))
+                    .thenReturn(List.of(
+                            transacao(TipoPagamento.PIX, "100.00"),
+                            transacao(TipoPagamento.PIX, "50.00"),
+                            transacao(TipoPagamento.DINHEIRO, "50.00")
+                    ));
+
+            List<GrupoPagamentoDTO> grupos = resumoService.agruparFormaPagamento(usuario);
+
+            assertThat(grupos).hasSize(2);
+
+            GrupoPagamentoDTO pix = grupoPor(grupos, TipoPagamento.PIX);
+            assertThat(pix.getQuantidade()).isEqualTo(2);
+            assertThat(pix.getTotal()).isEqualByComparingTo(new BigDecimal("150.00"));
+            assertThat(pix.getPercentual()).isEqualByComparingTo(new BigDecimal("75.00"));
+            assertThat(pix.getRotulo()).isEqualTo("Pix");
+
+            GrupoPagamentoDTO dinheiro = grupoPor(grupos, TipoPagamento.DINHEIRO);
+            assertThat(dinheiro.getQuantidade()).isEqualTo(1);
+            assertThat(dinheiro.getTotal()).isEqualByComparingTo(new BigDecimal("50.00"));
+            assertThat(dinheiro.getPercentual()).isEqualByComparingTo(new BigDecimal("25.00"));
+            assertThat(dinheiro.getRotulo()).isEqualTo("Dinheiro");
+        }
+
+        @Test
+        @DisplayName("Soma dos percentuais dos grupos fecha em 100")
+        void deveFecharPercentualEmCem() {
+            when(transacaoRepository.findAllByContaUsuarioId(usuario.getId()))
+                    .thenReturn(List.of(
+                            transacao(TipoPagamento.PIX, "100.00"),
+                            transacao(TipoPagamento.DINHEIRO, "50.00"),
+                            transacao(TipoPagamento.BOLETO, "50.00")
+                    ));
+
+            List<GrupoPagamentoDTO> grupos = resumoService.agruparFormaPagamento(usuario);
+
+            BigDecimal somaPercentual = grupos.stream()
+                    .map(GrupoPagamentoDTO::getPercentual)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+            assertThat(somaPercentual).isEqualByComparingTo(new BigDecimal("100.00"));
+        }
+
+        @Test
+        @DisplayName("Agrupa transações sem forma de pagamento como \"Não informado\"")
+        void deveAgruparSemFormaComoNaoInformado() {
+            when(transacaoRepository.findAllByContaUsuarioId(usuario.getId()))
+                    .thenReturn(List.of(
+                            transacao(null, "30.00"),
+                            transacao(TipoPagamento.PIX, "70.00")
+                    ));
+
+            List<GrupoPagamentoDTO> grupos = resumoService.agruparFormaPagamento(usuario);
+
+            GrupoPagamentoDTO naoInformado = grupos.stream()
+                    .filter(grupo -> grupo.getFormaPagamento() == null)
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(naoInformado.getRotulo()).isEqualTo("Não informado");
+            assertThat(naoInformado.getQuantidade()).isEqualTo(1);
+            assertThat(naoInformado.getTotal()).isEqualByComparingTo(new BigDecimal("30.00"));
+            assertThat(naoInformado.getPercentual()).isEqualByComparingTo(new BigDecimal("30.00"));
+        }
+
+        @Test
+        @DisplayName("Mapeia o rótulo de cada forma de pagamento")
+        void deveMapearRotulosDeCadaForma() {
+            when(transacaoRepository.findAllByContaUsuarioId(usuario.getId()))
+                    .thenReturn(List.of(
+                            transacao(TipoPagamento.PIX, "10.00"),
+                            transacao(TipoPagamento.CARTAO_DEBITO, "10.00"),
+                            transacao(TipoPagamento.CARTAO_CREDITO, "10.00"),
+                            transacao(TipoPagamento.DINHEIRO, "10.00"),
+                            transacao(TipoPagamento.BOLETO, "10.00"),
+                            transacao(TipoPagamento.TED_DOC, "10.00")
+                    ));
+
+            List<GrupoPagamentoDTO> grupos = resumoService.agruparFormaPagamento(usuario);
+
+            assertThat(grupos)
+                    .extracting(GrupoPagamentoDTO::getRotulo)
+                    .containsExactlyInAnyOrder(
+                            "Pix", "Cartão de débito", "Cartão de crédito",
+                            "Dinheiro", "Boleto", "TED/DOC");
+        }
+    }
+}

--- a/app-financeiro-front-end/src/components/resumo/ResumoFormaPagamento.test.tsx
+++ b/app-financeiro-front-end/src/components/resumo/ResumoFormaPagamento.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ResumoFormaPagamento from './ResumoFormaPagamento';
+
+const { mockBuscarResumoPorPagamento, mockObterMensagemErroApi } = vi.hoisted(() => ({
+  mockBuscarResumoPorPagamento: vi.fn(),
+  mockObterMensagemErroApi: vi.fn((_erro: unknown, fallback: string) => fallback),
+}));
+
+vi.mock('../../services/api', () => ({
+  buscarResumoPorPagamento: mockBuscarResumoPorPagamento,
+  obterMensagemErroApi: mockObterMensagemErroApi,
+}));
+
+describe('ResumoFormaPagamento (Issue #158)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockObterMensagemErroApi.mockImplementation((_erro: unknown, fallback: string) => fallback);
+  });
+
+  it('exibe o estado de carregamento enquanto a API não responde', () => {
+    mockBuscarResumoPorPagamento.mockReturnValue(new Promise(() => {}));
+
+    render(<ResumoFormaPagamento />);
+
+    expect(
+      screen.getByText('Carregando resumo por forma de pagamento...'),
+    ).toBeInTheDocument();
+  });
+
+  it('exibe o estado vazio quando não há dados de resumo', async () => {
+    mockBuscarResumoPorPagamento.mockResolvedValue([]);
+
+    render(<ResumoFormaPagamento />);
+
+    expect(await screen.findByText('Nenhum resumo disponível')).toBeInTheDocument();
+  });
+
+  it('exibe mensagem de erro quando a chamada do resumo falha', async () => {
+    mockBuscarResumoPorPagamento.mockRejectedValue(new Error('falha'));
+
+    render(<ResumoFormaPagamento />);
+
+    expect(
+      await screen.findByText('Não foi possível carregar o resumo por forma de pagamento.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('renderiza forma de pagamento, total, quantidade e percentual', async () => {
+    mockBuscarResumoPorPagamento.mockResolvedValue([
+      { formaPagamento: 'PIX', total: 1500.5, quantidade: 2, percentual: 75 },
+      { formaPagamento: 'DINHEIRO', total: 400, quantidade: 1, percentual: 20 },
+      { formaPagamento: null, total: 100, quantidade: 3, percentual: 5 },
+    ]);
+
+    render(<ResumoFormaPagamento />);
+
+    // forma de pagamento (rótulos), incluindo o mapeamento de null -> "Não informado"
+    expect(await screen.findByText('Pix')).toBeInTheDocument();
+    expect(screen.getByText('Dinheiro')).toBeInTheDocument();
+    expect(screen.getByText('Não informado')).toBeInTheDocument();
+
+    // total formatado em moeda
+    expect(screen.getByText(/1\.500,50/)).toBeInTheDocument();
+
+    // quantidade (forma singular do item com 1 transação)
+    expect(screen.getByText('1 transação')).toBeInTheDocument();
+
+    // percentual do total movimentado
+    expect(screen.getByText(/75,0% do total movimentado/)).toBeInTheDocument();
+  });
+});

--- a/app-financeiro-front-end/src/components/resumo/ResumoFormaPagamento.test.tsx
+++ b/app-financeiro-front-end/src/components/resumo/ResumoFormaPagamento.test.tsx
@@ -49,9 +49,9 @@ describe('ResumoFormaPagamento (Issue #158)', () => {
 
   it('renderiza forma de pagamento, total, quantidade e percentual', async () => {
     mockBuscarResumoPorPagamento.mockResolvedValue([
-      { formaPagamento: 'PIX', total: 1500.5, quantidade: 2, percentual: 75 },
-      { formaPagamento: 'DINHEIRO', total: 400, quantidade: 1, percentual: 20 },
-      { formaPagamento: null, total: 100, quantidade: 3, percentual: 5 },
+      { formaPagamento: 'PIX', rotulo: 'Pix', total: 1500.5, quantidade: 2, percentual: 75 },
+      { formaPagamento: 'DINHEIRO', rotulo: 'Dinheiro', total: 400, quantidade: 1, percentual: 20 },
+      { formaPagamento: null, rotulo: 'Não informado', total: 100, quantidade: 3, percentual: 5 },
     ]);
 
     render(<ResumoFormaPagamento />);

--- a/app-financeiro-front-end/src/components/resumo/ResumoFormaPagamentoPizza.test.tsx
+++ b/app-financeiro-front-end/src/components/resumo/ResumoFormaPagamentoPizza.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ResumoFormaPagamentoPizza from './ResumoFormaPagamentoPizza';
+
+const { mockBuscarResumoPorPagamento, mockObterMensagemErroApi } = vi.hoisted(() => ({
+  mockBuscarResumoPorPagamento: vi.fn(),
+  mockObterMensagemErroApi: vi.fn((_erro: unknown, fallback: string) => fallback),
+}));
+
+vi.mock('../../services/api', () => ({
+  buscarResumoPorPagamento: mockBuscarResumoPorPagamento,
+  obterMensagemErroApi: mockObterMensagemErroApi,
+}));
+
+describe('ResumoFormaPagamentoPizza (Issue #158)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockObterMensagemErroApi.mockImplementation((_erro: unknown, fallback: string) => fallback);
+  });
+
+  it('exibe o estado de carregamento enquanto a API não responde', () => {
+    mockBuscarResumoPorPagamento.mockReturnValue(new Promise(() => {}));
+
+    render(<ResumoFormaPagamentoPizza />);
+
+    expect(
+      screen.getByText('Carregando resumo por forma de pagamento...'),
+    ).toBeInTheDocument();
+  });
+
+  it('exibe o estado vazio quando não há dados de resumo', async () => {
+    mockBuscarResumoPorPagamento.mockResolvedValue([]);
+
+    render(<ResumoFormaPagamentoPizza />);
+
+    expect(await screen.findByText('Nenhum resumo disponível')).toBeInTheDocument();
+  });
+
+  it('exibe mensagem de erro quando a chamada do resumo falha', async () => {
+    mockBuscarResumoPorPagamento.mockRejectedValue(new Error('falha'));
+
+    render(<ResumoFormaPagamentoPizza />);
+
+    expect(
+      await screen.findByText('Não foi possível carregar o resumo por forma de pagamento.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('renderiza os rótulos e percentuais na legenda', async () => {
+    mockBuscarResumoPorPagamento.mockResolvedValue([
+      { formaPagamento: 'PIX', total: 600, quantidade: 3, percentual: 60 },
+      { formaPagamento: 'DINHEIRO', total: 300, quantidade: 2, percentual: 30 },
+      { formaPagamento: null, total: 100, quantidade: 1, percentual: 10 },
+    ]);
+
+    render(<ResumoFormaPagamentoPizza />);
+
+    // rótulos da legenda (inclui o mapeamento de null -> "Não informado")
+    expect(await screen.findByText('Pix')).toBeInTheDocument();
+    expect(screen.getByText('Dinheiro')).toBeInTheDocument();
+    expect(screen.getByText('Não informado')).toBeInTheDocument();
+
+    // percentuais da legenda
+    expect(screen.getByText('60,0%')).toBeInTheDocument();
+    expect(screen.getByText('30,0%')).toBeInTheDocument();
+    expect(screen.getByText('10,0%')).toBeInTheDocument();
+
+    // o gráfico de pizza é renderizado
+    expect(
+      screen.getByRole('img', { name: /Gráfico de pizza do resumo por forma de pagamento/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app-financeiro-front-end/src/components/resumo/ResumoFormaPagamentoPizza.test.tsx
+++ b/app-financeiro-front-end/src/components/resumo/ResumoFormaPagamentoPizza.test.tsx
@@ -49,9 +49,9 @@ describe('ResumoFormaPagamentoPizza (Issue #158)', () => {
 
   it('renderiza os rótulos e percentuais na legenda', async () => {
     mockBuscarResumoPorPagamento.mockResolvedValue([
-      { formaPagamento: 'PIX', total: 600, quantidade: 3, percentual: 60 },
-      { formaPagamento: 'DINHEIRO', total: 300, quantidade: 2, percentual: 30 },
-      { formaPagamento: null, total: 100, quantidade: 1, percentual: 10 },
+      { formaPagamento: 'PIX', rotulo: 'Pix', total: 600, quantidade: 3, percentual: 60 },
+      { formaPagamento: 'DINHEIRO', rotulo: 'Dinheiro', total: 300, quantidade: 2, percentual: 30 },
+      { formaPagamento: null, rotulo: 'Não informado', total: 100, quantidade: 1, percentual: 10 },
     ]);
 
     render(<ResumoFormaPagamentoPizza />);


### PR DESCRIPTION
Reabre os testes da issue #158 **direto na `dev`**.

O #178 anterior tinha como base a branch `feat/#157-tela-resumo-forma-pagamento` (do #157/#164). Quando o #157 entrou na `dev`, os arquivos de teste ficaram só naquela branch e **não chegaram na `dev`**. Este PR traz exatamente esses testes (cherry-pick dos mesmos commits) sobre a `dev` atual.

### Backend
- **`ResumoServiceTest`** (novo): total/quantidade/percentual por grupo, soma fechando em 100, "Não informado" p/ sem forma, vazio (sem transações / total geral 0), rótulo de cada `TipoPagamento`, `AccessDenied` p/ usuário inválido.
- **`ContaServiceTest`** (atualizado): remoção de conta — sucesso, 404, 403 (outro usuário), 409 (conta com transações).

### Frontend
- **`ResumoFormaPagamento.test.tsx`** (novo): carregamento, vazio, erro e renderização (forma/total/quantidade/percentual).
- **`ResumoFormaPagamentoPizza.test.tsx`** (novo): carregamento, vazio, erro e rótulos/percentuais na legenda.

Validado localmente sobre a `dev`: backend `./gradlew test` (BUILD SUCCESSFUL) e frontend `npm run build && npm run test` (47 testes). Diff = só os 4 arquivos de teste.

Closes #158