### PR TITLE
docs(#126): documentação de deploy + configuração por variáveis de ambiente (base main)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,16 @@
+# Variáveis usadas pelo docker-compose.prod.yml.
+# Copie para `.env` (não versionado) e ajuste os valores antes do deploy.
+
+# Banco de dados
+POSTGRES_DB=app_financeiro
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=troque-esta-senha
+
+# Segredo JWT (HMAC). Gere um forte, p.ex.: openssl rand -hex 32
+JWT_SECRET=troque-por-um-segredo-com-no-minimo-32-bytes
+
+# Origem(ns) do frontend permitida(s) no CORS (separe múltiplas por vírgula)
+CORS_ALLOWED_ORIGINS=http://localhost:8081
+
+# URL pública da API consumida pelo frontend (embutida no build do Vite)
+VITE_API_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,9 @@ $RECYCLE.BIN/
 !app-financeiro-back-end/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/react,windows,linux,java,groovy,git,visualstudiocode,intellij
+
+### Env / secrets ###
+.env
+.env.*
+!.env.example
+!.env.prod.example

--- a/app-financeiro-back-end/.dockerignore
+++ b/app-financeiro-back-end/.dockerignore
@@ -1,0 +1,6 @@
+build/
+.gradle/
+bin/
+*.log
+.idea/
+.vscode/

--- a/app-financeiro-back-end/Dockerfile
+++ b/app-financeiro-back-end/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+# --- Build: gera o jar executável com o Gradle Wrapper (Java 21) ---
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /app
+
+# Copia primeiro o wrapper e os arquivos de build para aproveitar cache de camadas
+COPY gradle ./gradle
+COPY gradlew settings.gradle build.gradle ./
+RUN chmod +x gradlew
+
+COPY src ./src
+RUN ./gradlew bootJar --no-daemon
+
+# --- Runtime: imagem enxuta apenas com a JRE ---
+FROM eclipse-temurin:21-jre AS runtime
+WORKDIR /app
+
+# Usuário sem privilégios
+RUN useradd --uid 1001 --create-home spring
+USER spring
+
+COPY --from=build /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/security/WebConfig.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/security/WebConfig.java
@@ -1,5 +1,6 @@
 package bcd.appfinanceirobackend.security;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,10 +8,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    @Value("${app.cors.allowed-origins:http://localhost:5173}")
+    private String[] allowedOrigins;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173")
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/app-financeiro-back-end/src/main/resources/application.properties
+++ b/app-financeiro-back-end/src/main/resources/application.properties
@@ -1,11 +1,13 @@
 # Servidor HTTP
-server.port=8080
+# A porta pode ser sobrescrita via variável de ambiente PORT (útil em PaaS).
+server.port=${PORT:8080}
 
 # Configuração da Conexão com PostgreSQL
-# O banco 'app_financeiro' foi detectado no seu pgAdmin 4
-spring.datasource.url=jdbc:postgresql://localhost:5432/app_financeiro
-spring.datasource.username=postgres
-spring.datasource.password=1234
+# Localmente usa o Postgres do docker-compose; em produção sobrescreva via
+# variáveis de ambiente SPRING_DATASOURCE_URL / USERNAME / PASSWORD.
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/app_financeiro}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:postgres}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:1234}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 
@@ -21,6 +23,11 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
 # Desabilita o H2 Console para evitar conflitos
 spring.h2.console.enabled=false
+
+# CORS
+# Origens permitidas (separadas por vírgula). Em produção, defina o domínio
+# do frontend publicado via variável de ambiente CORS_ALLOWED_ORIGINS.
+app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173}
 
 # JWT
 # Em produção, sobrescrever via variável de ambiente JWT_SECRET (mín. 32 bytes / 256 bits)

--- a/app-financeiro-front-end/.dockerignore
+++ b/app-financeiro-front-end/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.log
+.vscode/
+.idea/

--- a/app-financeiro-front-end/.env.example
+++ b/app-financeiro-front-end/.env.example
@@ -1,0 +1,4 @@
+# URL base da API consumida pelo frontend.
+# Em desenvolvimento, o backend roda em http://localhost:8080 (default se não definida).
+# Em produção, aponte para a URL pública da API.
+VITE_API_URL=http://localhost:8080

--- a/app-financeiro-front-end/.gitignore
+++ b/app-financeiro-front-end/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Env / secrets
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/app-financeiro-front-end/Dockerfile
+++ b/app-financeiro-front-end/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+# --- Build: compila o frontend Vite ---
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+# A URL da API é embutida no build (Vite). Sobrescreva com --build-arg VITE_API_URL=...
+ARG VITE_API_URL=http://localhost:8080
+ENV VITE_API_URL=$VITE_API_URL
+RUN npm run build
+
+# --- Runtime: serve os estáticos com nginx ---
+FROM nginx:1.27-alpine AS runtime
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/app-financeiro-front-end/nginx.conf
+++ b/app-financeiro-front-end/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: rotas do React Router caem no index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache longo para assets versionados pelo Vite
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/app-financeiro-front-end/src/services/api.ts
+++ b/app-financeiro-front-end/src/services/api.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { limparSessao, obterAccessToken } from '../utils/authStorage';
 
 const api = axios.create({
-  baseURL: 'http://localhost:8080',
+  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:8080',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/app-financeiro-front-end/src/vite-env.d.ts
+++ b/app-financeiro-front-end/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** URL base da API consumida pelo frontend. Definida no build (Vite). */
+  readonly VITE_API_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,55 @@
+# Sobe a stack completa (banco + backend + frontend) em containers.
+# Uso:
+#   cp .env.prod.example .env   # e ajuste os valores
+#   docker compose -f docker-compose.prod.yml up -d --build
+#
+# Frontend: http://localhost:8081   |   API: http://localhost:8080
+services:
+  postgres:
+    image: postgres:16
+    container_name: smartbudget-postgres-prod
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-app_financeiro}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?defina POSTGRES_PASSWORD no .env}
+    volumes:
+      - postgres_data_prod:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-app_financeiro}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ./app-financeiro-back-end
+    container_name: smartbudget-backend
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB:-app_financeiro}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-postgres}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:?defina POSTGRES_PASSWORD no .env}
+      JWT_SECRET: ${JWT_SECRET:?defina JWT_SECRET com no minimo 32 bytes no .env}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:8081}
+    ports:
+      - "8080:8080"
+
+  frontend:
+    build:
+      context: ./app-financeiro-front-end
+      args:
+        VITE_API_URL: ${VITE_API_URL:-http://localhost:8080}
+    container_name: smartbudget-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "8081:80"
+
+volumes:
+  postgres_data_prod:
+    name: app-financeiro-pgdata-prod

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,145 @@
+# Deploy — SmartBudget
+
+Guia de **deploy / execução reprodutível** do MVP (backend + frontend + banco).
+
+Para desenvolvimento local (rodar com `bootRun`/`npm run dev`), veja [`como-rodar.md`](./como-rodar.md). Este documento foca em publicar o sistema de forma parametrizável por variáveis de ambiente.
+
+## Visão geral
+
+| Serviço  | Stack                     | Porta (default) |
+|----------|---------------------------|-----------------|
+| Frontend | React + Vite (nginx)      | `8081` → `80`   |
+| Backend  | Spring Boot (Java 21)     | `8080`          |
+| Banco    | PostgreSQL 16 + Flyway    | `5432`          |
+
+O frontend é uma SPA estática que chama a API pelo **navegador**, então a URL da API (`VITE_API_URL`) precisa ser acessível pelo cliente e é **embutida no build** do Vite.
+
+## Pré-requisitos
+
+- **Docker** + **Docker Compose v2** (caminho recomendado), ou
+- **Java JDK 21**, **Node.js 20+** e **PostgreSQL 16** (build/execução manual).
+
+## Variáveis de ambiente
+
+### Backend (`application.properties`)
+
+| Variável                     | Default                                          | Descrição |
+|------------------------------|--------------------------------------------------|-----------|
+| `PORT`                       | `8080`                                           | Porta HTTP do backend. |
+| `SPRING_DATASOURCE_URL`      | `jdbc:postgresql://localhost:5432/app_financeiro`| URL JDBC do PostgreSQL. |
+| `SPRING_DATASOURCE_USERNAME` | `postgres`                                       | Usuário do banco. |
+| `SPRING_DATASOURCE_PASSWORD` | `1234`                                           | Senha do banco. |
+| `JWT_SECRET`                 | chave de dev (apenas local)                      | Segredo HMAC do JWT. **Em produção use ≥ 32 bytes.** |
+| `CORS_ALLOWED_ORIGINS`       | `http://localhost:5173`                          | Origem(ns) do frontend permitida(s) no CORS, separadas por vírgula. |
+
+### Frontend (build-time, Vite)
+
+| Variável        | Default                 | Descrição |
+|-----------------|-------------------------|-----------|
+| `VITE_API_URL`  | `http://localhost:8080` | URL pública da API consumida pelo frontend. |
+
+> Os defaults preservam a execução local. Em produção, **sempre** sobrescreva `JWT_SECRET`, as credenciais do banco e o `CORS_ALLOWED_ORIGINS`.
+
+## Opção A — Docker Compose (recomendado)
+
+Sobe banco + backend + frontend em containers, com migrations Flyway aplicadas automaticamente.
+
+```bash
+# 1. Configure as variáveis (não versionado)
+cp .env.prod.example .env
+#    edite .env: defina POSTGRES_PASSWORD, JWT_SECRET (>=32 bytes), CORS_ALLOWED_ORIGINS, VITE_API_URL
+
+# 2. Suba a stack (build das imagens incluído)
+docker compose -f docker-compose.prod.yml up -d --build
+
+# 3. Acompanhe os logs do backend (migrations + boot)
+docker compose -f docker-compose.prod.yml logs -f backend
+```
+
+Acesso:
+
+- Frontend: `http://localhost:8081`
+- API: `http://localhost:8080`
+- Swagger UI: `http://localhost:8080/swagger-ui.html`
+
+Gere um `JWT_SECRET` forte com:
+
+```bash
+openssl rand -hex 32
+```
+
+Encerrar:
+
+```bash
+docker compose -f docker-compose.prod.yml down      # mantém os dados
+docker compose -f docker-compose.prod.yml down -v   # apaga o volume do banco
+```
+
+## Opção B — Build e execução manual
+
+### Banco
+
+Use o `docker-compose.yml` da raiz (Postgres local) ou um PostgreSQL próprio, e exporte as variáveis de conexão apontando para ele. As migrations Flyway rodam automaticamente no boot do backend (`spring.jpa.hibernate.ddl-auto=validate`; o Hibernate apenas valida o schema criado pelo Flyway).
+
+### Backend
+
+```bash
+cd app-financeiro-back-end
+./gradlew bootJar                       # gera build/libs/app-financeiro-back-end-*.jar
+
+export SPRING_DATASOURCE_URL="jdbc:postgresql://<host>:5432/app_financeiro"
+export SPRING_DATASOURCE_USERNAME="<usuario>"
+export SPRING_DATASOURCE_PASSWORD="<senha>"
+export JWT_SECRET="$(openssl rand -hex 32)"
+export CORS_ALLOWED_ORIGINS="https://<dominio-do-frontend>"
+java -jar build/libs/app-financeiro-back-end-*.jar
+```
+
+### Frontend
+
+```bash
+cd app-financeiro-front-end
+npm ci
+VITE_API_URL="https://<dominio-da-api>" npm run build   # gera dist/
+```
+
+Sirva o conteúdo de `dist/` em qualquer servidor de estáticos (nginx, Vercel, Netlify, etc.). Para SPA, configure o fallback de rotas para `index.html` (veja `app-financeiro-front-end/nginx.conf`).
+
+## Validação do ambiente
+
+Substitua as portas se necessário. Com a stack no ar:
+
+```bash
+API=http://localhost:8080
+
+# 1. Cria um usuário de teste (retorna 201 + token)
+curl -s -X POST $API/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"nome":"Validacao","email":"validacao@teste.com","cpf":"52998224725","senha":"123456"}'
+
+# 2. Login (retorna 200 + token)
+curl -s -X POST $API/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"validacao@teste.com","senha":"123456"}'
+
+# 3. Endpoint autenticado (use o token do passo 1/2) — retorna 200
+curl -s -o /dev/null -w "%{http_code}\n" $API/categorias -H "Authorization: Bearer <TOKEN>"
+
+# 4. Frontend servido (retorna 200, inclusive em rotas da SPA)
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8081/login
+```
+
+Pela interface: acesse o frontend, **cadastre uma conta** (`/register`), faça login e valide os fluxos do MVP (contas, transações, listagem com filtros, categorização).
+
+> O banco já vem com usuários demo do seed (`demo@smartbudget.com`, `teste@smartbudget.com`). Para validação, prefira **registrar um novo usuário** pela tela/`/auth/register`. Os CPFs `12345678909` e `11144477735` já estão em uso pelo seed.
+
+## Segurança
+
+- **Nunca** commite o arquivo `.env` — ele está no `.gitignore` (apenas `*.example` são versionados).
+- Defina um `JWT_SECRET` forte e exclusivo do ambiente (≥ 32 bytes). Trocar o segredo invalida tokens já emitidos.
+- Use senhas de banco fortes; não reutilize as senhas de exemplo (`1234`, `smoketest123`).
+- Restrinja `CORS_ALLOWED_ORIGINS` ao(s) domínio(s) reais do frontend.
+
+## Troubleshooting
+
+Cenários comuns (Connection refused, porta `5432` ocupada, erro de validação do Hibernate/Flyway, CORS, JWT inválido após login) estão documentados em [`como-rodar.md`](./como-rodar.md#6-problemas-comuns).


### PR DESCRIPTION
Documentação de deploy + configuração por variáveis de ambiente, **baseado direto na `main`**.

### Por que um PR novo (substitui o #169)
O #169 tinha base na `dev`. Como o deploy é da versão do projeto que está na **`main`**, e a branch fora feita sobre a `dev`, trocar a base do #169 para `main` arrastaria **todo o conteúdo da `dev`** junto — não só o deploy. Então este PR refaz **apenas as mudanças de deploy** (cherry-pick do commit de deploy) sobre a `main`. O #169 será fechado.

### O que entra (15 arquivos, só deploy)
- `docker-compose.prod.yml`, `app-financeiro-back-end/Dockerfile`, `app-financeiro-front-end/Dockerfile`, `app-financeiro-front-end/nginx.conf`
- `.env.prod.example`, `app-financeiro-front-end/.env.example`, `.dockerignore`/`.gitignore`
- `docs/DEPLOY.md`
- Config por env vars: `application.properties` (`PORT`, `SPRING_DATASOURCE_*`, `JWT_SECRET`, `CORS_ALLOWED_ORIGINS`), `WebConfig` (CORS via `app.cors.allowed-origins`), `api.ts` (`VITE_API_URL`), `vite-env.d.ts`.

Obs.: a `main` já possui `docker-compose.yml`, então o PR monta sobre essa versão sem puxar features da `dev`.

### Validação local (sobre a `main`)
- Backend `./gradlew assemble test` → **BUILD SUCCESSFUL**
- Frontend `npm run build && npm run test` → build ok, testes verdes

Closes #126