### PR TITLE
test: adiciona testes da tela Primeira Conta (#184)

### DIFF
--- a/app-financeiro-front-end/src/pages/PrimeiraConta.test.tsx
+++ b/app-financeiro-front-end/src/pages/PrimeiraConta.test.tsx
@@ -89,6 +89,20 @@ describe.sequential('Tela de Primeira Conta (onboarding)', () => {
     });
   });
 
+  it('deve exibir erro de validação quando o tipo de conta estiver vazio', async () => {
+    renderizarComponente();
+    preencherCamposMinimos();
+
+    fireEvent.change(screen.getByLabelText(/Tipo de conta/i), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /Finalizar cadastro/i }));
+
+    expect(mockRegistrarConta).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(screen.getByText('Tipo de conta é obrigatório.')).toBeInTheDocument();
+    });
+  });
+
   it('deve exibir mensagem de alerta geral em tela caso a API de registro falhe', async () => {
     mockRegistrarConta.mockRejectedValueOnce(new Error('Erro na API'));
 

--- a/app-financeiro-front-end/src/pages/PrimeiraConta.test.tsx
+++ b/app-financeiro-front-end/src/pages/PrimeiraConta.test.tsx
@@ -1,0 +1,180 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+import PrimeiraConta from './PrimeiraConta';
+
+const { mockRegistrarConta, mockNavigate } = vi.hoisted(() => ({
+  mockRegistrarConta: vi.fn(),
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+  registrarConta: mockRegistrarConta,
+  obterMensagemErroApi: vi.fn((_err: unknown, fallback: string) => fallback),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const aguardarRedirecionamentoPendente = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 1000);
+  });
+
+describe.sequential('Tela de Primeira Conta (onboarding)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegistrarConta.mockReset();
+    mockNavigate.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+  });
+
+  const renderizarComponente = () =>
+    render(
+      <BrowserRouter>
+        <PrimeiraConta />
+      </BrowserRouter>,
+    );
+
+  const preencherCamposMinimos = () => {
+    fireEvent.change(screen.getByLabelText(/Nome da conta/i), { target: { value: 'Conta Principal' } });
+    fireEvent.change(screen.getByLabelText(/Banco/i), { target: { value: 'Itaú' } });
+  };
+
+  it('deve renderizar os campos do formulário com valores padrão', () => {
+    renderizarComponente();
+
+    expect(screen.getByLabelText(/Nome da conta/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Banco/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Tipo de conta/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Descrição/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Finalizar cadastro/i })).toBeInTheDocument();
+
+    expect(screen.getByLabelText(/Banco/i)).toHaveValue('Nubank');
+    expect(screen.getByLabelText(/Tipo de conta/i)).toHaveValue('CORRENTE');
+  });
+
+  it('deve exibir erro de validação ao tentar submeter com o nome em branco', async () => {
+    renderizarComponente();
+
+    fireEvent.change(screen.getByLabelText(/Nome da conta/i), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /Finalizar cadastro/i }));
+
+    expect(mockRegistrarConta).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(screen.getByText('Nome da conta é obrigatório.')).toBeInTheDocument();
+    });
+  });
+
+  it('deve exibir erro de validação ao tentar submeter sem banco informado', async () => {
+    renderizarComponente();
+
+    fireEvent.change(screen.getByLabelText(/Nome da conta/i), { target: { value: 'Conta sem banco' } });
+    fireEvent.change(screen.getByLabelText(/Banco/i), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /Finalizar cadastro/i }));
+
+    expect(mockRegistrarConta).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(screen.getByText('Banco é obrigatório.')).toBeInTheDocument();
+    });
+  });
+
+  it('deve exibir mensagem de alerta geral em tela caso a API de registro falhe', async () => {
+    mockRegistrarConta.mockRejectedValueOnce(new Error('Erro na API'));
+
+    renderizarComponente();
+    preencherCamposMinimos();
+
+    fireEvent.click(screen.getByRole('button', { name: /Finalizar cadastro/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Não foi possível cadastrar a conta bancária.')).toBeInTheDocument();
+    });
+
+    expect(mockRegistrarConta).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('deve exibir loading enquanto registrarConta estiver pendente', async () => {
+    let resolver: (conta: { contaId: string }) => void = () => undefined;
+
+    mockRegistrarConta.mockImplementationOnce(
+      () =>
+        new Promise<{ contaId: string }>((resolve) => {
+          resolver = resolve;
+        }),
+    );
+
+    renderizarComponente();
+    preencherCamposMinimos();
+
+    fireEvent.click(screen.getByRole('button', { name: /Finalizar cadastro/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Cadastrando...')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Cadastrando/i })).toBeDisabled();
+    });
+
+    resolver({ contaId: 'conta-1' });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Conta bancária cadastrada com sucesso. Redirecionando para o Dashboard/i),
+      ).toBeInTheDocument();
+    });
+
+    await aguardarRedirecionamentoPendente();
+    mockNavigate.mockClear();
+  });
+
+  it('deve chamar registrarConta com dados tratados e redirecionar para o dashboard', async () => {
+    mockRegistrarConta.mockResolvedValueOnce({
+      contaId: 'conta-1',
+      nome: 'Conta Salário',
+      tipoConta: 'POUPANCA',
+      banco: 'Itaú',
+      descricao: 'Reserva de emergência.',
+    });
+
+    renderizarComponente();
+
+    fireEvent.change(screen.getByLabelText(/Nome da conta/i), { target: { value: '  Conta Salário  ' } });
+    fireEvent.change(screen.getByLabelText(/Tipo de conta/i), { target: { value: 'POUPANCA' } });
+    fireEvent.change(screen.getByLabelText(/Banco/i), { target: { value: 'Itaú' } });
+    fireEvent.change(screen.getByLabelText(/Descrição/i), { target: { value: 'Reserva de emergência.' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Finalizar cadastro/i }));
+
+    await waitFor(() => {
+      expect(mockRegistrarConta).toHaveBeenCalledWith({
+        nome: 'Conta Salário',
+        tipoConta: 'POUPANCA',
+        banco: 'Itaú',
+        descricao: 'Reserva de emergência.',
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Conta bancária cadastrada com sucesso. Redirecionando para o Dashboard/i),
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(
+      () => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+      },
+      { timeout: 2000 },
+    );
+  });
+});


### PR DESCRIPTION
## O que mudou

- Adicionado `src/pages/PrimeiraConta.test.tsx` com testes automatizados da tela de onboarding (`/contas/primeira`).
- Cobertos renderização com valores padrão, validações de nome e banco, loading, sucesso com `registrarConta` tratado, redirecionamento para `/dashboard` e erro de API.
- Nenhuma alteração em componentes de produção.

## Por quê

- Atende à issue #184, cobrindo o fluxo pós-cadastro que ainda não tinha testes dedicados.
- Complementa `Cadastro.test.tsx` (redireciona para `/contas/primeira`) e `NovaConta.test.tsx` (gerenciamento logado).
- Reduz risco de regressão no onboarding antes do primeiro acesso ao Dashboard.

## Como testar

1. Entre na pasta do frontend:

   ```bash
   cd app-financeiro-front-end
   ```

2. Instale dependências, se necessário:

   ```bash
   npm install
   ```

3. Execute a suíte de testes:

   ```bash
   npm test
   ```

4. Confirme que os 6 testes de `PrimeiraConta.test.tsx` passam.

5. Opcional — apenas este arquivo:

   ```bash
   npm test -- PrimeiraConta.test.tsx
   ```

6. Valide o TypeScript:

   ```bash
   npx tsc -b
   ```

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos

- [Teste] Padrão alinhado a `NovaConta.test.tsx`: `fireEvent` nos campos, `waitFor` nos fluxos assíncronos e mock de `registrarConta`/`useNavigate`.
- [Manutenção] O redirecionamento usa `setTimeout(900)` na tela; os testes usam `describe.sequential`, `waitFor` com timeout de 2s no sucesso e limpeza do timer pendente após o cenário de loading, evitando falso positivo de navegação nos testes de erro.
- [Risco] Descrição opcional é enviada como `undefined` quando vazia; o teste de sucesso valida o payload já com `.trim()` para espelhar o contrato real da API.

Closes #184
