### PR TITLE
fix: adiciona relatório de cobertura dos testes frontend (#177)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,36 @@ jobs:
       - name: Tests
         run: npm test --if-present
 
+      - name: Resumo de cobertura (Vitest)
+        run: |
+          npm run test:coverage
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          summary_path = Path("coverage/coverage-summary.json")
+          if not summary_path.is_file():
+              print("Relatório de cobertura do frontend não encontrado; execute npm run test:coverage.")
+              raise SystemExit(1)
+
+          data = json.loads(summary_path.read_text(encoding="utf-8"))
+          total = data.get("total", {})
+          for key, label in (
+              ("lines", "linhas"),
+              ("functions", "funções"),
+              ("branches", "branches"),
+              ("statements", "statements"),
+          ):
+              metric = total.get(key, {})
+              pct = metric.get("pct", 0)
+              covered = metric.get("covered", 0)
+              total_count = metric.get("total", 0)
+              print(
+                  f"Cobertura de {label} (frontend): {pct:.1f}% "
+                  f"({covered}/{total_count})"
+              )
+          PY
+
   yaml-lint:
     name: YAML syntax validation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Tests
-        run: npm test --if-present
-
-      - name: Resumo de cobertura (Vitest)
+      - name: Tests e cobertura (Vitest)
         run: |
           npm run test:coverage
           python3 - <<'PY'

--- a/app-financeiro-front-end/.gitignore
+++ b/app-financeiro-front-end/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+coverage
 dist
 dist-ssr
 *.local

--- a/app-financeiro-front-end/package-lock.json
+++ b/app-financeiro-front-end/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.7",
         "eslint": "^10.2.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -224,9 +225,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -234,9 +235,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -268,13 +269,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -328,17 +329,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -1537,6 +1548,37 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.7",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
@@ -1734,6 +1776,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2580,6 +2641,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2649,6 +2720,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2715,6 +2793,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3151,6 +3268,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3680,6 +3838,19 @@
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"

--- a/app-financeiro-front-end/package.json
+++ b/app-financeiro-front-end/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "axios": "^1.15.2",
@@ -25,6 +26,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.7",
     "eslint": "^10.2.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/app-financeiro-front-end/vitest.config.ts
+++ b/app-financeiro-front-end/vitest.config.ts
@@ -7,5 +7,18 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/setupTests.ts',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'html'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/main.tsx',
+        'src/App.tsx',
+        'src/setupTests.ts',
+        'src/**/*.test.{ts,tsx}',
+        'src/**/*.d.ts',
+      ],
+    },
   },
 });

--- a/docs/como-rodar.md
+++ b/docs/como-rodar.md
@@ -271,7 +271,25 @@ npm run build
 npm run preview
 npm run lint
 npm test
+npm run test:coverage
 ```
+
+### Cobertura de testes do frontend
+
+Para gerar o relatório de cobertura com Vitest (provider `v8`):
+
+```bash
+cd app-financeiro-front-end
+npm run test:coverage
+```
+
+O resumo aparece no terminal. O relatório detalhado fica em:
+
+```text
+app-financeiro-front-end/coverage/index.html
+```
+
+O arquivo `coverage/coverage-summary.json` alimenta o step **Resumo de cobertura (Vitest)** no CI, no mesmo espírito do JaCoCo do backend.
 
 ## 6. Problemas comuns
 

--- a/docs/como-rodar.md
+++ b/docs/como-rodar.md
@@ -289,7 +289,7 @@ O resumo aparece no terminal. O relatório detalhado fica em:
 app-financeiro-front-end/coverage/index.html
 ```
 
-O arquivo `coverage/coverage-summary.json` alimenta o step **Resumo de cobertura (Vitest)** no CI, no mesmo espírito do JaCoCo do backend.
+No CI, o job **Frontend** executa apenas `npm run test:coverage` (sem duplicar `npm test`), e imprime o resumo a partir de `coverage/coverage-summary.json`, no mesmo espírito do JaCoCo do backend.
 
 ## 6. Problemas comuns
 

--- a/docs/metricas.md
+++ b/docs/metricas.md
@@ -247,7 +247,7 @@ cd app-financeiro-front-end
 npm run test:coverage
 ```
 
-Relatório HTML: `app-financeiro-front-end/coverage/index.html`. O CI imprime o resumo a partir de `coverage/coverage-summary.json` no step **Resumo de cobertura (Vitest)**.
+Relatório HTML: `app-financeiro-front-end/coverage/index.html`. O CI executa `npm run test:coverage` uma única vez no step **Tests e cobertura (Vitest)** e imprime o resumo a partir de `coverage/coverage-summary.json`.
 
 **Referência observada** (Vitest `v8`, escopo `src/**/*.{ts,tsx}` exceto `App.tsx`, `main.tsx`, arquivos `*.test.*` e `setupTests.ts`):
 

--- a/docs/metricas.md
+++ b/docs/metricas.md
@@ -235,3 +235,27 @@ A cobertura de testes da Sprint 3 foi obtida a partir do relatório JaCoCo gerad
 Cobertura de linhas (projeto backend): 75.5% (694/919 linhas cobertas)
 Cobertura de linhas (pacote service): 68.6% (188/274)
 ```
+
+### Cobertura de testes do frontend (correção Sprint 3 — issue #177)
+
+A dívida registrada na Sprint 2 (“frontend sem testes/cobertura”) foi **superada** com Vitest + Testing Library (#111) e testes de telas nas Sprints 3–4. A issue **#177** formaliza a **medição** da cobertura no frontend, alinhada ao JaCoCo do backend.
+
+**Como reproduzir localmente:**
+
+```bash
+cd app-financeiro-front-end
+npm run test:coverage
+```
+
+Relatório HTML: `app-financeiro-front-end/coverage/index.html`. O CI imprime o resumo a partir de `coverage/coverage-summary.json` no step **Resumo de cobertura (Vitest)**.
+
+**Referência observada** (Vitest `v8`, escopo `src/**/*.{ts,tsx}` exceto `App.tsx`, `main.tsx`, arquivos `*.test.*` e `setupTests.ts`):
+
+| Métrica | Valor |
+|--------|-------|
+| Linhas | **70,3%** (568/808) |
+| Statements | **67,6%** (627/927) |
+| Funções | **58,7%** (125/213) |
+| Branches | **61,2%** (341/557) |
+
+**Leitura:** a cobertura agregada do frontend reflete telas já testadas (login, cadastro, nova conta, nova transação, importação, resumo por pagamento) e componentes ainda sem testes dedicados (`Dashboard`, `PrimeiraConta`, `Transacoes` até merge dos PRs de teste, rotas, parte de `api.ts`). A meta de acompanhar evolução nas próximas sprints passa a ser **mensurável** no pipeline.


### PR DESCRIPTION
## O que mudou

- Configurada cobertura no Vitest (`provider: v8`) em `vitest.config.ts`, com relatórios `text`, `json-summary` e `html`.
- Adicionado script `test:coverage` no `package.json` e dependência `@vitest/coverage-v8`.
- CI do frontend passa a executar `npm run test:coverage` e imprimir resumo (linhas, funções, branches, statements), no mesmo espírito do JaCoCo.
- Documentação atualizada em `docs/como-rodar.md` e `docs/metricas.md` com comando local e percentuais de referência.
- Pasta `coverage/` ignorada no `.gitignore` do frontend.

## Por quê

- Atende à issue #177 (correção Sprint 3): o frontend já tinha testes, mas não havia relatório de cobertura equivalente ao backend.
- Permite acompanhar evolução da qualidade do frontend com dados objetivos no CI e em `docs/metricas.md`.

## Como testar

1. Entre no frontend:

   ```bash
   cd app-financeiro-front-end
   npm install
   ```

2. Execute os testes com cobertura:

   ```bash
   npm run test:coverage
   ```

3. Confirme o resumo no terminal e abra `coverage/index.html` no navegador.

4. Valide que a suíte segue passando:

   ```bash
   npm test
   ```

5. No CI, confira o step **Resumo de cobertura (Vitest)** após o job Frontend.

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos

- [Teste] Provider `v8` nativo do Vitest 4; exclusões limitam ruído de bootstrap (`main.tsx`, `App.tsx`) e dos próprios arquivos `*.test.*`.
- [Manutenção] O CI lê `coverage/coverage-summary.json` com script Python, espelhando o padrão já usado no step JaCoCo do backend.
- [Risco] A cobertura agregada (~70% linhas no recorte atual) mistura telas testadas e pendentes; merges futuros de PRs de teste (#156, #185) devem elevar o indicador sem alterar esta configuração.

Closes #177
