### PR TITLE
Deploy no Render: blueprint + datasource via env (#126)

### DIFF
--- a/app-financeiro-back-end/src/main/resources/application.properties
+++ b/app-financeiro-back-end/src/main/resources/application.properties
@@ -4,8 +4,8 @@ server.port=${PORT:8080}
 
 # Configuração da Conexão com PostgreSQL
 # Localmente usa o Postgres do docker-compose; em produção sobrescreva via
-# variáveis de ambiente SPRING_DATASOURCE_URL / USERNAME / PASSWORD.
-spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/app_financeiro}
+# SPRING_DATASOURCE_URL, ou via DB_HOST/DB_PORT/DB_NAME (ex.: o Render injeta esses).
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:app_financeiro}}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:postgres}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:1234}
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@
 databases:
   - name: smartbudget-db
     databaseName: app_financeiro
-    user: postgres
+    user: smartbudget
     plan: free
 
 services:

--- a/render.yaml
+++ b/render.yaml
@@ -50,7 +50,7 @@ services:
         generateValue: true
       # Origem do frontend permitida no CORS (ajuste se a URL mudar)
       - key: CORS_ALLOWED_ORIGINS
-        value: https://smartbudget-web.onrender.com
+        value: https://smartbudget-web-atkh.onrender.com
       # Limita o heap pra caber nos 512MB do plano free
       - key: JAVA_TOOL_OPTIONS
         value: -XX:MaxRAMPercentage=75.0
@@ -65,7 +65,7 @@ services:
     envVars:
       # URL publica da API embutida no build do Vite (ajuste se a URL mudar)
       - key: VITE_API_URL
-        value: https://smartbudget-api.onrender.com
+        value: https://smartbudget-api-4rtr.onrender.com
     routes:
       # SPA: qualquer rota cai no index.html (React Router)
       - type: rewrite

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,73 @@
+# Blueprint do Render — sobe banco + backend + frontend no plano gratuito.
+# Como usar: Render > New + > Blueprint > conecte este repo > Apply.
+# Docs: https://render.com/docs/blueprint-spec
+#
+# ATENCAO (subdominio .onrender.com e global e unico):
+#   As URLs abaixo assumem que os nomes "smartbudget-api" e "smartbudget-web"
+#   estao livres. Se o Render adicionar um sufixo, atualize CORS_ALLOWED_ORIGINS
+#   (backend) e VITE_API_URL (frontend) com as URLs reais e faca redeploy.
+
+databases:
+  - name: smartbudget-db
+    databaseName: app_financeiro
+    user: postgres
+    plan: free
+
+services:
+  # --- Backend: Spring Boot (Java 21) via Docker ---
+  - type: web
+    name: smartbudget-api
+    runtime: docker
+    plan: free
+    region: oregon
+    rootDir: app-financeiro-back-end
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    envVars:
+      # Conexao com o banco (preenchida automaticamente pelo Render)
+      - key: DB_HOST
+        fromDatabase:
+          name: smartbudget-db
+          property: host
+      - key: DB_PORT
+        fromDatabase:
+          name: smartbudget-db
+          property: port
+      - key: DB_NAME
+        fromDatabase:
+          name: smartbudget-db
+          property: database
+      - key: SPRING_DATASOURCE_USERNAME
+        fromDatabase:
+          name: smartbudget-db
+          property: user
+      - key: SPRING_DATASOURCE_PASSWORD
+        fromDatabase:
+          name: smartbudget-db
+          property: password
+      # Segredo JWT forte gerado pelo Render
+      - key: JWT_SECRET
+        generateValue: true
+      # Origem do frontend permitida no CORS (ajuste se a URL mudar)
+      - key: CORS_ALLOWED_ORIGINS
+        value: https://smartbudget-web.onrender.com
+      # Limita o heap pra caber nos 512MB do plano free
+      - key: JAVA_TOOL_OPTIONS
+        value: -XX:MaxRAMPercentage=75.0
+
+  # --- Frontend: React + Vite (site estatico) ---
+  - type: web
+    name: smartbudget-web
+    runtime: static
+    rootDir: app-financeiro-front-end
+    buildCommand: npm ci && npm run build
+    staticPublishPath: dist
+    envVars:
+      # URL publica da API embutida no build do Vite (ajuste se a URL mudar)
+      - key: VITE_API_URL
+        value: https://smartbudget-api.onrender.com
+    routes:
+      # SPA: qualquer rota cai no index.html (React Router)
+      - type: rewrite
+        source: /*
+        destination: /index.html


### PR DESCRIPTION
## O que mudou

- Adiciona `render.yaml` (Blueprint do Render): banco Postgres + backend (Docker) + frontend (site estático) no plano gratuito, com as variáveis ligadas automaticamente e `JWT_SECRET` gerado pelo Render.
- `application.properties`: a URL do datasource agora também aceita `DB_HOST` / `DB_PORT` / `DB_NAME` (injetadas pelo Render). `SPRING_DATASOURCE_URL` e o uso local continuam idênticos.

## Por quê

- Habilita subir o MVP em produção, acessível por URL pública no Render (free tier), conforme orientação do professor. Encaminha a task #126.

## Como testar

1. Render → **New +** → **Blueprint** → conectar este repo → **Apply**.
2. Aguardar `smartbudget-db`, `smartbudget-api` e `smartbudget-web` ficarem **Live**.
3. Acessar a URL do `smartbudget-web`, registrar uma conta e validar login + fluxos do MVP.
4. Local segue igual: `docker compose -f docker-compose.prod.yml up -d --build`.

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado (2 arquivos)
- [x] Casos limite considerados (colisão de subdomínio, cold start, expiração do banco free)
- [x] Evidência de teste (passo a passo no Render acima)
- [x] Não quebrou funcionalidades existentes (mudança retrocompatível)
- [x] Código revisado e limpo

## Comentários técnicos

- [Risco] Subdomínio `.onrender.com` é global e único; se os nomes colidirem, o Render adiciona sufixo — atualizar `CORS_ALLOWED_ORIGINS` (api) e `VITE_API_URL` (web) com as URLs reais e redeploy.
- [Risco] Plano free: backend dorme após 15 min (cold start ~50s) e o Postgres gratuito expira em ~30 dias — criar perto da entrega.
- [Manutenção] Mudança no datasource é retrocompatível: defaults preservam o comportamento local e `SPRING_DATASOURCE_URL` continua tendo prioridade.
- [Teste] `VITE_API_URL` é embutida no build do Vite; trocar a URL exige rebuild do frontend (o Render rebuilda ao salvar a env var).
