### PR TITLE
docs(adr): registra decomposicao do TransacaoService na sprint 4 (#130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ A proteção da branch `main` no GitHub já exige os quatro jobs (`Backend (buil
 - [ADR-0005 — Padrões de Projeto](docs/adrs/ADR-0005-padroes-de-projeto.md)
 - [ADR-0006 — Versionamento de Banco de Dados com Flyway](docs/adrs/ADR-0006-migracoes-de-banco-de-dados-com-flyway.md)
 - [ADR-0007 — Bibliotecas de Leitura de Extratos](docs/adrs/ADR-0007-bibliotecas-leitura-extratos.md)
+- [ADR-0008 — Decomposição do TransacaoService](docs/adrs/ADR-0008-decomposicao-transacao-service.md)
 - [Board](https://github.com/orgs/IFSC-ES2/projects/20)
 - [Backlog](https://github.com/IFSC-ES2/projeto-app_financeiro/issues)
 - [Estimativas](docs/estimativas.md)

--- a/docs/adrs/ADR-0008-decomposicao-transacao-service.md
+++ b/docs/adrs/ADR-0008-decomposicao-transacao-service.md
@@ -1,0 +1,65 @@
+# ADR-0008 — Decomposição do `TransacaoService` (Sprint 4)
+
+## Status
+Aceito
+
+## Contexto
+Na Sprint 4, a issue #128 exigiu refatoração/reengenharia orientada a design no backend. O `TransacaoService` concentrou, ao longo das Sprints 2 e 3, responsabilidades de domínios diferentes: registro e edição de transações, resolução de conta do usuário (incluindo conta automática de dinheiro), validação de categoria permitida, sugestão automática de categoria por palavras-chave e conversão de entidade para DTO.
+
+Esse acúmulo gerou efeitos colaterais práticos:
+
+- **Alto acoplamento:** o `ImportacaoService` dependia do `TransacaoService` apenas para chamar `sugerirCategoria()`, misturando o fluxo de importação com o módulo de transações manuais.
+- **Baixa coesão:** alterações em regra de conta, categoria ou mapeamento exigiam editar a mesma classe usada por criação, edição, listagem e categorização.
+- **Testes mais difíceis:** cenários unitários precisavam mockar dependências que não eram centrais ao caso de uso testado.
+
+A refatoração foi conduzida no PR #187 (`refactor/128-transacao-service-design`) e motivou a necessidade de registrar formalmente a decisão arquitetural, conforme a issue #130.
+
+## Decisão
+A equipe decidiu decompor responsabilidades extraídas do `TransacaoService` em componentes especializados, mantendo o `TransacaoService` como coordenador dos casos de uso de transação.
+
+Componentes criados ou reforçados:
+
+| Componente | Pacote | Responsabilidade |
+| --- | --- | --- |
+| `ContaUsuarioService` | `service` | Resolver a conta usada na transação, validar propriedade do usuário autenticado e criar/obter a conta automática `Dinheiro / Carteira` quando a forma de pagamento for dinheiro. |
+| `SugestaoCategoriaService` | `service` | Sugerir categoria padrão a partir da descrição da transação, com base em palavras-chave. |
+| `TransacaoMapper` | `mapper` | Converter `Transacao` em `TransacaoResponseDTO`, isolando a montagem de resposta da API. |
+| `CategoriaService` (extensão) | `service` | Centralizar a busca de categoria por ID e a validação de categoria permitida ao usuário (`buscarCategoriaPermitida`). |
+
+Papéis após a mudança:
+
+- **`TransacaoService`:** orquestra `registrarManual`, `editar`, `excluir`, `listarTransacoesPorUsuario` e `categorizar`, delegando regras auxiliares aos serviços acima.
+- **`ImportacaoService`:** passa a depender diretamente de `SugestaoCategoriaService`, sem acoplamento ao `TransacaoService`.
+
+A API pública dos endpoints de transação e importação permanece a mesma; a mudança é interna à organização do backend.
+
+## Alternativas consideradas
+
+- **Manter o `TransacaoService` monolítico:** Descartado por perpetuar acoplamento entre importação e transações, dificultar testes isolados e aumentar o risco de regressão em refatorações futuras.
+- **Extrair apenas métodos privados dentro da mesma classe:** Descartado por não reduzir dependências entre módulos nem permitir reutilização independente (como no caso da importação).
+- **Separar em microserviços por domínio:** Descartado pelo escopo do MVP monolítico e pelo custo operacional desproporcional à necessidade atual.
+
+## Consequências
+
+### Positivas
+- Melhor aderência ao **Single Responsibility Principle (SRP)** dentro do monólito Spring.
+- Testes unitários mais focados: cada serviço pode ser testado com mocks mínimos.
+- Redução de acoplamento entre importação e transações manuais.
+- Evolução mais segura: mudanças em sugestão de categoria ou resolução de conta não exigem alterar todo o fluxo de transação.
+
+### Negativas / trade-offs
+- Maior quantidade de classes e injeções no construtor dos serviços.
+- Curva de leitura inicial: o desenvolvedor precisa saber qual serviço consultar para cada regra auxiliar.
+- A refatoração exige atualização coordenada de testes existentes (`RegistrarManualTransacaoTests`, `TransacaoEdicaoExclusaoServiceTest`, `CategorizacaoNaImportacaoTests`, entre outros).
+
+## Justificativa
+A decomposição foi considerada superior à manutenção de um service único porque preserva o comportamento externo da API enquanto melhora a estrutura interna exigida pela Sprint 4. O padrão segue a estratégia de camadas já definida na ADR-0004 e complementa os padrões formalizados na ADR-0005, aplicando separação de responsabilidades também dentro da camada de serviços — não apenas entre controller, service e repository.
+
+## Referências
+- Issue #128 — Refatoração/reengenharia orientada a design
+- Issue #130 — ADR da refatoração da Sprint 4
+- PR #187 — `refactor/128-transacao-service-design`
+- Classes afetadas: `TransacaoService`, `ContaUsuarioService`, `SugestaoCategoriaService`, `TransacaoMapper`, `CategoriaService`, `ImportacaoService`
+
+## Revisão futura
+A decisão poderá ser revista se o backend evoluir para arquitetura distribuída ou se novos domínios (dashboard, extrato futuro, parcelamentos) exigirem uma reorganização mais ampla dos bounded contexts. Enquanto o sistema permanecer monolítico, a decomposição por serviços especializados deve ser o padrão para novos módulos que acumulem responsabilidades semelhantes.

--- a/docs/arquitetura.md
+++ b/docs/arquitetura.md
@@ -112,7 +112,8 @@ Principais camadas MVC/backend:
 | Camada | Pacotes/arquivos | Responsabilidade |
 | --- | --- | --- |
 | Controller | `controller/*Controller.java` | Receber requisições HTTP, validar entrada básica, acionar serviços e devolver respostas HTTP. |
-| Service | `service/*Service.java` | Concentrar regras de negócio, validações de propriedade do usuário, fluxo de importação e conversão para DTOs. |
+| Service | `service/*Service.java` | Concentrar regras de negócio, validações de propriedade do usuário e fluxo de importação. |
+| Mapper | `mapper/*Mapper.java` | Converter entidades de domínio em DTOs de resposta da API. |
 | Model | `model/*.java` | Representar entidades persistidas, como `Usuario`, `Conta`, `Transacao`, `Categoria`, `Importacao`, `Fatura` e `CartaoCredito`. |
 | Repository | `repository/*Repository.java` | Acessar o banco por meio de Spring Data JPA. |
 | DTO | `dto/**` | Definir contratos de entrada e saída da API sem expor diretamente as entidades. |
@@ -197,13 +198,23 @@ Esse módulo apoia a visualização futura de relatórios por categoria.
 
 ### Transações
 
-O módulo de transações permite registrar manualmente lançamentos financeiros e alterar a categoria de uma transação existente. `TransacaoService` também possui lógica de sugestão simples de categoria a partir da descrição.
+O módulo de transações permite registrar manualmente lançamentos financeiros, editar, excluir, listar e categorizar transações do usuário autenticado.
 
-Esse módulo é central para o MVP porque representa os gastos e receitas controlados pelo usuário.
+Na Sprint 4, o `TransacaoService` foi reengenhado para atuar como coordenador dos casos de uso, delegando responsabilidades auxiliares:
+
+| Componente | Responsabilidade no módulo |
+| --- | --- |
+| `TransacaoService` | Orquestra criação, edição, exclusão, listagem paginada e categorização de transações. |
+| `ContaUsuarioService` | Resolve a conta da transação e valida se ela pertence ao usuário autenticado. |
+| `CategoriaService` | Busca categoria por ID e valida se ela pode ser usada pelo usuário. |
+| `SugestaoCategoriaService` | Sugere categoria padrão a partir da descrição (palavras-chave). |
+| `TransacaoMapper` | Converte `Transacao` em `TransacaoResponseDTO`. |
+
+Esse módulo é central para o MVP porque representa os gastos e receitas controlados pelo usuário. A decomposição está registrada na ADR-0008.
 
 ### Importações
 
-O módulo de importação processa arquivos enviados pelo usuário. `ImportacaoController` recebe upload `multipart/form-data`, `ImportacaoService` seleciona o parser compatível e registra o resultado da importação.
+O módulo de importação processa arquivos enviados pelo usuário. `ImportacaoController` recebe upload `multipart/form-data`, `ImportacaoService` seleciona o parser compatível, aplica sugestão de categoria via `SugestaoCategoriaService` e registra o resultado da importação.
 
 Parsers implementados:
 
@@ -320,3 +331,19 @@ Quando um arquivo chega via requisição, o `ImportacaoService` itera sobre as e
 **Benefício (Open/Closed Principle):**
 
 Se o SmartBudget precisar suportar arquivos PDF ou OFX no futuro, a equipe precisará apenas criar uma nova classe `ParserOFX` que implemente `ParserExtrato`. O `ImportacaoService` não precisará sofrer nenhuma alteração estrutural, garantindo segurança contra regressões.
+
+### Decomposição de serviços: Módulo de Transações
+
+Na Sprint 4, o `TransacaoService` deixou de concentrar regras auxiliares de conta, categoria, sugestão automática e mapeamento de DTO. A decisão segue o princípio de responsabilidade única dentro da camada de serviços.
+
+**Como funciona no código:**
+
+1. **Coordenador:** `TransacaoService` valida campos obrigatórios e executa o fluxo de cada caso de uso (registrar, editar, excluir, listar, categorizar).
+2. **Serviços especializados:** `ContaUsuarioService`, `CategoriaService` e `SugestaoCategoriaService` concentram regras reutilizáveis entre transações manuais e importação.
+3. **Mapper:** `TransacaoMapper` isola a montagem de `TransacaoResponseDTO`.
+
+**Benefício:**
+
+Alterações em sugestão de categoria ou resolução de conta podem ser testadas e evoluídas sem modificar toda a classe de transações. O `ImportacaoService` deixa de depender do `TransacaoService` apenas para sugerir categoria.
+
+**Referência:** ADR-0008.


### PR DESCRIPTION
Close #130

## O que mudou

- Criado `docs/adrs/ADR-0008-decomposicao-transacao-service.md` registrando a decomposição do `TransacaoService` na Sprint 4.
- Atualizado `docs/arquitetura.md` com os novos componentes (`ContaUsuarioService`, `SugestaoCategoriaService`, `TransacaoMapper`, extensão do `CategoriaService`) e nova subseção de padrões de projeto.
- Adicionado link do ADR-0008 no `README.md`.

## Por quê

- A issue #130 exige documentar a decisão arquitetural da refatoração/reengenharia da Sprint 4 (#128).
- O PR #187 do Victor extrai responsabilidades do `TransacaoService`; o ADR formaliza contexto, decisão, alternativas e consequências para rastreabilidade do time.

## Como testar

1. Abra `docs/adrs/ADR-0008-decomposicao-transacao-service.md` e confira se o documento segue o padrão dos ADRs anteriores (status, contexto, decisão, alternativas, consequências).
2. Verifique o link do ADR-0008 na seção **Documentos** do `README.md`.
3. Em `docs/arquitetura.md`, confira a seção **Transações**, a menção ao `SugestaoCategoriaService` em **Importações** e a subseção **Decomposição de serviços**.
4. Confirme que o PR referencia a refatoração do Victor (#187 / #128) sem alterar código de produção.

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos (mínimo 3)

- [Manutenção] O ADR-0008 documenta a separação de responsabilidades que o PR #187 aplica no backend, facilitando onboarding e revisões futuras no módulo de transações.
- [Manutenção] A atualização do `arquitetura.md` mantém a documentação C4 alinhada ao código refatorado, incluindo a camada `mapper` e o desacoplamento entre `ImportacaoService` e `TransacaoService`.
- [Risco] Este PR é apenas documentação; o comportamento da API depende do merge do PR #187. O ADR já deixa explícito que a mudança é interna e preserva os contratos HTTP existentes.
- [Teste] Não há impacto em testes automatizados; validação manual da consistência textual entre ADR, README e arquitetura.
