### PR TITLE
fix(frontend): importacao nao desloga em 403 Forbidden (#170)

### DIFF
--- a/app-financeiro-front-end/src/pages/ImportarExtrato.test.tsx
+++ b/app-financeiro-front-end/src/pages/ImportarExtrato.test.tsx
@@ -1,9 +1,19 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { AxiosError } from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import ImportarExtrato from './ImportarExtrato';
 import type { ContaResponse, ImportacaoResponse } from '../services/api';
+
+const criarErroAxios = (status: number, mensagem: string) =>
+  new AxiosError(mensagem, AxiosError.ERR_BAD_REQUEST, undefined, undefined, {
+    status,
+    statusText: String(status),
+    headers: {},
+    config: {} as never,
+    data: { erro: mensagem },
+  });
 
 const contaPrincipal: ContaResponse = {
   contaId: 'conta-1',
@@ -353,5 +363,47 @@ describe('Tela de Importação de Extratos', () => {
     await waitFor(() => {
       expect(screen.getByText('Não foi possível carregar suas contas. Tente novamente.')).toBeInTheDocument();
     });
+  });
+
+  it('nao deve deslogar o usuario quando criarImportacao retornar 403 Forbidden', async () => {
+    mockCriarImportacao.mockRejectedValueOnce(
+      criarErroAxios(403, 'Conta não pertence ao usuário autenticado.'),
+    );
+
+    renderizarComponente();
+    await aguardarContas();
+    await preencherEEnviar(criarArquivo('extrato.csv', 'text/csv'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Conta não pertence ao usuário autenticado.')).toBeInTheDocument();
+    });
+
+    expect(authState.sair).not.toHaveBeenCalled();
+    expect(screen.getByText(/Importar extrato ou NF-e/i)).toBeInTheDocument();
+  });
+
+  it('deve deslogar o usuario quando criarImportacao retornar 401 Unauthorized', async () => {
+    mockCriarImportacao.mockRejectedValueOnce(criarErroAxios(401, 'Sessão expirada.'));
+
+    renderizarComponente();
+    await aguardarContas();
+    await preencherEEnviar(criarArquivo('extrato.csv', 'text/csv'));
+
+    await waitFor(() => {
+      expect(authState.sair).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('nao deve deslogar o usuario quando listarContas retornar 403 Forbidden', async () => {
+    mockListarContas.mockReset();
+    mockListarContas.mockRejectedValue(criarErroAxios(403, 'Acesso negado.'));
+
+    renderizarComponente();
+
+    await waitFor(() => {
+      expect(screen.getByText('Acesso negado.')).toBeInTheDocument();
+    });
+
+    expect(authState.sair).not.toHaveBeenCalled();
   });
 });

--- a/app-financeiro-front-end/src/pages/ImportarExtrato.tsx
+++ b/app-financeiro-front-end/src/pages/ImportarExtrato.tsx
@@ -75,11 +75,13 @@ const ImportarExtrato: React.FC = () => {
         if (data.length === 1) setContaId(data[0].contaId);
       } catch (err) {
         const status = obterStatusHttp(err);
-        if (status === 401 || status === 403) {
+        if (status === 401) {
           sair();
           return;
         }
-        setErroGeral('Não foi possível carregar suas contas. Tente novamente.');
+        setErroGeral(
+          obterMensagemErroApi(err, 'Não foi possível carregar suas contas. Tente novamente.'),
+        );
       } finally {
         setCarregandoContas(false);
       }
@@ -106,8 +108,13 @@ const ImportarExtrato: React.FC = () => {
       } catch (err) {
         if (cancelado) return;
         const status = obterStatusHttp(err);
-        if (status === 401 || status === 403) {
+        if (status === 401) {
           sair();
+          return;
+        }
+        if (status === 403) {
+          setErroGeral(obterMensagemErroApi(err, 'Acesso negado ao acompanhar a importação.'));
+          setStatusAtual('ERRO');
           return;
         }
         // erro pontual no polling não interrompe — segue tentando até timeout
@@ -197,7 +204,7 @@ const ImportarExtrato: React.FC = () => {
       setStatusAtual(resultado.status);
     } catch (err) {
       const status = obterStatusHttp(err);
-      if (status === 401 || status === 403) {
+      if (status === 401) {
         sair();
         return;
       }

--- a/app-financeiro-front-end/src/services/api.ts
+++ b/app-financeiro-front-end/src/services/api.ts
@@ -30,7 +30,7 @@ api.interceptors.response.use(
     if (
       axios.isAxiosError(erro) &&
       !erro.config?.ignorarLogoutAutomatico &&
-      (erro.response?.status === 401 || erro.response?.status === 403)
+      erro.response?.status === 401
     ) {
       limparSessao();
       window.dispatchEvent(new Event('smartbudget:unauthorized'));


### PR DESCRIPTION
## O que mudou

- Interceptor do Axios passa a encerrar sessao apenas em respostas 401 Unauthorized (removido logout automatico em 403).
- Tela ImportarExtrato trata 403 exibindo mensagem de erro sem chamar sair(), em carregamento de contas, envio do arquivo e polling de status.
- Testes de regressao em ImportarExtrato.test.tsx para 403 e 401 em criarImportacao e listarContas.

## Por que

- Issue #170: usuario autenticado era redirecionado ao login ao importar extrato quando a API retornava 403 Forbidden (ex.: conta invalida ou permissao), em vez de exibir o erro e manter a sessao.
- O escopo deste PR cobre a parte frontend/testes; validacao E2E e backend do fluxo completo permanecem na issue para acompanhamento do assignee.

## Como testar

1. Faca login com usuario valido que possua conta cadastrada.
2. Acesse Importar extrato, selecione conta e arquivo .csv valido.
3. Confirme que a importacao conclui sem redirecionar para login.
4. (Opcional) Simule 403 na API e verifique mensagem de erro na tela sem logout.
5. Automatizado: cd app-financeiro-front-end && npm test -- --run src/pages/ImportarExtrato.test.tsx

## Auto-review (checklist)

- [x] Descricao clara (o que/por que/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidencia de teste (manual ou automatizado)
- [x] Nao quebrou funcionalidades existentes
- [x] Codigo revisado e limpo

## Comentarios tecnicos (minimo 3)

- [Risco] Mudanca no interceptor Axios afeta todas as requisicoes; apenas 401 dispara logout global agora.
- [Manutencao] Tratamento de erro unificado com obterMensagemErroApi no carregamento de contas e polling.
- [Teste] 18 testes em ImportarExtrato.test.tsx, incluindo regressao para 403 nao chamar sair e 401 chamar sair.
