### PR TITLE
Feat/#194 editar conta

### DIFF
--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ContaController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ContaController.java
@@ -1,5 +1,6 @@
 package bcd.appfinanceirobackend.controller;
 
+import bcd.appfinanceirobackend.dto.conta.ContaEdicaoRequestDTO;
 import bcd.appfinanceirobackend.dto.conta.ContaRequestDTO;
 import bcd.appfinanceirobackend.dto.conta.ContaResponseDTO;
 import bcd.appfinanceirobackend.model.Usuario;
@@ -29,6 +30,13 @@ public class ContaController {
     public ResponseEntity<ContaResponseDTO> registrarConta (@RequestBody ContaRequestDTO dto,
                                                             @AuthenticationPrincipal Usuario usuario) {
         return ResponseEntity.status(HttpStatus.CREATED).body(contaService.registrar(dto, usuario));
+    }
+
+    @PutMapping("/{contaId}")
+    public ResponseEntity<ContaResponseDTO> editarConta(@PathVariable UUID contaId,
+                                                        @RequestBody ContaEdicaoRequestDTO dto,
+                                                        @AuthenticationPrincipal Usuario usuario) {
+        return ResponseEntity.ok(contaService.editar(contaId, dto, usuario));
     }
 
     @DeleteMapping("/{id}")

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/conta/ContaEdicaoRequestDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/conta/ContaEdicaoRequestDTO.java
@@ -1,0 +1,11 @@
+package bcd.appfinanceirobackend.dto.conta;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ContaEdicaoRequestDTO {
+    private String nome;
+    private String descricao;
+}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
@@ -85,8 +85,8 @@ public class ContaService {
     }
 
     private void validarCamposObrigatoriosEdicao(ContaEdicaoRequestDTO dto) {
-        if (dto.getNome() == null || dto.getNome().isBlank()) {
-            throw new IllegalArgumentException("Campo obrigatório não informado: nome");
+        if (dto == null || dto.getNome() == null || dto.getNome().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Campo obrigatório não informado: nome");
         }
     }
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
@@ -89,7 +89,7 @@ public class ContaService {
             throw new IllegalArgumentException("Campo obrigatório não informado: nome");
         }
     }
-    
+
     public ContaResponseDTO toResponse(Conta conta) {
         ContaResponseDTO responseDTO = new ContaResponseDTO();
         responseDTO.setBanco(conta.getBanco());

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ContaService.java
@@ -1,5 +1,6 @@
 package bcd.appfinanceirobackend.service;
 
+import bcd.appfinanceirobackend.dto.conta.ContaEdicaoRequestDTO;
 import bcd.appfinanceirobackend.dto.conta.ContaRequestDTO;
 import bcd.appfinanceirobackend.dto.conta.ContaResponseDTO;
 import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
@@ -66,6 +67,29 @@ public class ContaService {
          contaRepository.delete(conta);
     }
 
+    public ContaResponseDTO editar(UUID contaId, ContaEdicaoRequestDTO dto, Usuario usuarioAutenticado) {
+        validarCamposObrigatoriosEdicao(dto);
+
+        Conta conta = contaRepository.findById(contaId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Conta não encontrada"));
+
+        if (!conta.getUsuario().getId().equals(usuarioAutenticado.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Conta não pertence ao usuário autenticado");
+        }
+
+        conta.setNome(dto.getNome());
+        conta.setDescricao(dto.getDescricao());
+
+        Conta contaAtualizada = contaRepository.save(conta);
+        return toResponse(contaAtualizada);
+    }
+
+    private void validarCamposObrigatoriosEdicao(ContaEdicaoRequestDTO dto) {
+        if (dto.getNome() == null || dto.getNome().isBlank()) {
+            throw new IllegalArgumentException("Campo obrigatório não informado: nome");
+        }
+    }
+    
     public ContaResponseDTO toResponse(Conta conta) {
         ContaResponseDTO responseDTO = new ContaResponseDTO();
         responseDTO.setBanco(conta.getBanco());


### PR DESCRIPTION
## O que mudou

- Implementado endpoint `PUT /contas/{contaId}` para edição de conta.
- Criado DTO específico para edição de conta, permitindo alterar apenas `nome` e `descricao`.
- Adicionada validação para impedir edição de conta pertencente a outro usuário.
- Mantidos `banco` e `tipoConta` sem alteração durante a edição.
- Ajustado o `ContaService` para concentrar a regra de negócio da edição.

Closes #194 

## Por quê

- Correção da issue #194, que solicita a funcionalidade de editar conta.
- A edição foi limitada a nome e descrição para evitar alteração de dados estruturais da conta.
- A validação de usuário dono da conta é necessária para manter o isolamento dos dados financeiros.

## Como testar

1. Suba o backend:

   ```bash
   cd app-financeiro-back-end
   ./gradlew bootRun
   ```

2. Faça login com um usuário válido e copie o token JWT.

3. Liste as contas do usuário autenticado:

   ```http
   GET /contas
   Authorization: Bearer <token>
   ```

4. Envie uma requisição para editar uma conta existente:

   ```http
   PUT /contas/{contaId}
   Authorization: Bearer <token>
   Content-Type: application/json
   ```

   ```json
   {
     "nome": "Conta principal",
     "descricao": "Conta usada para gastos do dia a dia"
   }
   ```

5. Verifique se a resposta retorna `nome` e `descricao` atualizados.

6. Verifique se `banco` e `tipoConta` continuam com os valores anteriores.

7. Tente editar uma conta pertencente a outro usuário e verifique se a API bloqueia a operação.

8. Rode os testes automatizados:

   ```bash
   cd app-financeiro-back-end
   ./gradlew test
   ```

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos (mínimo 3)

- [Risco] A edição valida se a conta pertence ao usuário autenticado antes de aplicar qualquer alteração, evitando acesso indevido a dados financeiros de outro usuário.
- [Manutenção] Foi usado um DTO específico para edição, deixando claro no contrato da API que apenas `nome` e `descricao` podem ser alterados.
- [Teste] Deve ser validado o cenário em que o usuário tenta editar uma conta inexistente ou pertencente a outro usuário.
- [Teste] Deve ser validado que `banco` e `tipoConta` permanecem inalterados após a edição.