### PR TITLE
test(frontend): testes de edicao e exclusao de transacoes (#149, #150)

### DIFF
--- a/app-financeiro-front-end/src/pages/EditarTransacao.test.tsx
+++ b/app-financeiro-front-end/src/pages/EditarTransacao.test.tsx
@@ -1,0 +1,251 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import EditarTransacao from './EditarTransacao';
+import * as api from '../services/api';
+
+vi.mock('../hooks/useAutenticacao', () => ({
+  useAutenticacao: () => ({
+    usuario: { id: 'user-123', nome: 'Usuário Teste', email: 'teste@teste.com' },
+    autenticado: true,
+    sair: vi.fn(),
+  }),
+}));
+
+vi.mock('../services/api', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../services/api')>();
+  return {
+    ...original,
+    listarContas: vi.fn(),
+    listarCategorias: vi.fn(),
+    editarTransacao: vi.fn(),
+    obterMensagemErroApi: vi.fn((_err: unknown, fallback: string) => fallback),
+  };
+});
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const original = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...original,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockContas: api.ContaResponse[] = [
+  { contaId: 'conta-1', nome: 'NuConta', banco: 'Nubank', tipoConta: 'CORRENTE' },
+];
+
+const mockCategorias: api.CategoriaResponse[] = [
+  { categoriaId: 'cat-1', nome: 'Alimentação', padrao: true },
+];
+
+const transacaoEdicao: api.TransacaoResponse = {
+  transacaoId: 'tx-1',
+  valor: 80,
+  data: '2026-06-02',
+  descricao: 'Supermercado',
+  tipoTransacao: 'DEBITO',
+  formaPagamento: 'PIX',
+  categoriaId: 'cat-1',
+  contaId: 'conta-1',
+  categorizada: true,
+};
+
+const renderEditarTransacao = (transacao?: api.TransacaoResponse) =>
+  render(
+    <MemoryRouter
+      initialEntries={[
+        transacao
+          ? {
+              pathname: `/transacoes/${transacao.transacaoId}/editar`,
+              state: { transacao },
+            }
+          : { pathname: '/transacoes/tx-1/editar' },
+      ]}
+    >
+      <Routes>
+        <Route path="/transacoes/:transacaoId/editar" element={<EditarTransacao />} />
+        <Route path="/transacoes" element={<span>Lista de transações</span>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+const aguardarFormulario = async () => {
+  await waitFor(() => {
+    expect(screen.queryByText(/Carregando dados da transação/i)).not.toBeInTheDocument();
+  });
+
+  expect(screen.getByLabelText(/Valor \*/i)).toBeInTheDocument();
+};
+
+describe('Tela de Edição de Transações (Issue #149)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.clearAllTimers();
+    mockNavigate.mockClear();
+    vi.mocked(api.listarContas).mockReset();
+    vi.mocked(api.listarCategorias).mockReset();
+    vi.mocked(api.editarTransacao).mockReset();
+    vi.mocked(api.listarContas).mockResolvedValue(mockContas);
+    vi.mocked(api.listarCategorias).mockResolvedValue(mockCategorias);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+  });
+
+  it('deve exibir mensagem quando a transação não for carregada pelo state da navegação', async () => {
+    renderEditarTransacao();
+
+    expect(
+      screen.getByText(
+        /Não foi possível carregar os dados diretamente por esta URL/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Voltar para transações/i })).toHaveAttribute('href', '/transacoes');
+    expect(api.editarTransacao).not.toHaveBeenCalled();
+  });
+
+  it('deve carregar os dados da transação nos campos do formulário', async () => {
+    renderEditarTransacao(transacaoEdicao);
+    await aguardarFormulario();
+
+    expect(screen.getByLabelText(/Valor \*/i)).toHaveValue(80);
+    expect(screen.getByLabelText(/Data \*/i)).toHaveValue('2026-06-02');
+    expect(screen.getByLabelText(/Descrição/i)).toHaveValue('Supermercado');
+    expect(screen.getByLabelText(/Tipo \*/i)).toHaveValue('DEBITO');
+    expect(screen.getByLabelText(/Forma de pagamento/i)).toHaveValue('PIX');
+    expect(screen.getByRole('combobox', { name: /^categoria$/i })).toHaveValue('cat-1');
+    expect(screen.getByLabelText(/Conta \*/i)).toHaveValue('conta-1');
+  });
+
+  it('deve exibir loading enquanto carrega contas e categorias', async () => {
+    let resolverContas: (valor: api.ContaResponse[]) => void = () => undefined;
+    let resolverCategorias: (valor: api.CategoriaResponse[]) => void = () => undefined;
+
+    vi.mocked(api.listarContas).mockImplementationOnce(
+      () =>
+        new Promise<api.ContaResponse[]>((resolve) => {
+          resolverContas = resolve;
+        }),
+    );
+    vi.mocked(api.listarCategorias).mockImplementationOnce(
+      () =>
+        new Promise<api.CategoriaResponse[]>((resolve) => {
+          resolverCategorias = resolve;
+        }),
+    );
+
+    renderEditarTransacao(transacaoEdicao);
+
+    expect(screen.getByText(/Carregando dados da transação/i)).toBeInTheDocument();
+
+    resolverContas(mockContas);
+    resolverCategorias(mockCategorias);
+
+    await aguardarFormulario();
+  });
+
+  it('deve validar campos obrigatórios antes de enviar a atualização', async () => {
+    renderEditarTransacao(transacaoEdicao);
+    await aguardarFormulario();
+
+    fireEvent.change(screen.getByLabelText(/Valor \*/i), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText(/Data \*/i), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText(/Conta \*/i), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /Salvar alterações/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Valor é obrigatório.')).toBeInTheDocument();
+      expect(screen.getByText('Data é obrigatória.')).toBeInTheDocument();
+      expect(screen.getByText('Conta é obrigatória para esta forma de pagamento.')).toBeInTheDocument();
+    });
+
+    expect(api.editarTransacao).not.toHaveBeenCalled();
+  });
+
+  it('deve exibir loading enquanto editarTransacao estiver pendente', async () => {
+    let resolver: () => void = () => undefined;
+
+    vi.mocked(api.editarTransacao).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolver = () => resolve();
+        }),
+    );
+
+    renderEditarTransacao(transacaoEdicao);
+    await aguardarFormulario();
+
+    fireEvent.change(screen.getByLabelText(/Valor \*/i), { target: { value: '95' } });
+    fireEvent.click(screen.getByRole('button', { name: /Salvar alterações/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Salvando...')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Salvando/i })).toBeDisabled();
+    });
+
+    resolver();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled();
+    });
+  });
+
+  it('deve enviar alterações com sucesso e redirecionar para a listagem', async () => {
+    vi.mocked(api.editarTransacao).mockResolvedValueOnce(transacaoEdicao);
+
+    renderEditarTransacao(transacaoEdicao);
+    await aguardarFormulario();
+
+    fireEvent.change(screen.getByLabelText(/Valor \*/i), { target: { value: '95.50' } });
+    fireEvent.change(screen.getByLabelText(/Descrição/i), { target: { value: 'Mercado atualizado' } });
+    fireEvent.change(screen.getByRole('combobox', { name: /^categoria$/i }), { target: { value: 'cat-1' } });
+    fireEvent.click(screen.getByRole('button', { name: /Salvar alterações/i }));
+
+    await waitFor(() => {
+      expect(api.editarTransacao).toHaveBeenCalledWith('tx-1', {
+        valor: 95.5,
+        data: '2026-06-02',
+        descricao: 'Mercado atualizado',
+        tipoTransacao: 'DEBITO',
+        formaPagamento: 'PIX',
+        categoriaId: 'cat-1',
+        contaId: 'conta-1',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/transacoes', {
+        replace: true,
+        state: { mensagem: 'Transação atualizada com sucesso.' },
+      });
+    });
+  });
+
+  it('deve exibir erro quando a atualização falhar', async () => {
+    vi.mocked(api.editarTransacao).mockRejectedValueOnce(new Error('Falha na API'));
+
+    renderEditarTransacao(transacaoEdicao);
+    await aguardarFormulario();
+
+    fireEvent.click(screen.getByRole('button', { name: /Salvar alterações/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Não foi possível atualizar a transação.')).toBeInTheDocument();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('deve voltar para a listagem ao cancelar sem persistir alterações', async () => {
+    renderEditarTransacao(transacaoEdicao);
+    await aguardarFormulario();
+
+    fireEvent.change(screen.getByLabelText(/Valor \*/i), { target: { value: '999' } });
+    fireEvent.click(screen.getByRole('link', { name: /Cancelar/i }));
+
+    expect(await screen.findByText('Lista de transações')).toBeInTheDocument();
+    expect(api.editarTransacao).not.toHaveBeenCalled();
+  });
+});

--- a/app-financeiro-front-end/src/pages/Transacoes.test.tsx
+++ b/app-financeiro-front-end/src/pages/Transacoes.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../services/api', async (importOriginal) => {
     listarCategorias: vi.fn(),
     listarTransacoes: vi.fn(),
     categorizarTransacao: vi.fn(),
+    excluirTransacao: vi.fn(),
     obterMensagemErroApi: vi.fn((_err: unknown, fallback: string) => fallback),
   };
 });
@@ -118,6 +119,7 @@ describe('Tela de listagem de Transações (Issue #155)', () => {
     vi.mocked(api.listarCategorias).mockReset();
     vi.mocked(api.listarTransacoes).mockReset();
     vi.mocked(api.categorizarTransacao).mockReset();
+    vi.mocked(api.excluirTransacao).mockReset();
     vi.mocked(api.listarContas).mockResolvedValue(mockContas);
     vi.mocked(api.listarCategorias).mockResolvedValue(mockCategorias);
     vi.mocked(api.listarTransacoes).mockResolvedValue(paginaVazia());
@@ -335,5 +337,127 @@ describe('Tela de listagem de Transações (Issue #155)', () => {
       expect(api.categorizarTransacao).toHaveBeenCalledWith('tx-2', 'cat-1');
       expect(screen.getByText('Categoria atualizada com sucesso.')).toBeInTheDocument();
     });
+  });
+});
+
+describe('Fluxo de exclusão de Transações (Issue #150)', () => {
+  let confirmSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    vi.mocked(api.excluirTransacao).mockReset();
+    vi.mocked(api.listarContas).mockResolvedValue(mockContas);
+    vi.mocked(api.listarCategorias).mockResolvedValue(mockCategorias);
+    vi.mocked(api.listarTransacoes).mockResolvedValue(paginaComConteudo([transacaoDespesa]));
+  });
+
+  afterEach(() => {
+    confirmSpy.mockRestore();
+  });
+
+  it('deve exibir link de edição com rota e state da transação', async () => {
+    renderTransacoes();
+    await aguardarCarregamento();
+
+    const linkEditar = screen.getByRole('link', { name: /Editar/i });
+    expect(linkEditar).toHaveAttribute('href', '/transacoes/tx-1/editar');
+  });
+
+  it('deve solicitar confirmação ao acionar excluir em uma transação', async () => {
+    confirmSpy.mockReturnValue(false);
+
+    const usuario = userEvent.setup();
+    renderTransacoes();
+    await aguardarCarregamento();
+
+    await usuario.click(screen.getByRole('button', { name: /^Excluir$/i }));
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Deseja excluir a transação "Supermercado"? Esta ação não pode ser desfeita.',
+    );
+    expect(api.excluirTransacao).not.toHaveBeenCalled();
+  });
+
+  it('deve manter a transação na listagem quando a exclusão for cancelada', async () => {
+    confirmSpy.mockReturnValue(false);
+
+    const usuario = userEvent.setup();
+    renderTransacoes();
+    await aguardarCarregamento();
+
+    await usuario.click(screen.getByRole('button', { name: /^Excluir$/i }));
+
+    expect(screen.getByText('Supermercado')).toBeInTheDocument();
+    expect(api.excluirTransacao).not.toHaveBeenCalled();
+  });
+
+  it('deve remover a transação da listagem e exibir sucesso ao confirmar exclusão', async () => {
+    confirmSpy.mockReturnValue(true);
+    vi.mocked(api.excluirTransacao).mockResolvedValueOnce(undefined);
+    vi.mocked(api.listarTransacoes)
+      .mockResolvedValueOnce(paginaComConteudo([transacaoDespesa]))
+      .mockResolvedValueOnce(paginaVazia());
+
+    const usuario = userEvent.setup();
+    renderTransacoes();
+    await aguardarCarregamento();
+
+    await usuario.click(screen.getByRole('button', { name: /^Excluir$/i }));
+
+    await waitFor(() => {
+      expect(api.excluirTransacao).toHaveBeenCalledWith('tx-1');
+      expect(screen.getByText('Transação excluída com sucesso.')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(api.listarTransacoes).toHaveBeenCalledTimes(2);
+      expect(screen.getByText(/Nenhuma transação encontrada/i)).toBeInTheDocument();
+    });
+  });
+
+  it('deve exibir estado de carregamento enquanto a exclusão estiver pendente', async () => {
+    confirmSpy.mockReturnValue(true);
+
+    let resolverExclusao: () => void = () => undefined;
+    vi.mocked(api.excluirTransacao).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolverExclusao = () => resolve();
+        }),
+    );
+
+    const usuario = userEvent.setup();
+    renderTransacoes();
+    await aguardarCarregamento();
+
+    await usuario.click(screen.getByRole('button', { name: /^Excluir$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Excluindo/i })).toBeDisabled();
+    });
+
+    resolverExclusao();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Excluir$/i })).toBeInTheDocument();
+    });
+  });
+
+  it('deve exibir erro quando excluirTransacao falhar', async () => {
+    confirmSpy.mockReturnValue(true);
+    vi.mocked(api.excluirTransacao).mockRejectedValueOnce(new Error('Falha na API'));
+
+    const usuario = userEvent.setup();
+    renderTransacoes();
+    await aguardarCarregamento();
+
+    await usuario.click(screen.getByRole('button', { name: /^Excluir$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Não foi possível excluir a transação.')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Supermercado')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
> **Substituído por [#204](https://github.com/IFSC-ES2/projeto-app_financeiro/pull/204) e [#205](https://github.com/IFSC-ES2/projeto-app_financeiro/pull/205).**

## O que mudou

- Criado `EditarTransacao.test.tsx` com testes da tela de edição.
- Adicionados testes do fluxo de exclusão em `Transacoes.test.tsx`.

Close #149
Close #150

## Por quê

- Issues #149 e #150 pediam cobertura automatizada após merge da #135.
- Escopo restrito a `*.test.tsx`, sem alterar componentes de produção.

## Como testar

```bash
cd app-financeiro-front-end
npm test -- --run src/pages/EditarTransacao.test.tsx
npm test -- --run src/pages/Transacoes.test.tsx
```

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: vazio, 0, erro)
- [x] Evidência de teste (manual ou automatizado)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos (mínimo 3)

- [Risco] Baixo: alterações apenas em arquivos de teste.
- [Manutenção] Reutiliza padrão de mocks de `NovaTransacao.test.tsx` e `Transacoes.test.tsx` (#155).
- [Teste] Exclusão valida `window.confirm`; edição mocka `location.state` conforme limitação atual da API.
