### PR TITLE
Modelagem: TipoTransacao apenas com sentido financeiro (#176)

### DIFF
--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/model/enums/TipoTransacao.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/model/enums/TipoTransacao.java
@@ -1,8 +1,11 @@
 package bcd.appfinanceirobackend.model.enums;
 
+/**
+ * Sentido financeiro da transação.
+ * Não representa forma nem condição de pagamento — isso é responsabilidade
+ * de {@link TipoPagamento}. Boleto e parcelamento foram removidos daqui (issue #176).
+ */
 public enum TipoTransacao {
     DEBITO,
-    CREDITO,
-    PARCELAMENTO,
-    BOLETO
+    CREDITO
 }

--- a/app-financeiro-back-end/src/main/resources/db/migration/V4__ajusta_tipo_transacao.sql
+++ b/app-financeiro-back-end/src/main/resources/db/migration/V4__ajusta_tipo_transacao.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- SmartBudget - Ajuste de modelagem de tipo de transação
+-- V4__ajusta_tipo_transacao.sql
+-- ============================================================
+-- TipoTransacao passa a representar apenas o sentido financeiro
+-- (DEBITO / CREDITO). Valores que descrevem forma/condição de
+-- pagamento saem da coluna `tipo`:
+--   - BOLETO       -> tipo DEBITO + forma_pagamento BOLETO
+--   - PARCELAMENTO -> tipo DEBITO (parcela paga é uma saída)
+--
+-- Necessário porque `tipo` é mapeado como @Enumerated(STRING); uma linha
+-- legada com 'BOLETO'/'PARCELAMENTO' quebraria a leitura do Hibernate.
+-- Em banco novo nenhuma linha é afetada (no-op seguro).
+-- ============================================================
+
+UPDATE transacoes
+   SET forma_pagamento = 'BOLETO'
+ WHERE tipo = 'BOLETO'
+   AND (forma_pagamento IS NULL OR forma_pagamento = '');
+
+UPDATE transacoes
+   SET tipo = 'DEBITO'
+ WHERE tipo IN ('BOLETO', 'PARCELAMENTO');

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/parser/ParserCSVTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/parser/ParserCSVTest.java
@@ -316,4 +316,71 @@ class ParserCSVTest {
             );
         }
     }
+
+    @Nested
+    @DisplayName("parsear() - Tipo textual legado (regressão #176)")
+    class TipoTextualLegado {
+
+        @Test
+        @DisplayName("tipo BOLETO legado com valor positivo não quebra e faz fallback para CREDITO")
+        void tipoBoletoPositivo_naoQuebra_viraCredito() {
+            String conteudo = "2024-01-10,Recebimento,300.00,BOLETO\n";
+
+            ResultadoParser resultado = parser.parsear(fromString("extrato.csv", conteudo), conta);
+
+            assertAll(
+                    () -> assertEquals(1, resultado.getTransacoes().size()),
+                    () -> assertEquals(0, resultado.getLinhasInvalidas()),
+                    () -> assertEquals(TipoTransacao.CREDITO, resultado.getTransacoes().get(0).getTipo()),
+                    // o parser deriva apenas o sentido financeiro; não infere forma de pagamento do extrato
+                    () -> assertNull(resultado.getTransacoes().get(0).getFormaPagamento())
+            );
+        }
+
+        @Test
+        @DisplayName("tipo BOLETO legado com valor negativo vira DEBITO pela regra do sinal")
+        void tipoBoletoNegativo_viraDebito() {
+            String conteudo = "2024-01-10,Pagamento boleto,-300.00,BOLETO\n";
+
+            ResultadoParser resultado = parser.parsear(fromString("extrato.csv", conteudo), conta);
+
+            assertAll(
+                    () -> assertEquals(1, resultado.getTransacoes().size()),
+                    () -> assertEquals(0, resultado.getLinhasInvalidas()),
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(0).getTipo())
+            );
+        }
+
+        @Test
+        @DisplayName("tipo PARCELAMENTO legado com valor negativo vira DEBITO")
+        void tipoParcelamentoNegativo_viraDebito() {
+            String conteudo = "2024-01-11,Parcela cartao,-150.00,PARCELAMENTO\n";
+
+            ResultadoParser resultado = parser.parsear(fromString("extrato.csv", conteudo), conta);
+
+            assertAll(
+                    () -> assertEquals(1, resultado.getTransacoes().size()),
+                    () -> assertEquals(0, resultado.getLinhasInvalidas()),
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(0).getTipo())
+            );
+        }
+
+        @Test
+        @DisplayName("arquivo só com tipos legados não lança exceção e só produz DEBITO/CREDITO")
+        void arquivoComTiposLegados_naoLancaEProduzApenasDebitoOuCredito() {
+            String conteudo = "2024-01-10,Boleto a pagar,-300.00,BOLETO\n"
+                    + "2024-01-11,Parcela cartao,-150.00,PARCELAMENTO\n"
+                    + "2024-01-12,Recebimento,80.00,BOLETO\n";
+
+            ResultadoParser resultado = parser.parsear(fromString("extrato.csv", conteudo), conta);
+
+            assertAll(
+                    () -> assertEquals(3, resultado.getTransacoes().size()),
+                    () -> assertEquals(0, resultado.getLinhasInvalidas()),
+                    () -> assertTrue(resultado.getTransacoes().stream().allMatch(transacao ->
+                            transacao.getTipo() == TipoTransacao.DEBITO
+                                    || transacao.getTipo() == TipoTransacao.CREDITO))
+            );
+        }
+    }
 }

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/parser/ParserXMLTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/parser/ParserXMLTest.java
@@ -449,4 +449,58 @@ class ParserXMLTest {
             assertTrue(ex.getMessage().contains("Erro ao processar arquivo XML"));
         }
     }
+
+    @Nested
+    @DisplayName("parsear() - Tipo textual legado (regressão #176)")
+    class TipoTextualLegado {
+
+        private String xmlComTipo(String valor, String tipo) {
+            return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                    + "<extrato><transacao>"
+                    + "<data>2024-01-10</data>"
+                    + "<descricao>Lancamento legado</descricao>"
+                    + "<valor>" + valor + "</valor>"
+                    + "<tipo>" + tipo + "</tipo>"
+                    + "</transacao></extrato>";
+        }
+
+        @Test
+        @DisplayName("tipo BOLETO legado com valor positivo não quebra e faz fallback para CREDITO")
+        void tipoBoletoPositivo_naoQuebra_viraCredito() {
+            ResultadoParser resultado = parser.parsear(fromString("extrato.xml", xmlComTipo("300.00", "BOLETO")), conta);
+            Transacao transacao = resultado.getTransacoes().get(0);
+
+            assertAll(
+                    () -> assertEquals(1, resultado.getTransacoes().size()),
+                    () -> assertEquals(0, resultado.getLinhasInvalidas()),
+                    () -> assertEquals(TipoTransacao.CREDITO, transacao.getTipo()),
+                    // o parser deriva apenas o sentido financeiro; não infere forma de pagamento do extrato
+                    () -> assertNull(transacao.getFormaPagamento())
+            );
+        }
+
+        @Test
+        @DisplayName("tipo BOLETO legado com valor negativo vira DEBITO pela regra do sinal")
+        void tipoBoletoNegativo_viraDebito() {
+            ResultadoParser resultado = parser.parsear(fromString("extrato.xml", xmlComTipo("-300.00", "BOLETO")), conta);
+
+            assertAll(
+                    () -> assertEquals(1, resultado.getTransacoes().size()),
+                    () -> assertEquals(0, resultado.getLinhasInvalidas()),
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(0).getTipo())
+            );
+        }
+
+        @Test
+        @DisplayName("tipo PARCELAMENTO legado com valor negativo vira DEBITO")
+        void tipoParcelamentoNegativo_viraDebito() {
+            ResultadoParser resultado = parser.parsear(fromString("extrato.xml", xmlComTipo("-150.00", "PARCELAMENTO")), conta);
+
+            assertAll(
+                    () -> assertEquals(1, resultado.getTransacoes().size()),
+                    () -> assertEquals(0, resultado.getLinhasInvalidas()),
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(0).getTipo())
+            );
+        }
+    }
 }

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/AjusteTipoTransacaoMigrationIntegrationTests.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/AjusteTipoTransacaoMigrationIntegrationTests.java
@@ -1,0 +1,168 @@
+package bcd.appfinanceirobackend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Valida a regra da migration V4 com banco real: dados legados com
+ * {@code tipo = 'BOLETO'} ou {@code tipo = 'PARCELAMENTO'} precisam ser
+ * normalizados, porque o enum Java {@code TipoTransacao} deixou de mapear esses
+ * valores e o Hibernate quebraria ao lê-los.
+ *
+ * As linhas legadas são inseridas via JDBC bruto (a coluna é VARCHAR sem CHECK,
+ * então aceita o valor antigo que o enum já não tem). O SQL executado é o
+ * próprio arquivo da V4 lido do classpath — o Flyway já a roda no startup, mas
+ * sobre uma tabela vazia (no-op), então a reexecutamos sobre as linhas legadas.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@Transactional
+@DisplayName("Migration V4 (ajuste TipoTransacao) - Integração com banco real")
+class AjusteTipoTransacaoMigrationIntegrationTests {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("app_financeiro_test")
+            .withUsername("postgres")
+            .withPassword("1234");
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private UUID contaId;
+
+    @BeforeEach
+    void seedConta() {
+        UUID usuarioId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO usuario (id, nome, email, senha, cpf) VALUES (?, ?, ?, ?, ?)",
+                usuarioId, "Dono Migration", "dono-migration@test.com", "hash", "12345678901");
+
+        contaId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO contas (id, usuario_id, nome, tipo) VALUES (?, ?, ?, ?)",
+                contaId, usuarioId, "Conta Corrente", "CORRENTE");
+    }
+
+    @Test
+    @DisplayName("tipo='BOLETO' legado vira DEBITO e move BOLETO para forma_pagamento")
+    void boletoLegado_viraDebito_eMoveFormaPagamento() throws IOException {
+        UUID id = inserirTransacaoLegada("BOLETO", new BigDecimal("150.00"), null);
+
+        aplicarMigracaoV4();
+
+        assertThat(tipoDe(id)).isEqualTo("DEBITO");
+        assertThat(formaPagamentoDe(id)).isEqualTo("BOLETO");
+    }
+
+    @Test
+    @DisplayName("tipo='PARCELAMENTO' legado vira DEBITO sem inventar forma_pagamento")
+    void parcelamentoLegado_viraDebito() throws IOException {
+        UUID id = inserirTransacaoLegada("PARCELAMENTO", new BigDecimal("90.00"), null);
+
+        aplicarMigracaoV4();
+
+        assertThat(tipoDe(id)).isEqualTo("DEBITO");
+        assertThat(formaPagamentoDe(id)).isNull();
+    }
+
+    @Test
+    @DisplayName("Após a migração, nenhuma linha permanece com tipo fora de DEBITO/CREDITO")
+    void aposMigracao_nenhumaLinhaForaDeDebitoOuCredito() throws IOException {
+        inserirTransacaoLegada("BOLETO", new BigDecimal("150.00"), null);
+        inserirTransacaoLegada("PARCELAMENTO", new BigDecimal("90.00"), null);
+        inserirTransacaoLegada("DEBITO", new BigDecimal("30.00"), null);
+        inserirTransacaoLegada("CREDITO", new BigDecimal("500.00"), null);
+
+        aplicarMigracaoV4();
+
+        Integer fora = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM transacoes WHERE tipo NOT IN ('DEBITO', 'CREDITO')", Integer.class);
+        assertThat(fora).isZero();
+    }
+
+    @Test
+    @DisplayName("BOLETO com forma_pagamento já preenchida vira DEBITO e preserva a forma existente")
+    void boletoComFormaPagamentoExistente_preservaForma() throws IOException {
+        UUID id = inserirTransacaoLegada("BOLETO", new BigDecimal("150.00"), "PIX");
+
+        aplicarMigracaoV4();
+
+        assertThat(tipoDe(id)).isEqualTo("DEBITO");
+        assertThat(formaPagamentoDe(id)).isEqualTo("PIX");
+    }
+
+    @Test
+    @DisplayName("Linhas já corretas (DEBITO/CREDITO) não são alteradas pela migração")
+    void debitoECreditoExistentes_naoSaoAlterados() throws IOException {
+        UUID debito = inserirTransacaoLegada("DEBITO", new BigDecimal("30.00"), null);
+        UUID credito = inserirTransacaoLegada("CREDITO", new BigDecimal("500.00"), null);
+
+        aplicarMigracaoV4();
+
+        assertThat(tipoDe(debito)).isEqualTo("DEBITO");
+        assertThat(tipoDe(credito)).isEqualTo("CREDITO");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private UUID inserirTransacaoLegada(String tipo, BigDecimal valor, String formaPagamento) {
+        UUID id = UUID.randomUUID();
+        if (formaPagamento == null) {
+            jdbcTemplate.update(
+                    "INSERT INTO transacoes (id, conta_id, valor, data, descricao, tipo) VALUES (?, ?, ?, ?, ?, ?)",
+                    id, contaId, valor, LocalDate.of(2024, 1, 1), "legado " + tipo, tipo);
+        } else {
+            jdbcTemplate.update(
+                    "INSERT INTO transacoes (id, conta_id, valor, data, descricao, tipo, forma_pagamento) "
+                            + "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    id, contaId, valor, LocalDate.of(2024, 1, 1), "legado " + tipo, tipo, formaPagamento);
+        }
+        return id;
+    }
+
+    /** Executa o SQL real da V4 (lido do classpath), instrução a instrução. */
+    private void aplicarMigracaoV4() throws IOException {
+        String conteudo = new String(new ClassPathResource(
+                "db/migration/V4__ajusta_tipo_transacao.sql").getInputStream().readAllBytes(),
+                StandardCharsets.UTF_8);
+        String semComentarios = conteudo.lines()
+                .filter(linha -> !linha.stripLeading().startsWith("--"))
+                .collect(Collectors.joining("\n"));
+        for (String instrucao : semComentarios.split(";")) {
+            if (!instrucao.isBlank()) {
+                jdbcTemplate.execute(instrucao.strip());
+            }
+        }
+    }
+
+    private String tipoDe(UUID id) {
+        return jdbcTemplate.queryForObject("SELECT tipo FROM transacoes WHERE id = ?", String.class, id);
+    }
+
+    private String formaPagamentoDe(UUID id) {
+        return jdbcTemplate.queryForObject("SELECT forma_pagamento FROM transacoes WHERE id = ?", String.class, id);
+    }
+}

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/ListarTransacoesPaginadoIntegrationTests.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/ListarTransacoesPaginadoIntegrationTests.java
@@ -72,7 +72,7 @@ class ListarTransacoesPaginadoIntegrationTests {
         salvarTransacao(contaDono, LocalDate.of(2024, 1, 10), TipoTransacao.DEBITO, alimentacao);
         salvarTransacao(contaDono, LocalDate.of(2024, 2, 15), TipoTransacao.CREDITO, null);
         salvarTransacao(contaDono, LocalDate.of(2024, 3, 20), TipoTransacao.DEBITO, transporte);
-        salvarTransacao(contaDono, LocalDate.of(2024, 3, 25), TipoTransacao.BOLETO, null);
+        salvarTransacao(contaDono, LocalDate.of(2024, 3, 25), TipoTransacao.CREDITO, null);
 
         // Transação de outro usuário — não deve aparecer para o dono
         Usuario outro = salvarUsuario("outro106@test.com", "39053344705");

--- a/app-financeiro-front-end/src/pages/EditarTransacao.tsx
+++ b/app-financeiro-front-end/src/pages/EditarTransacao.tsx
@@ -36,8 +36,6 @@ interface EstadoEdicaoTransacao {
 const tiposTransacao: Array<{ valor: TipoTransacao; rotulo: string }> = [
   { valor: 'DEBITO', rotulo: 'Saída / despesa' },
   { valor: 'CREDITO', rotulo: 'Entrada / receita' },
-  { valor: 'PARCELAMENTO', rotulo: 'Parcelamento' },
-  { valor: 'BOLETO', rotulo: 'Boleto' },
 ];
 
 const formasPagamento: Array<{ valor: TipoPagamento; rotulo: string }> = [

--- a/app-financeiro-front-end/src/pages/NovaTransacao.tsx
+++ b/app-financeiro-front-end/src/pages/NovaTransacao.tsx
@@ -261,8 +261,6 @@ const NovaTransacao = () => {
                 >
                   <option value="DEBITO">Saída / despesa</option>
                   <option value="CREDITO">Entrada / receita</option>
-                  <option value="PARCELAMENTO">Parcelamento</option>
-                  <option value="BOLETO">Boleto</option>
                 </select>
                 {erros.tipoTransacao && <small className="field-error">{erros.tipoTransacao}</small>}
               </label>

--- a/app-financeiro-front-end/src/pages/Transacoes.tsx
+++ b/app-financeiro-front-end/src/pages/Transacoes.tsx
@@ -49,8 +49,6 @@ const obterRotuloTipo = (tipo: TipoTransacao) => {
   const rotulos: Record<TipoTransacao, string> = {
     CREDITO: 'Receita',
     DEBITO: 'Despesa',
-    PARCELAMENTO: 'Parcelamento',
-    BOLETO: 'Boleto',
   };
 
   return rotulos[tipo];
@@ -292,8 +290,6 @@ const Transacoes = () => {
             <option value="">Todos os tipos</option>
             <option value="CREDITO">Receita</option>
             <option value="DEBITO">Despesa</option>
-            <option value="PARCELAMENTO">Parcelamento</option>
-            <option value="BOLETO">Boleto</option>
           </select>
         </label>
 

--- a/app-financeiro-front-end/src/services/api.ts
+++ b/app-financeiro-front-end/src/services/api.ts
@@ -40,7 +40,7 @@ api.interceptors.response.use(
   }
 );
 
-export type TipoTransacao = 'DEBITO' | 'CREDITO' | 'PARCELAMENTO' | 'BOLETO';
+export type TipoTransacao = 'DEBITO' | 'CREDITO';
 export type TipoPagamento = 'PIX' | 'CARTAO_DEBITO' | 'CARTAO_CREDITO' | 'DINHEIRO' | 'BOLETO' | 'TED_DOC';
 export type TipoConta = 'CORRENTE' | 'POUPANCA' | 'CARTAO_CREDITO' | 'CARTEIRA';
 

--- a/docs/diagramaUML.md
+++ b/docs/diagramaUML.md
@@ -87,8 +87,6 @@ classDiagram
     <<enumeration>>
     DEBITO
     CREDITO
-    PARCELAMENTO
-    BOLETO
   }
  
   class TipoPagamento {


### PR DESCRIPTION
## O que mudou

- `TipoTransacao` passa a representar **apenas o sentido financeiro**: agora só `DEBITO` e `CREDITO` (removidos `PARCELAMENTO` e `BOLETO`).
- `BOLETO` permanece em `TipoPagamento`, onde é a modelagem correta (forma de pagamento).
- Migration `V4__ajusta_tipo_transacao.sql`: normaliza dados existentes — `tipo='BOLETO'` vira `DEBITO` + `forma_pagamento='BOLETO'`; `tipo='PARCELAMENTO'` vira `DEBITO`.
- Frontend: `TipoTransacao` em `api.ts` reduzido a `DEBITO | CREDITO`; selects de tipo em Nova/Editar transação e o filtro da listagem passam a oferecer só esses dois; `Record` de rótulos atualizado.
- `docs/diagramaUML.md`: enum `TipoTransacao` atualizado.
- Teste de paginação ajustado (a transação que era `BOLETO` virou `CREDITO`, preservando a distribuição 2 débitos / 2 créditos e todas as asserções existentes).

Closes #176

## Por quê

- `TipoTransacao` misturava sentido financeiro (débito/crédito) com forma/condição de pagamento (`BOLETO`, `PARCELAMENTO`), gerando ambiguidade em filtros, resumos, importação e dashboard.
- Como `tipo` é mapeado com `@Enumerated(STRING)`, uma linha legada com `'BOLETO'`/`'PARCELAMENTO'` quebraria a leitura do Hibernate — por isso a migration roda no startup (Flyway) **antes** de qualquer leitura. Em banco novo é um no-op seguro.
- Backend e frontend passam a usar a mesma regra de modelagem.

## Como testar

1. Backend: `cd app-financeiro-back-end && ./gradlew test` — a suíte (incl. testes de integração com Postgres via Testcontainers) sobe o Flyway com a V4 e passa.
2. Frontend: `cd app-financeiro-front-end && npm run build && npm test` — o `tsc` valida que não sobrou referência aos tipos removidos; 68 testes verdes.
3. App: em **Nova transação** / **Editar transação**, o seletor "Tipo" mostra só *Saída / despesa* e *Entrada / receita*.
4. Em **Transações**, o filtro por tipo mostra só *Receita* e *Despesa*.
5. Importação de CSV/TXT/XML/NF-e continua funcionando (parsers mapeiam pelo sinal do valor; `tipo` textual não reconhecido cai no fallback DEBITO/CREDITO).

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (dados legados, banco novo, importação)
- [x] Evidência de teste (back + front verdes)
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos

- [Modelagem] Separar sentido financeiro (`TipoTransacao`) de forma de pagamento (`TipoPagamento`) remove ambiguidade para dashboard, resumo por forma de pagamento e extrato futuro (#67, #68, #171).
- [Migração] A V4 é idempotente e segura em banco novo (nenhuma linha afetada); em banco com dados, preserva a informação movendo `BOLETO` para `forma_pagamento`.
- [Risco] `parsearTipo` nos parsers usa `valueOf` dentro de `try/catch` — com os valores removidos, qualquer `tipo` textual não reconhecido cai no fallback por sinal, então a importação não quebra.
- [Escopo] A condição "parcelamento" (parcelas) não ganhou campo próprio nesta correção; fica como evolução futura (a página `/parcelamentos` já existe como placeholder).
