### PR TITLE
fix: corrige cors para frontend em producao

### DIFF
--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/SecurityConfig.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/config/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 
 @Configuration
 @EnableWebSecurity
@@ -31,9 +33,11 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/auth/**",
                                 "/health",

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/security/WebConfig.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/security/WebConfig.java
@@ -14,8 +14,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-         
-                .allowedOrigins("http://localhost:5173")
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION
## O que mudou

<!-- Liste as principais alterações deste PR -->

- Corrigida a configuração de CORS do backend para aceitar o frontend publicado no Render.
- Ajustado o `WebConfig` para usar a variável `CORS_ALLOWED_ORIGINS` em vez de manter apenas `http://localhost:5173` fixo no código.
- Adicionada liberação de requisições `OPTIONS` no `SecurityConfig` para permitir o preflight CORS do navegador.
- Habilitado o uso de CORS no fluxo de segurança do Spring Security.
- Mantido suporte ao ambiente local e ao ambiente publicado em produção.

## Por quê

<!-- Explique o motivo das mudanças -->

- Após o deploy da Sprint 4, o frontend publicado em `https://smartbudget-web-0sic.onrender.com` não conseguia realizar login ou cadastro.
- O navegador bloqueava as requisições para a API por erro de CORS.
- A variável `CORS_ALLOWED_ORIGINS` estava correta no Render, mas o backend não usava essa variável na configuração efetiva de CORS.
- A correção permite que o frontend em produção consiga se comunicar com a API publicada no Render.
- Também garante que as requisições de preflight `OPTIONS` não sejam bloqueadas pela configuração de segurança.

## Como testar

<!-- Descreva o passo a passo para testar as mudanças -->

1. Faça deploy do backend atualizado no Render.
2. Confirme que a variável `CORS_ALLOWED_ORIGINS` no serviço `smartbudget-api` contém: `http://localhost:5173,https://smartbudget-web-0sic.onrender.com`
3. Acesse o frontend publicado em: `https://smartbudget-web-0sic.onrender.com`
4. Abra o DevTools do navegador na aba **Network**.
5. Tente fazer login com um usuário válido.
6. Verifique se a requisição `OPTIONS /auth/login` não retorna mais erro de CORS.
7. Verifique se a requisição `POST /auth/login` é enviada normalmente.
8. Teste também o cadastro de um novo usuário.
9. Confirme que o usuário consegue avançar para o fluxo da primeira conta.
10. Opcionalmente, teste localmente com frontend em `http://localhost:5173`.

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (ex.: frontend local e frontend em produção)
- [x] Evidência de teste manual
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos

<!-- Comente pontos técnicos relevantes, use rótulos: [Risco], [Manutenção], [Teste] -->

- [Risco] A mudança impacta a comunicação entre frontend e backend em produção, especialmente os fluxos de login e cadastro.
- [Risco] Caso a variável `CORS_ALLOWED_ORIGINS` esteja incorreta no ambiente, o navegador voltará a bloquear as requisições por CORS.
- [Manutenção] O backend passa a usar a variável de ambiente já prevista na configuração, evitando URL fixa no código.
- [Manutenção] A liberação de `OPTIONS` permite apenas o preflight CORS, sem abrir endpoints protegidos para acesso sem autenticação.
- [Teste] A correção foi validada manualmente no frontend publicado, testando login/cadastro após o redeploy da API.