### PR TITLE
docs/release 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Projeto de App de Gerenciamento Financeiro - SmartBudget
 
+[Acesse web pelo Render](https://smartbudget-web-0sic.onrender.com) e a  [ API](https://smartbudget-api-kbze.onrender.com).
+
 Projeto proposto pelo Clayrton em Extensão II:
 
 > Desenvolvimento de um gerenciador financeiro pessoal que permita a integração de notas fiscais (NF-e), extratos bancários (xml, csv, txt), extratos de cartão (xml, csv, txt), e que permita gerenciar as contas do usuário de modo a prover relatórios de gastos e despesas mensais por categorias (habitação, saúde, serviços, lazer, manutenção, transportes, etc.).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -14,6 +14,11 @@ Para desenvolvimento local (rodar com `bootRun`/`npm run dev`), veja [`como-roda
 
 O frontend é uma SPA estática que chama a API pelo **navegador**, então a URL da API (`VITE_API_URL`) precisa ser acessível pelo cliente e é **embutida no build** do Vite.
 
+Ambientes publicados atuais:
+
+- Web: `https://smartbudget-web-0sic.onrender.com`
+- API: `https://smartbudget-api-kbze.onrender.com`
+
 ## Pré-requisitos
 
 - **Docker** + **Docker Compose v2** (caminho recomendado), ou

--- a/docs/entregas/sprint4.md
+++ b/docs/entregas/sprint4.md
@@ -274,7 +274,7 @@ A partir da versão `v0.4.1`, os ambientes publicados considerados para validaç
 
 Lucas de Leon atuou principalmente em funcionalidades de transações, manutenção de contas bancárias e revisões técnicas de frontend e backend.
 
-Durante a Sprint 4, abriu PRs relacionados a:
+Durante a Sprint 4 e a estabilização da `v0.4.1`, abriu PRs relacionados a:
 
 - CRUD de transações;
 - testes backend para edição e exclusão de transações;
@@ -372,7 +372,17 @@ Também contribuiu em muitas revisões técnicas, com foco em testes, controller
 - PR `#151`, apontamento de testes faltantes e ajustes na lógica dos testes;
 - PR `#152`, revisão de testes faltantes, descrição do PR e correções pontuais;
 - PR `#153`, revisão de testes e correções nos testes montados;
-- PR `#159`, contribuição em review técnico;
+- PR `#159`, contribuição em correção backend para funcionamento da tela e review técnico;
+- PR `#163`, sugestão de novos testes;
+- PR `#142`, sugestão de novo teste;
+- PR `#143`, sugestão de novo teste e inconsistência no controller;
+- PR `#181`, review e aprovação;
+- PR `#164`, ajustes apontados por Lucas de Leon e aprovação;
+- PR `#178`, sugestão de novo teste;
+- PR `#156`, sugestão de dois novos testes;
+- PR `#185`, sugestão de novo teste;
+- PR `#186`, review e aprovação;
+- PR `#189`, review e aprovação;
 - PR `#166`, apontamentos sobre controller, service e cobertura;
 - PR `#167`, revisão de testes e validações;
 - PR `#169`, revisão de pontos de manutenção e consistência;
@@ -390,24 +400,139 @@ A contribuição de Victor Blum foi central para a evolução técnica do backen
 
 #### Contribuições principais
 
-Alexandre Villela atuou principalmente em testes, modelagem e confiabilidade da importação.
+Alexandre Villela atuou principalmente em testes, deploy, paginação, filtros server-side, categorização, documentação de publicação, modelagem e confiabilidade da importação.
 
 Durante a Sprint 4 e a estabilização da `v0.4.1`, abriu PRs relacionados a:
 
+- testes automatizados de categorização de transações;
+- deploy no Render com blueprint e datasource por variáveis de ambiente;
+- documentação de deploy;
+- testes de resumo por pagamento e gestão de contas;
+- paginação e filtros server-side nas transações;
 - testes de contrato dos parsers de importação;
 - ajuste de modelagem de `TipoTransacao`;
 - validações de comportamento esperado na importação.
 
+Também contribuiu em reviews de frontend e apontou melhorias de experiência e manutenção, incluindo confirmação antes de exclusões e redução de duplicação de código.
+
 #### Evidências associadas
 
+- PR `test(#107): testes automatizados de categorização de transações`;
+- PR `Deploy no Render: blueprint + datasource via env (#126)`;
+- PR `docs(#126): documentação de deploy + configuração por variáveis de ambiente`;
+- PR `test(#158): testes de resumo por pagamento e gestão de contas`;
+- PR `feat(#106): paginação e filtros server-side nas transações`;
 - PR `#209`, testes de contrato dos parsers de importação;
 - PR `#208`, modelagem de `TipoTransacao` apenas com sentido financeiro;
 - issue `#175`, testes de contrato dos parsers;
-- issue `#176`, ajuste de modelagem de `TipoTransacao`.
+- issue `#176`, ajuste de modelagem de `TipoTransacao`;
+- PR `#145`, review e aprovação;
+- PR `#180`, review com sugestão de ajuste visual;
+- contribuição em review da issue `#195`, sugerindo confirmação por `window` antes da exclusão de conta bancária;
+- apontamentos de duplicação de código em PRs da equipe.
 
 #### Observações
 
-A atuação de Alexandre Villela foi importante para reduzir ambiguidades no domínio financeiro e aumentar a confiabilidade da importação de extratos. As entregas foram incorporadas na versão complementar `v0.4.1`.
+A atuação de Alexandre Villela foi importante para o avanço do deploy, da documentação de execução, dos testes automatizados, da evolução da listagem de transações com filtros e paginação, da redução de ambiguidades no domínio financeiro e da confiabilidade da importação de extratos. Parte dessas entregas foi incorporada na versão complementar `v0.4.1`.
+
+---
+
+### João Pedro Callegaro Guimarães
+
+#### Contribuições principais
+
+João Pedro atuou principalmente em testes frontend, documentação arquitetural, cobertura de testes, importação de extratos e registro de ADR.
+
+Durante a Sprint 4, abriu PRs relacionados a:
+
+- atualização da documentação de padrões arquiteturais com Strategy;
+- testes automatizados da tela de importação de extratos;
+- testes automatizados da tela de registro manual de transações;
+- testes unitários da tela de nova conta bancária;
+- testes da listagem de transações;
+- testes da tela Primeira Conta;
+- relatório de cobertura dos testes frontend;
+- ADR de decomposição do `TransacaoService`;
+- correção para importação não deslogar em erro `403 Forbidden`.
+
+Também registrou que a issue `#97` foi transferida para Lucas de Leon Rodrigues Coelho.
+
+#### Evidências associadas
+
+- PR `docs: atualiza documentação de padrões arquiteturais (Strategy)`;
+- PR `test: adiciona testes automatizados da tela de importação de extratos (#151)`;
+- PR `test: adiciona testes automatizados para a tela de registro manual de transações`;
+- PR `test: adiciona testes unitários para a tela de nova conta bancária (#147)`;
+- PR `test: adiciona testes da listagem de transações (#155)`;
+- PR `test: adiciona testes da tela Primeira Conta (#184)`;
+- PR `fix: adiciona relatório de cobertura dos testes frontend (#177)`;
+- PR `docs(adr): registra decomposicao do TransacaoService na sprint 4 (#130)`;
+- PR `fix(frontend): importacao nao desloga em 403 Forbidden (#170)`;
+- PR `#143`, review concordando com a aprovação;
+- PR `#188`, review com sugestões para segurança no deploy;
+- PR `#190`, review com sugestão de ordem de merges;
+- PR `#187`, review sobre regra de negócio refatorada e posterior aprovação.
+
+#### Observações
+
+A contribuição de João Pedro foi importante para consolidar a qualidade automatizada do frontend, documentar decisões arquiteturais e registrar a cobertura de testes como métrica acompanhada pela equipe. Também contribuiu para a estabilidade do fluxo de importação ao tratar o comportamento de logout indevido em erro `403 Forbidden`.
+
+## PRs e reviews relevantes
+
+Durante a Sprint 4, os PRs tiveram papel importante não apenas para entrega de funcionalidades, mas também para discussão técnica, revisão de regras de negócio e melhoria da qualidade geral do projeto.
+
+Os PRs revisados envolveram principalmente:
+
+- frontend de contas, transações, resumo e importação;
+- backend de categorização, transações, contas e parsers;
+- testes automatizados frontend e backend;
+- documentação arquitetural;
+- deploy e configuração por variáveis de ambiente;
+- métricas e cobertura de testes.
+
+Alguns PRs se destacaram pela quantidade de comentários e discussões técnicas:
+
+### PR `Feat/#60 processamento extrato endpoint upload`
+
+Esse PR recebeu grande volume de comentários e serviu como ponto importante de discussão sobre o fluxo de importação. O PR avançou tecnicamente, mas os comentários indicaram melhorias necessárias para evitar retrabalho futuro. Victor Blum e Victor Gabriel participaram ativamente com respostas e reviews.
+
+### PR `test: Implementa testes unitários para parsers de extratos bancários (#97)`
+
+Esse PR também recebeu muitos comentários. Devido à quantidade de problemas encontrados e ao impacto no andamento da issue, a equipe decidiu fechar o PR e transferir a issue `#97` para Lucas de Leon Rodrigues Coelho, que posteriormente ficou responsável pelo encaminhamento.
+
+### PR `Feat/#64 categorizacao transacoes`
+
+Esse PR teve discussão relevante sobre categorização de transações. Victor Blum e Victor Gabriel participaram ativamente para melhorar a implementação, com reviews válidos e comunicação clara.
+
+### Reviews durante a Sprint
+
+As reviews da Sprint 4 ajudaram a:
+
+- identificar inconsistências em controllers e serviços;
+- apontar testes ausentes;
+- corrigir descrições de PRs que não representavam corretamente o escopo entregue;
+- sugerir melhorias de UX, como mensagens temporárias e confirmação antes de exclusões;
+- evitar links quebrados após mudança de rotas;
+- reforçar documentação de regras de negócio;
+- revisar deploy e segurança da configuração;
+- manter a branch `dev` mais estável antes da consolidação na `main`.
+
+Esse processo de review foi essencial para que a Sprint 4 entregasse funcionalidades novas sem perder o controle de qualidade.
+
+## Pontos adicionais de documentação
+
+A Sprint 4 também atualizou documentação técnica e de processo:
+
+- `README.md`;
+- `docs/como-rodar.md`;
+- `docs/metricas.md`;
+- `docs/arquitetura.md`;
+- `docs/adrs/ADR-0004-Estrategia-de-arquiteturas-e-camadas.md`;
+- `docs/adrs/ADR-0005-padroes-de-projeto.md`;
+- `docs/adrs/ADR-0008-decomposicao-transacao-service.md`;
+- `docs/DEPLOY.md`.
+
+Essas atualizações melhoram a rastreabilidade do projeto, a execução local, a compreensão da arquitetura e a reprodução do ambiente de entrega.
 
 ## Observação sobre a versão 0.4.1
 

--- a/docs/entregas/sprint4.md
+++ b/docs/entregas/sprint4.md
@@ -2,179 +2,29 @@
 
 A Sprint 4 representou uma etapa de consolidação do MVP do SmartBudget. Enquanto a Sprint 3 havia avançado na base de importação, categorização, autenticação, listagem e testes iniciais, a Sprint 4 focou em transformar essas bases em fluxos mais completos para o usuário, com manutenção de transações, gestão de contas, melhoria de listagens, ampliação de testes, refatoração técnica e preparação do projeto para publicação estável.
 
-No recorte da Sprint 4 foram consideradas 30 issues únicas. Após a consolidação da entrega, 28 foram consideradas concluídas e 2 permaneceram como pendência ou entrega parcial: `#67` e `#170`.
+No recorte original da Sprint 4 foram consideradas 30 issues únicas. Após a consolidação inicial da entrega, 28 foram consideradas concluídas e 2 permaneceram como pendência ou entrega parcial: `#67` e `#170`.
 
-## Decisões durante a Sprint 4
+Após a publicação inicial da versão `v0.4.0`, a equipe realizou uma rodada complementar de estabilização e fechamento de pendências, consolidada na versão `v0.4.1`. Essa versão incorporou correções, testes adicionais, ajustes de modelagem e a finalização de funcionalidades que haviam ficado pendentes no recorte inicial da Sprint 4.
 
-A equipe decidiu manter a evolução do MVP em torno de fluxos reais de uso da aplicação, priorizando funcionalidades que melhoram a experiência do usuário autenticado.
+## Complementos incorporados na versão 0.4.1
 
-A tela de conta bancária deixou de ser apenas um formulário isolado de cadastro e passou a representar uma área de **Contas**, com listagem das contas do usuário e cadastro de novas contas por modal. Também foi mantido um fluxo específico de primeira conta após o cadastro inicial do usuário.
+Após a consolidação inicial da Sprint 4 na versão `v0.4.0`, a equipe realizou uma nova rodada de merges para fechar pendências e estabilizar a entrega. Esses ajustes foram incorporados à versão `v0.4.1`.
 
-No backend, o `TransacaoService` foi refatorado para reduzir a concentração de responsabilidades. Regras auxiliares foram separadas em componentes mais específicos, como:
+Os principais complementos foram:
 
-- `ContaUsuarioService`;
-- `SugestaoCategoriaService`;
-- `TransacaoMapper`;
-- `TransacaoSpecs`.
+| PR | Responsável pela abertura | Entrega |
+|----|---------------------------|---------|
+| `#212` - Feat/67 resumo mensal categorias | `Victor3294` | Finalização do backend do resumo mensal do dashboard, incluindo total recebido, total gasto, saldo, categoria com maior gasto, gastos agrupados por categoria e variação percentual em relação ao mês anterior. |
+| `#208` - Modelagem: `TipoTransacao` apenas com sentido financeiro (`#176`) | `apvillela` | Ajuste de modelagem para deixar `TipoTransacao` com sentido financeiro mais claro, separando melhor a ideia de crédito e débito das demais classificações do domínio. |
+| `#211` - Fix: importação + modificações pequenas na UX (`#170`) | `lucaslrc01` | Correção complementar do fluxo de importação, com ajuste no envio de arquivos via `FormData`, remoção do `Content-Type` global no Axios e melhorias de navegação e textos na interface. |
+| `#209` - Testes de contrato dos parsers de importação (`#175`) | `apvillela` | Inclusão de testes de contrato para parsers de importação, reforçando o comportamento esperado na leitura de extratos e reduzindo risco de regressões. |
+| `#210` - Fix: corrige CORS para frontend em produção | `victorlcrd` | Correção de CORS para permitir integração adequada entre frontend e backend no ambiente publicado. |
 
-Essa decisão foi registrada na ADR `docs/adrs/ADR-0008-decomposicao-transacao-service.md`.
+Com esses merges, a versão `v0.4.1` passou a representar uma versão mais estável da Sprint 4, com fechamento das principais pendências que ainda estavam abertas na `v0.4.0`.
 
-Também foi reforçada a decisão de tornar a cobertura frontend mensurável no pipeline, com Vitest e geração de relatório de cobertura. A partir da Sprint 4, o frontend passou a ter acompanhamento formal de cobertura, complementando o JaCoCo já usado no backend.
+Em especial, a issue `#67`, que inicialmente havia ficado pendente, foi finalizada com a entrega do backend de resumo mensal e agrupamento por categorias. A issue `#170`, que estava como correção parcial no recorte inicial, também recebeu ajuste complementar no fluxo de importação.
 
-## Incremento funcional da Sprint 4
-
-### Gestão de contas bancárias
-
-A Sprint 4 evoluiu o fluxo de contas bancárias. A tela `NovaConta.tsx` passou a funcionar visualmente como uma área de **Contas**, permitindo listar contas cadastradas, exibir estado vazio e abrir um modal para cadastrar uma nova conta.
-
-Também foi criado o fluxo de primeira conta após cadastro, representado por:
-
-- `app-financeiro-front-end/src/pages/PrimeiraConta.tsx`;
-- `app-financeiro-front-end/src/pages/PrimeiraConta.test.tsx`.
-
-Com isso, o fluxo ficou dividido em duas experiências:
-
-- usuário recém-cadastrado segue para cadastrar a primeira conta;
-- usuário já logado usa a área **Contas** para gerenciar contas existentes e adicionar novas.
-
-No backend, a gestão de contas também evoluiu com suporte a edição e validação de propriedade, incluindo:
-
-- `ContaEdicaoRequestDTO`;
-- alterações em `ContaController`;
-- alterações em `ContaService`;
-- `ContaUsuarioService`.
-
-### Manutenção de transações
-
-A Sprint 4 adicionou suporte mais completo para manutenção de transações. A aplicação passou a contar com recursos de edição e exclusão de transações no backend e no frontend.
-
-As principais evidências são:
-
-- `app-financeiro-front-end/src/pages/EditarTransacao.tsx`;
-- alterações em `Transacoes.tsx`;
-- alterações em `NovaTransacao.tsx`;
-- alterações em `TransacaoController`;
-- alterações em `TransacaoService`;
-- `TransacaoEdicaoExclusaoControllerTest`;
-- `TransacaoEdicaoExclusaoServiceTest`.
-
-Com isso, o histórico de transações deixou de ser apenas uma visualização e passou a permitir manutenção pelo usuário autenticado.
-
-### Listagem, filtros e paginação de transações
-
-A listagem de transações foi evoluída com suporte a filtros e paginação server-side. A Sprint 4 introduziu estrutura para filtros no backend, incluindo:
-
-- `PaginaDTO`;
-- `TransacaoSpecs`;
-- alterações em `TransacaoRepository`;
-- alterações em `TransacaoController`;
-- testes de listagem paginada.
-
-No frontend, a tela de transações também foi ajustada para consumir e testar melhor esse fluxo.
-
-### Categorização de transações pela interface
-
-A categorização, que já havia sido iniciada no backend na Sprint 3, avançou na Sprint 4 com integração pela interface e reforço de testes.
-
-As principais evidências são:
-
-- alterações em `TransacaoController`;
-- alterações em `CategoriaService`;
-- `CategorizarTransacaoIntegrationTests`;
-- `CategorizarTransacaoTests`;
-- `CategorizacaoNaImportacaoTests`;
-- testes e ajustes na tela de transações.
-
-Também houve avanço na sugestão automática de categoria por palavras-chave com `SugestaoCategoriaService`.
-
-### Resumo por forma de pagamento
-
-A Sprint 4 avançou no resumo financeiro por forma de pagamento. No frontend, foram adicionados componentes específicos para visualização em lista e gráfico:
-
-- `ResumoFormaPagamento.tsx`;
-- `ResumoFormaPagamentoPizza.tsx`;
-- `ResumoFormaPagamento.test.tsx`;
-- `ResumoFormaPagamentoPizza.test.tsx`.
-
-No backend, houve ajustes em `ResumoController`, `ResumoService` e `GrupoPagamentoDTO`.
-
-Essa entrega contribui para a funcionalidade do MVP relacionada à categorização e visualização dos gastos por forma de pagamento, como PIX, cartão, dinheiro e boleto.
-
-### Importação de extratos e contrato dos parsers
-
-O fluxo de importação continuou sendo trabalhado na Sprint 4. Houve reorganização do contrato dos parsers e ajustes nos arquivos relacionados à importação:
-
-- `ParserExtrato`;
-- `ParserCSV`;
-- `ParserTXT`;
-- `ParserXML`;
-- `ParserNFe`;
-- `ResultadoParser`;
-- `ImportacaoService`;
-- `ImportarExtrato.tsx`;
-- `ImportarExtrato.test.tsx`.
-
-A issue `#174` melhorou a organização do contrato comum dos parsers.
-
-Ao mesmo tempo, a Sprint 4 identificou a issue `#170`, relacionada a bug no fluxo de importação de extratos. Esse bug indicou que o usuário podia ser redirecionado para login em cenários de erro que não deveriam encerrar a sessão. Por isso, a importação é considerada funcionalidade existente, mas com ressalva operacional nesta sprint.
-
-### Refatoração do `TransacaoService`
-
-A Sprint 4 teve uma frente técnica importante de reengenharia do `TransacaoService`.
-
-Antes da refatoração, o serviço concentrava responsabilidades de:
-
-- registrar transação manual;
-- editar transação;
-- excluir transação;
-- listar transações;
-- categorizar transação;
-- buscar transação do usuário;
-- validar conta;
-- sugerir categoria;
-- converter entidades em DTOs.
-
-Após a refatoração, parte dessas responsabilidades foi distribuída para componentes mais coesos:
-
-- `ContaUsuarioService`: resolução e validação de contas do usuário;
-- `SugestaoCategoriaService`: sugestão automática de categoria;
-- `CategoriaService`: validação de categoria permitida ao usuário;
-- `TransacaoMapper`: conversão de entidade para DTO;
-- `TransacaoSpecs`: composição de filtros para listagem.
-
-Essa mudança não alterou o contrato externo da API, mas reduziu acoplamento, melhorou testabilidade e facilitou evolução futura.
-
-### Testes automatizados
-
-A Sprint 4 ampliou significativamente a cobertura de testes no backend e no frontend.
-
-No backend, foram adicionados ou ajustados testes como:
-
-- `CategorizarTransacaoIntegrationTests`;
-- `ListarCategoriasIntegrationTests`;
-- `ListarTransacoesIntegrationTests`;
-- `TransacaoEdicaoExclusaoControllerTest`;
-- `TransacaoMapperTest`;
-- `CategoriaSeedIntegrationTests`;
-- `CategorizacaoNaImportacaoTests`;
-- `CategorizarTransacaoTests`;
-- `ListarTransacoesPaginadoIntegrationTests`;
-- `ListarTransacoesPaginadoTests`;
-- `ResumoServiceTest`;
-- `SugestaoCategoriaServiceTest`;
-- `TransacaoEdicaoExclusaoServiceTest`.
-
-No frontend, foram adicionados ou ampliados testes como:
-
-- `NovaConta.test.tsx`;
-- `NovaTransacao.test.tsx`;
-- `ImportarExtrato.test.tsx`;
-- `Transacoes.test.tsx`;
-- `PrimeiraConta.test.tsx`;
-- `ResumoFormaPagamento.test.tsx`;
-- `ResumoFormaPagamentoPizza.test.tsx`.
-
-Também foi consolidado o relatório de cobertura frontend com Vitest.
+A versão `v0.4.1` também reforçou a confiabilidade da importação com testes de contrato dos parsers e corrigiu a comunicação entre frontend e backend no ambiente de produção.
 
 ## Deploy e versão estável publicada
 
@@ -199,13 +49,18 @@ O arquivo `docs/DEPLOY.md` documenta a execução reprodutível do MVP com backe
 
 Essa entrega atende à necessidade de disponibilizar uma versão estável e validável do MVP, além de melhorar a rastreabilidade do processo de implantação.
 
+A partir da versão `v0.4.1`, os ambientes publicados considerados para validação são:
+
+- API: `https://smartbudget-api-kbze.onrender.com`;
+- Web: `https://smartbudget-web-0sic.onrender.com`.
+
 ## Itens considerados na Sprint 4
 
 | Item | Situação | Observação |
 |------|----------|------------|
 | #65 - Interface de categorização de transações | Concluído | Fecha o fluxo de categorização manual pela interface. |
 | #66 - Resumo por forma de pagamento e gestão de contas | Concluído | Avança visualização por forma de pagamento e complementa regras de contas. |
-| #67 - Resumo mensal/backend do dashboard | Não concluído | Replanejado. Não contabilizado como funcionalidade finalizada do MVP. |
+| #67 - Resumo mensal/backend do dashboard | Concluído na v0.4.1 | Inicialmente replanejado na v0.4.0, foi finalizado no PR #212. |
 | #106 - Filtros/listagem paginada de transações | Concluído | Melhora consulta de movimentações com filtros e paginação. |
 | #107 - Testes de categorização de transações | Concluído | Reforça confiabilidade das regras de categorização. |
 | #122 - Manutenção do CI com Gradle Wrapper e lint frontend | Concluído | Melhora reprodutibilidade do pipeline. |
@@ -227,289 +82,27 @@ Essa entrega atende à necessidade de disponibilizar uma versão estável e vali
 | #158 - Testes do resumo por pagamento e contas | Concluído | Amplia cobertura do resumo e contas. |
 | #162 - Testes para edição e exclusão de transações | Concluído | Reforça manutenção de transações. |
 | #165 - Tela de gerenciamento de contas bancárias | Concluído | Consolida gestão de contas no frontend. |
-| #170 - Bug no fluxo de importação de extrato | Parcial | Correção parcial, ainda não concluído. |
+| #170 - Bug no fluxo de importação de extrato | Concluído na v0.4.1 | Inicialmente parcial na v0.4.0, recebeu correção complementar no PR #211. |
 | #174 - Contrato comum dos parsers de importação | Concluído | Melhora organização dos parsers. |
+| #175 - Testes de contrato dos parsers de importação | Concluído na v0.4.1 | Reforça validação dos parsers de importação. |
+| #176 - Ajuste de modelagem de `TipoTransacao` | Concluído na v0.4.1 | Simplifica o sentido financeiro de crédito e débito. |
 | #177 - Relatório de cobertura dos testes frontend | Concluído | Torna cobertura frontend mensurável no CI. |
 | #184 - Testes da tela Primeira Conta | Concluído | Amplia cobertura do onboarding após cadastro. |
 | #194 - Backend para editar conta bancária | Concluído | Permite edição de contas com validação de propriedade. |
 | #195 - Frontend para editar e deletar contas bancárias | Concluído | Completa manutenção de contas na interface. |
-## Registro de contribuição individual
+| Correção de CORS em produção | Concluído na v0.4.1 | Ajusta integração entre frontend e backend publicados. |
 
-### Lucas de Leon Rodrigues Coelho
+## Observação sobre a versão 0.4.1
 
-#### Contribuições principais
+A versão `v0.4.1` não substitui o escopo principal da Sprint 4, mas registra uma rodada complementar de estabilização feita após a `v0.4.0`.
 
-Lucas de Leon atuou principalmente em funcionalidades de transações, manutenção de contas bancárias e revisões técnicas de frontend e backend.
+Essa versão foi criada para:
 
-Durante a Sprint 4, abriu PRs relacionados a:
+- finalizar pendências que ainda estavam abertas no recorte inicial;
+- corrigir problemas identificados no fluxo de importação;
+- reforçar testes de contrato dos parsers;
+- ajustar a modelagem de tipo de transação;
+- corrigir CORS para o ambiente publicado;
+- consolidar o backend do resumo mensal do dashboard.
 
-* CRUD de transações;
-* testes backend para edição e exclusão de transações;
-* implementação de funções de editar e excluir transações no menu;
-* edição de conta bancária.
-
-Também contribuiu em reviews importantes, apontando erros de lógica, inconsistências no backend e problemas de tipagem.
-
-#### Evidências associadas
-
-* PR relacionado à issue `#134`, CRUD de transações;
-* PR relacionado à issue `#162`, testes de edição e exclusão de transações;
-* PR relacionado à issue `#194`, edição de conta bancária;
-* PR `#160`, revisão com apontamentos sobre lógica backend e tipos;
-* PR `#168`, revisão sobre erro na refatoração;
-* PR `#164`, revisão apontando inconsistência no backend.
-
-#### Observações
-
-A atuação de Lucas foi relevante para a estabilização das funcionalidades de manutenção de transações e contas, além de contribuir para a qualidade técnica das entregas revisadas.
-
----
-
-### Victor Gabriel Lacerda
-
-#### Contribuições principais
-
-Victor Gabriel atuou principalmente no frontend, na experiência do usuário, na gestão de contas bancárias, no resumo por forma de pagamento e em revisões gerais do projeto.
-
-Durante a Sprint 4, abriu PRs relacionados a:
-
-* tela de cadastro de conta bancária para usuários logados;
-* refatoração da tela para gerenciamento de contas;
-* tela de resumo por forma de pagamento;
-* edição e exclusão de conta bancária.
-
-Também contribuiu com reviews em backend, frontend, testes e documentação, participando ativamente da aprovação de PRs antes do merge.
-
-#### Evidências associadas
-
-* PR `feat/#136-tela-cadastro-banco-logged-users`;
-* PR `refactor/tela gerenciamento contas`, relacionado à issue `#165`;
-* PR `feat/(closes #157)tela-resumo-forma-pagamento`;
-* PR `feat/(closes #195) editar e deletar conta bancaria`;
-* PR `#198`, review para evitar `NullPointerException` em requisições sem body e orientação sobre retorno de erro;
-* PR `#145`, review sobre mensagem de sucesso permanecendo indefinidamente e análise de possível erro de lógica;
-* PR `#163`, review e aprovação;
-* PR `#192`, review e aprovação em conversa com o responsável;
-* PR `#143`, apontamento de inconsistências pontuais na lógica;
-* PR `#183`, review e aprovação;
-* PR `#180`, review e aprovação;
-* PR `#188`, review e aprovação;
-* PR `#190`, review e aprovação;
-* PR `#187`, sugestão para documentar ajuste na regra de negócio e posterior aprovação;
-* PR `#191`, apontamento de que o PR não corrigia completamente a issue mencionada e sugestão para ajustar a descrição.
-
-#### Observações
-
-A contribuição de Victor Gabriel foi importante para transformar o cadastro de conta em um fluxo mais completo de gerenciamento, além de reforçar a experiência do usuário e a consistência dos PRs revisados.
-
----
-
-### Victor Blum
-
-#### Contribuições principais
-
-Victor Blum atuou principalmente em backend, arquitetura, categorização, refatoração do `TransacaoService`, contrato de parsers e métricas técnicas.
-
-Durante a Sprint 4, abriu PRs relacionados a:
-
-* interface de categorização;
-* categorização por forma de pagamento e conta;
-* correção do contrato dos parsers de importação;
-* atualização do documento de métricas com dados de refatoração;
-* refatoração do design do `TransacaoService`.
-
-Também contribuiu em muitas revisões técnicas, com foco em testes, controller, backend, documentação e qualidade das entregas.
-
-#### Evidências associadas
-
-* PR `Feat/#65 interface de categorizacao`;
-* PR `Feat/#66 categorizacao por forma de pagamento e conta`;
-* PR `Fix/174 contrato parsers importacao`;
-* PR de atualização das métricas de refatoração;
-* PR `Refactor/#128 transacao service design`;
-* PR `#141`, revisão de documentação desatualizada;
-* PR `#151`, apontamento de testes faltantes e ajustes na lógica dos testes;
-* PR `#152`, revisão de testes faltantes, descrição do PR e correções pontuais;
-* PR `#153`, revisão de testes e correções nos testes montados;
-* PR `#159`, contribuição em correção backend para funcionamento da tela;
-* PR `#163`, sugestão de novos testes;
-* PR `#142`, sugestão de novo teste;
-* PR `#143`, sugestão de novo teste e inconsistência no controller;
-* PR `#181`, review e aprovação;
-* PR `#164`, ajustes apontados por Lucas de Leon e aprovação;
-* PR `#178`, sugestão de novo teste;
-* PR `#156`, sugestão de dois novos testes;
-* PR `#185`, sugestão de novo teste;
-* PR `#186`, review e aprovação;
-* PR `#189`, review e aprovação.
-
-#### Observações
-
-A contribuição de Victor Blum foi central para a evolução técnica do backend, principalmente na redução de responsabilidades do `TransacaoService`, na melhoria da categorização e no aumento da qualidade por meio de testes e reviews.
-
----
-
-### Alexandre Vilella
-
-#### Contribuições principais
-
-Alexandre atuou em testes, deploy, paginação, filtros server-side, categorização e documentação de publicação.
-
-Durante a Sprint 4, abriu PRs relacionados a:
-
-* testes automatizados de categorização de transações;
-* deploy no Render com blueprint e datasource por variáveis de ambiente;
-* documentação de deploy;
-* testes de resumo por pagamento e gestão de contas;
-* paginação e filtros server-side nas transações.
-
-Também contribuiu em reviews de frontend e apontou melhorias de experiência e manutenção.
-
-#### Evidências associadas
-
-* PR `test(#107): testes automatizados de categorização de transações`;
-* PR `Deploy no Render: blueprint + datasource via env (#126)`;
-* PR `docs(#126): documentação de deploy + configuração por variáveis de ambiente`;
-* PR `test(#158): testes de resumo por pagamento e gestão de contas`;
-* PR `feat(#106): paginação e filtros server-side nas transações`;
-* PR `#145`, review e aprovação;
-* PR `#180`, review com sugestão de ajuste visual;
-* contribuição em review da issue `#195`, sugerindo confirmação por `window` antes da exclusão de conta bancária;
-* apontamentos de duplicação de código em PRs da equipe.
-
-#### Observações
-
-A contribuição de Alexandre foi importante para o avanço do deploy, da documentação de execução, dos testes automatizados e da evolução da listagem de transações com filtros e paginação.
-
----
-
-### João Pedro Callegaro Guimarães
-
-#### Contribuições principais
-
-João Pedro atuou principalmente em testes frontend, documentação arquitetural, cobertura de testes, importação de extratos e registro de ADR.
-
-Durante a Sprint 4, abriu PRs relacionados a:
-
-* atualização da documentação de padrões arquiteturais com Strategy;
-* testes automatizados da tela de importação de extratos;
-* testes automatizados da tela de registro manual de transações;
-* testes unitários da tela de nova conta bancária;
-* testes da listagem de transações;
-* testes da tela Primeira Conta;
-* relatório de cobertura dos testes frontend;
-* ADR de decomposição do `TransacaoService`;
-* correção para importação não deslogar em erro `403 Forbidden`.
-
-Também registrou que a issue `#97` foi transferida para Lucas de Leon Rodrigues Coelho.
-
-#### Evidências associadas
-
-* PR `docs: atualiza documentação de padrões arquiteturais (Strategy)`;
-* PR `test: adiciona testes automatizados da tela de importação de extratos (#151)`;
-* PR `test: adiciona testes automatizados para a tela de registro manual de transações`;
-* PR `test: adiciona testes unitários para a tela de nova conta bancária (#147)`;
-* PR `test: adiciona testes da listagem de transações (#155)`;
-* PR `test: adiciona testes da tela Primeira Conta (#184)`;
-* PR `fix: adiciona relatório de cobertura dos testes frontend (#177)`;
-* PR `docs(adr): registra decomposicao do TransacaoService na sprint 4 (#130)`;
-* PR `fix(frontend): importacao nao desloga em 403 Forbidden (#170)`;
-* PR `#143`, review concordando com a aprovação;
-* PR `#188`, review com sugestões para segurança no deploy;
-* PR `#190`, review com sugestão de ordem de merges;
-* PR `#187`, review sobre regra de negócio refatorada e posterior aprovação.
-
-#### Observações
-
-A contribuição de João Pedro foi importante para consolidar a qualidade automatizada do frontend, documentar decisões arquiteturais e registrar a cobertura de testes como métrica acompanhada pela equipe.
-
-## PRs e reviews relevantes
-
-Durante a Sprint 4, os PRs tiveram papel importante não apenas para entrega de funcionalidades, mas também para discussão técnica, revisão de regras de negócio e melhoria da qualidade geral do projeto.
-
-Os PRs revisados envolveram principalmente:
-
-* frontend de contas, transações, resumo e importação;
-* backend de categorização, transações, contas e parsers;
-* testes automatizados frontend e backend;
-* documentação arquitetural;
-* deploy e configuração por variáveis de ambiente;
-* métricas e cobertura de testes.
-
-Alguns PRs se destacaram pela quantidade de comentários e discussões técnicas:
-
-### PR `Feat/#60 processamento extrato endpoint upload`
-
-Esse PR recebeu grande volume de comentários e serviu como ponto importante de discussão sobre o fluxo de importação. O PR avançou tecnicamente, mas os comentários indicaram melhorias necessárias para evitar retrabalho futuro. Victor Blum e Victor Gabriel participaram ativamente com respostas e reviews.
-
-### PR `test: Implementa testes unitários para parsers de extratos bancários (#97)`
-
-Esse PR também recebeu muitos comentários. Devido à quantidade de problemas encontrados e ao impacto no andamento da issue, a equipe decidiu fechar o PR e transferir a issue `#97` para Lucas de Leon Rodrigues Coelho, que posteriormente ficou responsável pelo encaminhamento.
-
-### PR `Feat/#64 categorizacao transacoes`
-
-Esse PR teve discussão relevante sobre categorização de transações. Victor Blum e Victor Gabriel participaram ativamente para melhorar a implementação, com reviews válidos e comunicação clara.
-
-### Reviews durante a Sprint
-
-As reviews da Sprint 4 ajudaram a:
-
-* identificar inconsistências em controllers e serviços;
-* apontar testes ausentes;
-* corrigir descrições de PRs que não representavam corretamente o escopo entregue;
-* sugerir melhorias de UX, como mensagens temporárias e confirmação antes de exclusões;
-* evitar links quebrados após mudança de rotas;
-* reforçar documentação de regras de negócio;
-* revisar deploy e segurança da configuração;
-* manter a branch `dev` mais estável antes da consolidação na `main`.
-
-Esse processo de review foi essencial para que a Sprint 4 entregasse funcionalidades novas sem perder o controle de qualidade.
-
-
-## Pontos adicionais de documentação
-
-A Sprint 4 também atualizou documentação técnica e de processo:
-
-- `README.md`;
-- `docs/como-rodar.md`;
-- `docs/metricas.md`;
-- `docs/arquitetura.md`;
-- `docs/adrs/ADR-0004-Estrategia-de-arquiteturas-e-camadas.md`;
-- `docs/adrs/ADR-0005-padroes-de-projeto.md`;
-- `docs/adrs/ADR-0008-decomposicao-transacao-service.md`;
-- `docs/DEPLOY.md`.
-
-Essas atualizações melhoram a rastreabilidade do projeto, a execução local, a compreensão da arquitetura e a reprodução do ambiente de entrega.
-
-## Limitações e pendências
-
-### Issue `#67`
-
-A issue relacionada ao resumo mensal/backend do dashboard não foi concluída no recorte da Sprint 4. Portanto, a visualização completa de gastos do mês em dashboard ainda não deve ser contabilizada como funcionalidade finalizada do MVP.
-
-### Issue `#170`
-
-A issue `#170` registrou bug no fluxo de importação de extratos. Houve correção parcial, mas a issue ainda não foi considerada concluída. Por isso, a importação permanece como funcionalidade existente e testada, mas com ressalva operacional.
-
-### Extrato futuro
-
-A visualização de extrato dos próximos meses permanece como funcionalidade pendente do MVP.
-
-
-## Situação final da Sprint 4
-
-Ao final da Sprint 4, o projeto avançou de uma base funcional consolidada na `v0.3.1` para uma versão mais próxima de um MVP validável, com:
-
-- gestão de contas bancárias;
-- primeira conta no onboarding;
-- edição e exclusão de transações;
-- filtros e paginação de transações;
-- resumo por forma de pagamento;
-- categorização pela interface;
-- testes frontend e backend ampliados;
-- cobertura frontend mensurada;
-- backend mais modular após refatoração;
-- documentação de deploy;
-- versão estável publicada na `main`.
-
-A Sprint 4 fechou com alta taxa de conclusão, melhoria de cobertura e evolução funcional relevante, mas ainda com pendências importantes em dashboard mensal, extrato futuro e estabilização completa da importação em cenários afetados pela issue `#170`.
+Com isso, a Sprint 4 passa a ter uma entrega mais completa e alinhada ao MVP validável do SmartBudget.

--- a/docs/entregas/sprint4.md
+++ b/docs/entregas/sprint4.md
@@ -538,7 +538,7 @@ Essas atualizações melhoram a rastreabilidade do projeto, a execução local, 
 
 A versão `v0.4.1` não substitui o escopo principal da Sprint 4, mas registra uma rodada complementar de estabilização feita após a `v0.4.0`.
 
-Essa versão foi criada para:
+De maneira geral, 0.4.1 como a Sprint 4 toda cobre:
 
 - finalizar pendências que ainda estavam abertas no recorte inicial;
 - corrigir problemas identificados no fluxo de importação;

--- a/docs/entregas/sprint4.md
+++ b/docs/entregas/sprint4.md
@@ -2,9 +2,183 @@
 
 A Sprint 4 representou uma etapa de consolidação do MVP do SmartBudget. Enquanto a Sprint 3 havia avançado na base de importação, categorização, autenticação, listagem e testes iniciais, a Sprint 4 focou em transformar essas bases em fluxos mais completos para o usuário, com manutenção de transações, gestão de contas, melhoria de listagens, ampliação de testes, refatoração técnica e preparação do projeto para publicação estável.
 
-No recorte original da Sprint 4 foram consideradas 30 issues únicas. Após a consolidação inicial da entrega, 28 foram consideradas concluídas e 2 permaneceram como pendência ou entrega parcial: `#67` e `#170`.
+No recorte original da Sprint 4 foram consideradas 30 issues únicas. Após a consolidação inicial da entrega, 28 foram feitas na 0.4.0 e todas as 30 finalizadas na 0.4.1.
 
 Após a publicação inicial da versão `v0.4.0`, a equipe realizou uma rodada complementar de estabilização e fechamento de pendências, consolidada na versão `v0.4.1`. Essa versão incorporou correções, testes adicionais, ajustes de modelagem e a finalização de funcionalidades que haviam ficado pendentes no recorte inicial da Sprint 4.
+
+## Decisões durante a Sprint 4
+
+A equipe decidiu manter a evolução do MVP em torno de fluxos reais de uso da aplicação, priorizando funcionalidades que melhoram a experiência do usuário autenticado.
+
+A tela de conta bancária deixou de ser apenas um formulário isolado de cadastro e passou a representar uma área de **Contas**, com listagem das contas do usuário e cadastro de novas contas por modal. Também foi mantido um fluxo específico de primeira conta após o cadastro inicial do usuário.
+
+No backend, o `TransacaoService` foi refatorado para reduzir a concentração de responsabilidades. Regras auxiliares foram separadas em componentes mais específicos, como:
+
+- `ContaUsuarioService`;
+- `SugestaoCategoriaService`;
+- `TransacaoMapper`;
+- `TransacaoSpecs`.
+
+Essa decisão foi registrada na ADR `docs/adrs/ADR-0008-decomposicao-transacao-service.md`.
+
+Também foi reforçada a decisão de tornar a cobertura frontend mensurável no pipeline, com Vitest e geração de relatório de cobertura. A partir da Sprint 4, o frontend passou a ter acompanhamento formal de cobertura, complementando o JaCoCo já usado no backend.
+
+## Incremento funcional da Sprint 4
+
+### Gestão de contas bancárias
+
+A Sprint 4 evoluiu o fluxo de contas bancárias. A tela `NovaConta.tsx` passou a funcionar visualmente como uma área de **Contas**, permitindo listar contas cadastradas, exibir estado vazio e abrir um modal para cadastrar uma nova conta.
+
+Também foi criado o fluxo de primeira conta após cadastro, representado por:
+
+- `app-financeiro-front-end/src/pages/PrimeiraConta.tsx`;
+- `app-financeiro-front-end/src/pages/PrimeiraConta.test.tsx`.
+
+Com isso, o fluxo ficou dividido em duas experiências:
+
+- usuário recém-cadastrado segue para cadastrar a primeira conta;
+- usuário já logado usa a área **Contas** para gerenciar contas existentes e adicionar novas.
+
+No backend, a gestão de contas também evoluiu com suporte a edição e validação de propriedade, incluindo:
+
+- `ContaEdicaoRequestDTO`;
+- alterações em `ContaController`;
+- alterações em `ContaService`;
+- `ContaUsuarioService`.
+
+### Manutenção de transações
+
+A Sprint 4 adicionou suporte mais completo para manutenção de transações. A aplicação passou a contar com recursos de edição e exclusão de transações no backend e no frontend.
+
+As principais evidências são:
+
+- `app-financeiro-front-end/src/pages/EditarTransacao.tsx`;
+- alterações em `Transacoes.tsx`;
+- alterações em `NovaTransacao.tsx`;
+- alterações em `TransacaoController`;
+- alterações em `TransacaoService`;
+- `TransacaoEdicaoExclusaoControllerTest`;
+- `TransacaoEdicaoExclusaoServiceTest`.
+
+Com isso, o histórico de transações deixou de ser apenas uma visualização e passou a permitir manutenção pelo usuário autenticado.
+
+### Listagem, filtros e paginação de transações
+
+A listagem de transações foi evoluída com suporte a filtros e paginação server-side. A Sprint 4 introduziu estrutura para filtros no backend, incluindo:
+
+- `PaginaDTO`;
+- `TransacaoSpecs`;
+- alterações em `TransacaoRepository`;
+- alterações em `TransacaoController`;
+- testes de listagem paginada.
+
+No frontend, a tela de transações também foi ajustada para consumir e testar melhor esse fluxo.
+
+### Categorização de transações pela interface
+
+A categorização, que já havia sido iniciada no backend na Sprint 3, avançou na Sprint 4 com integração pela interface e reforço de testes.
+
+As principais evidências são:
+
+- alterações em `TransacaoController`;
+- alterações em `CategoriaService`;
+- `CategorizarTransacaoIntegrationTests`;
+- `CategorizarTransacaoTests`;
+- `CategorizacaoNaImportacaoTests`;
+- testes e ajustes na tela de transações.
+
+Também houve avanço na sugestão automática de categoria por palavras-chave com `SugestaoCategoriaService`.
+
+### Resumo por forma de pagamento
+
+A Sprint 4 avançou no resumo financeiro por forma de pagamento. No frontend, foram adicionados componentes específicos para visualização em lista e gráfico:
+
+- `ResumoFormaPagamento.tsx`;
+- `ResumoFormaPagamentoPizza.tsx`;
+- `ResumoFormaPagamento.test.tsx`;
+- `ResumoFormaPagamentoPizza.test.tsx`.
+
+No backend, houve ajustes em `ResumoController`, `ResumoService` e `GrupoPagamentoDTO`.
+
+Essa entrega contribui para a funcionalidade do MVP relacionada à categorização e visualização dos gastos por forma de pagamento, como PIX, cartão, dinheiro e boleto.
+
+### Importação de extratos e contrato dos parsers
+
+O fluxo de importação continuou sendo trabalhado na Sprint 4. Houve reorganização do contrato dos parsers e ajustes nos arquivos relacionados à importação:
+
+- `ParserExtrato`;
+- `ParserCSV`;
+- `ParserTXT`;
+- `ParserXML`;
+- `ParserNFe`;
+- `ResultadoParser`;
+- `ImportacaoService`;
+- `ImportarExtrato.tsx`;
+- `ImportarExtrato.test.tsx`.
+
+A issue `#174` melhorou a organização do contrato comum dos parsers.
+
+Ao mesmo tempo, a Sprint 4 identificou a issue `#170`, relacionada a bug no fluxo de importação de extratos. Esse bug indicou que o usuário podia ser redirecionado para login em cenários de erro que não deveriam encerrar a sessão. Por isso, na versão `v0.4.0`, a importação foi considerada funcionalidade existente, mas com ressalva operacional.
+
+Na versão complementar `v0.4.1`, essa pendência foi tratada com ajustes no fluxo de importação, incluindo correção do envio de arquivos via `FormData` e melhoria do comportamento da interface para evitar redirecionamentos indevidos.
+
+### Refatoração do `TransacaoService`
+
+A Sprint 4 teve uma frente técnica importante de reengenharia do `TransacaoService`.
+
+Antes da refatoração, o serviço concentrava responsabilidades de:
+
+- registrar transação manual;
+- editar transação;
+- excluir transação;
+- listar transações;
+- categorizar transação;
+- buscar transação do usuário;
+- validar conta;
+- sugerir categoria;
+- converter entidades em DTOs.
+
+Após a refatoração, parte dessas responsabilidades foi distribuída para componentes mais coesos:
+
+- `ContaUsuarioService`: resolução e validação de contas do usuário;
+- `SugestaoCategoriaService`: sugestão automática de categoria;
+- `CategoriaService`: validação de categoria permitida ao usuário;
+- `TransacaoMapper`: conversão de entidade para DTO;
+- `TransacaoSpecs`: composição de filtros para listagem.
+
+Essa mudança não alterou o contrato externo da API, mas reduziu acoplamento, melhorou testabilidade e facilitou evolução futura.
+
+### Testes automatizados
+
+A Sprint 4 ampliou significativamente a cobertura de testes no backend e no frontend.
+
+No backend, foram adicionados ou ajustados testes como:
+
+- `CategorizarTransacaoIntegrationTests`;
+- `ListarCategoriasIntegrationTests`;
+- `ListarTransacoesIntegrationTests`;
+- `TransacaoEdicaoExclusaoControllerTest`;
+- `TransacaoMapperTest`;
+- `CategoriaSeedIntegrationTests`;
+- `CategorizacaoNaImportacaoTests`;
+- `CategorizarTransacaoTests`;
+- `ListarTransacoesPaginadoIntegrationTests`;
+- `ListarTransacoesPaginadoTests`;
+- `ResumoServiceTest`;
+- `SugestaoCategoriaServiceTest`;
+- `TransacaoEdicaoExclusaoServiceTest`.
+
+No frontend, foram adicionados ou ampliados testes como:
+
+- `NovaConta.test.tsx`;
+- `NovaTransacao.test.tsx`;
+- `ImportarExtrato.test.tsx`;
+- `Transacoes.test.tsx`;
+- `PrimeiraConta.test.tsx`;
+- `ResumoFormaPagamento.test.tsx`;
+- `ResumoFormaPagamentoPizza.test.tsx`.
+
+Também foi consolidado o relatório de cobertura frontend com Vitest.
 
 ## Complementos incorporados na versão 0.4.1
 
@@ -15,9 +189,9 @@ Os principais complementos foram:
 | PR | Responsável pela abertura | Entrega |
 |----|---------------------------|---------|
 | `#212` - Feat/67 resumo mensal categorias | `Victor3294` | Finalização do backend do resumo mensal do dashboard, incluindo total recebido, total gasto, saldo, categoria com maior gasto, gastos agrupados por categoria e variação percentual em relação ao mês anterior. |
-| `#208` - Modelagem: `TipoTransacao` apenas com sentido financeiro (`#176`) | `apvillela` | Ajuste de modelagem para deixar `TipoTransacao` com sentido financeiro mais claro, separando melhor a ideia de crédito e débito das demais classificações do domínio. |
+| `#208` - Modelagem: `TipoTransacao` apenas com sentido financeiro (`#176`) | `Alexandre Villela` | Ajuste de modelagem para deixar `TipoTransacao` com sentido financeiro mais claro, separando melhor a ideia de crédito e débito das demais classificações do domínio. |
 | `#211` - Fix: importação + modificações pequenas na UX (`#170`) | `lucaslrc01` | Correção complementar do fluxo de importação, com ajuste no envio de arquivos via `FormData`, remoção do `Content-Type` global no Axios e melhorias de navegação e textos na interface. |
-| `#209` - Testes de contrato dos parsers de importação (`#175`) | `apvillela` | Inclusão de testes de contrato para parsers de importação, reforçando o comportamento esperado na leitura de extratos e reduzindo risco de regressões. |
+| `#209` - Testes de contrato dos parsers de importação (`#175`) | `Alexandre Villela` | Inclusão de testes de contrato para parsers de importação, reforçando o comportamento esperado na leitura de extratos e reduzindo risco de regressões. |
 | `#210` - Fix: corrige CORS para frontend em produção | `victorlcrd` | Correção de CORS para permitir integração adequada entre frontend e backend no ambiente publicado. |
 
 Com esses merges, a versão `v0.4.1` passou a representar uma versão mais estável da Sprint 4, com fechamento das principais pendências que ainda estavam abertas na `v0.4.0`.
@@ -91,6 +265,149 @@ A partir da versão `v0.4.1`, os ambientes publicados considerados para validaç
 | #194 - Backend para editar conta bancária | Concluído | Permite edição de contas com validação de propriedade. |
 | #195 - Frontend para editar e deletar contas bancárias | Concluído | Completa manutenção de contas na interface. |
 | Correção de CORS em produção | Concluído na v0.4.1 | Ajusta integração entre frontend e backend publicados. |
+
+## Registro de contribuição individual
+
+### Lucas de Leon Rodrigues Coelho
+
+#### Contribuições principais
+
+Lucas de Leon atuou principalmente em funcionalidades de transações, manutenção de contas bancárias e revisões técnicas de frontend e backend.
+
+Durante a Sprint 4, abriu PRs relacionados a:
+
+- CRUD de transações;
+- testes backend para edição e exclusão de transações;
+- implementação de funções de editar e excluir transações no menu;
+- edição de conta bancária;
+- correção complementar do fluxo de importação para a versão `v0.4.1`.
+
+Também contribuiu em reviews importantes, apontando erros de lógica, inconsistências no backend e problemas de tipagem.
+
+#### Evidências associadas
+
+- PR relacionado à issue `#134`, CRUD de transações;
+- PR relacionado à issue `#162`, testes de edição e exclusão de transações;
+- PR relacionado à issue `#194`, edição de conta bancária;
+- PR `#211`, correção de importação e melhorias pequenas de UX para a `v0.4.1`;
+- PR `#160`, revisão com apontamentos sobre lógica backend e tipos;
+- PR `#168`, revisão sobre erro na refatoração;
+- PR `#164`, revisão apontando inconsistência no backend.
+
+#### Observações
+
+A atuação de Lucas foi relevante para a estabilização das funcionalidades de manutenção de transações e contas, além de contribuir para a qualidade técnica das entregas revisadas. Na versão `v0.4.1`, também contribuiu para estabilizar o fluxo de importação de extratos.
+
+---
+
+### Victor Gabriel Lacerda
+
+#### Contribuições principais
+
+Victor Gabriel atuou principalmente no frontend, na experiência do usuário, na gestão de contas bancárias, no resumo por forma de pagamento e em revisões gerais do projeto.
+
+Durante a Sprint 4, abriu PRs relacionados a:
+
+- tela de cadastro de conta bancária para usuários logados;
+- refatoração da tela para gerenciamento de contas;
+- tela de resumo por forma de pagamento;
+- edição e exclusão de conta bancária;
+- correção de CORS para integração do frontend em produção.
+
+Também contribuiu com reviews em backend, frontend, testes e documentação, participando ativamente da aprovação de PRs antes do merge.
+
+#### Evidências associadas
+
+- PR `feat/#136-tela-cadastro-banco-logged-users`;
+- PR `refactor/tela gerenciamento contas`, relacionado à issue `#165`;
+- PR `feat/(closes #157)tela-resumo-forma-pagamento`;
+- PR `feat/(closes #195) editar e deletar conta bancaria`;
+- PR `#210`, correção de CORS para frontend em produção;
+- PR `#212`, review em cálculos do resumo mensal, ordem de parâmetros e tratamento de categoria sem nome;
+- PR `#211`, review e aprovação da correção de importação;
+- PR `#198`, review para evitar `NullPointerException` em requisições sem body e orientação sobre retorno de erro;
+- PR `#145`, review sobre mensagem de sucesso permanecendo indefinidamente e análise de possível erro de lógica;
+- PR `#163`, review e aprovação;
+- PR `#192`, review e aprovação em conversa com o responsável;
+- PR `#143`, apontamento de inconsistências pontuais na lógica;
+- PR `#183`, review e aprovação;
+- PR `#180`, review e aprovação;
+- PR `#188`, review e aprovação;
+- PR `#190`, review e aprovação;
+- PR `#187`, sugestão para documentar ajuste na regra de negócio e posterior aprovação;
+- PR `#191`, apontamento de que o PR não corrigia completamente a issue mencionada e sugestão para ajustar a descrição.
+
+#### Observações
+
+A contribuição de Victor Gabriel foi importante para transformar o cadastro de conta em um fluxo mais completo de gerenciamento, além de reforçar a experiência do usuário e a consistência dos PRs revisados. Na `v0.4.1`, também participou da estabilização do ambiente publicado e da revisão do backend de resumo mensal.
+
+---
+
+### Victor Blum
+
+#### Contribuições principais
+
+Victor Blum atuou principalmente em backend, arquitetura, categorização, refatoração do `TransacaoService`, contrato de parsers, métricas técnicas e dashboard mensal.
+
+Durante a Sprint 4, abriu PRs relacionados a:
+
+- interface de categorização;
+- categorização por forma de pagamento e conta;
+- correção do contrato dos parsers de importação;
+- atualização do documento de métricas com dados de refatoração;
+- refatoração do design do `TransacaoService`;
+- backend de resumo mensal e gastos por categoria para a versão `v0.4.1`.
+
+Também contribuiu em muitas revisões técnicas, com foco em testes, controller, backend, documentação e qualidade das entregas.
+
+#### Evidências associadas
+
+- PR `Feat/#65 interface de categorizacao`;
+- PR `Feat/#66 categorizacao por forma de pagamento e conta`;
+- PR `Fix/174 contrato parsers importacao`;
+- PR de atualização das métricas de refatoração;
+- PR `Refactor/#128 transacao service design`;
+- PR `#212`, finalização do backend do resumo mensal e gastos por categoria;
+- PR `#141`, revisão de documentação desatualizada;
+- PR `#151`, apontamento de testes faltantes e ajustes na lógica dos testes;
+- PR `#152`, revisão de testes faltantes, descrição do PR e correções pontuais;
+- PR `#153`, revisão de testes e correções nos testes montados;
+- PR `#159`, contribuição em review técnico;
+- PR `#166`, apontamentos sobre controller, service e cobertura;
+- PR `#167`, revisão de testes e validações;
+- PR `#169`, revisão de pontos de manutenção e consistência;
+- PR `#172`, acompanhamento da issue de testes do resumo mensal;
+- PR `#174`, revisão e correção do contrato dos parsers;
+- PR `#197`, documentação de métricas da Sprint 4.
+
+#### Observações
+
+A contribuição de Victor Blum foi central para a evolução técnica do backend e para a redução de complexidade do `TransacaoService`. Na versão `v0.4.1`, também foi responsável por finalizar o backend do resumo mensal e gastos por categoria, fechando uma das principais pendências da Sprint 4.
+
+---
+
+### Alexandre Villela
+
+#### Contribuições principais
+
+Alexandre Villela atuou principalmente em testes, modelagem e confiabilidade da importação.
+
+Durante a Sprint 4 e a estabilização da `v0.4.1`, abriu PRs relacionados a:
+
+- testes de contrato dos parsers de importação;
+- ajuste de modelagem de `TipoTransacao`;
+- validações de comportamento esperado na importação.
+
+#### Evidências associadas
+
+- PR `#209`, testes de contrato dos parsers de importação;
+- PR `#208`, modelagem de `TipoTransacao` apenas com sentido financeiro;
+- issue `#175`, testes de contrato dos parsers;
+- issue `#176`, ajuste de modelagem de `TipoTransacao`.
+
+#### Observações
+
+A atuação de Alexandre Villela foi importante para reduzir ambiguidades no domínio financeiro e aumentar a confiabilidade da importação de extratos. As entregas foram incorporadas na versão complementar `v0.4.1`.
 
 ## Observação sobre a versão 0.4.1
 

--- a/docs/entregas/sprint4.md
+++ b/docs/entregas/sprint4.md
@@ -2,7 +2,7 @@
 
 A Sprint 4 representou uma etapa de consolidação do MVP do SmartBudget. Enquanto a Sprint 3 havia avançado na base de importação, categorização, autenticação, listagem e testes iniciais, a Sprint 4 focou em transformar essas bases em fluxos mais completos para o usuário, com manutenção de transações, gestão de contas, melhoria de listagens, ampliação de testes, refatoração técnica e preparação do projeto para publicação estável.
 
-No recorte original da Sprint 4 foram consideradas 30 issues únicas. Após a consolidação inicial da entrega, 28 foram feitas na 0.4.0 e todas as 30 finalizadas na 0.4.1.
+No recorte da Sprint 4 foram consideradas 32 issues, todas concluídas após a consolidação da `v0.4.0` e a rodada complementar da `v0.4.1`.
 
 Após a publicação inicial da versão `v0.4.0`, a equipe realizou uma rodada complementar de estabilização e fechamento de pendências, consolidada na versão `v0.4.1`. Essa versão incorporou correções, testes adicionais, ajustes de modelagem e a finalização de funcionalidades que haviam ficado pendentes no recorte inicial da Sprint 4.
 

--- a/docs/entregas/sprint4.md
+++ b/docs/entregas/sprint4.md
@@ -546,5 +546,16 @@ Essa versão foi criada para:
 - ajustar a modelagem de tipo de transação;
 - corrigir CORS para o ambiente publicado;
 - consolidar o backend do resumo mensal do dashboard.
+- gestão de contas bancárias;
+- primeira conta no onboarding;
+- edição e exclusão de transações;
+- filtros e paginação de transações;
+- resumo por forma de pagamento;
+- categorização pela interface;
+- testes frontend e backend ampliados;
+- cobertura frontend mensurada;
+- backend mais modular após refatoração;
+- documentação de deploy;
+- versão estável publicada na `main`.
 
 Com isso, a Sprint 4 passa a ter uma entrega mais completa e alinhada ao MVP validável do SmartBudget.

--- a/docs/metricas.md
+++ b/docs/metricas.md
@@ -367,7 +367,7 @@ A mudança não alterou o contrato externo da API e foi validada por testes auto
 
 Como o projeto ainda não usa story points padronizados no GitHub Projects, as métricas de velocidade e taxa de conclusão continuam usando contagem de issues como aproximação operacional. Essa limitação deve ser considerada na interpretação dos resultados.
 
-> Observação: a contagem da Sprint 4 considera issues únicas. Após a estabilização na `v0.4.1`, as 30 issues consideradas no recorte da Sprint 4 foram concluídas.
+> Observação: a contagem da Sprint 4 considera issues. Após a estabilização na `v0.4.1`, as 32 issues consideradas no recorte da Sprint 4 foram concluídas.
 
 ## Referência de escopo do MVP usada nas métricas
 
@@ -398,8 +398,8 @@ Leitura adotada:
 | Taxa de sucesso na importação de arquivos | **100% nos cenários automatizados válidos do backend** | **Bug funcional identificado e resolvido até a `v0.4.1` (`#170`)** | **Estabilização após regressão operacional** | A Sprint 4 identificou um bug no fluxo de importação em que o usuário podia ser redirecionado para login e a importação não era concluída corretamente. A pendência foi resolvida até a versão `v0.4.1`. |
 | Eficiência de categorização automática | **Parcialmente mensurável: funcionalidade implementada, sem amostra real de produção** | **Parcialmente mensurável: regras e fluxo de categorização evoluídos, ainda sem base real suficiente para percentual operacional** | **Melhoria qualitativa** | A Sprint 4 avançou no fluxo de categorização pela interface e em testes relacionados. Porém, a métrica percentual ainda depende de uma base real de transações importadas para medir quantas foram categorizadas automaticamente sem intervenção manual. |
 | Taxa de erros reportados por usuários | **0 bugs válidos reportados/fechados como bug no recorte consultado** | **1 bug válido registrado e resolvido até a `v0.4.1` (`#170`)** | **Regressão tratada** | A `#170` registrou falha no fluxo de importação de extrato, incluindo redirecionamento indevido para login e tratamento incorreto de erros que não deveriam encerrar a sessão. |
-| Velocidade do time (Velocity) | **Não medida em story points; 14 itens relevantes considerados na Sprint 3** | **Não medida em story points; 30 issues únicas consideradas na Sprint 4** | **Melhoria operacional, sem comparação formal em SP** | O volume de issues trabalhadas aumentou, mas a ausência de story points impede comparação formal de velocity Scrum. A contagem de issues serve apenas como aproximação operacional. |
-| Taxa de conclusão de itens planejados | **92,9%** em critério estrito na Sprint 3 | **100%** em critério estrito na Sprint 4 (**30/30 issues concluídas**) | **Melhoria** | A Sprint 4 concluiu as 30 issues únicas consideradas após a estabilização incorporada na `v0.4.1`. |
+| Velocidade do time (Velocity) | **Não medida em story points; 14 itens relevantes considerados na Sprint 3** | **Não medida em story points; 32 issues consideradas na Sprint 4** | **Melhoria operacional, sem comparação formal em SP** | O volume de issues trabalhadas aumentou, mas a ausência de story points impede comparação formal de velocity Scrum. A contagem de issues serve apenas como aproximação operacional. |
+| Taxa de conclusão de itens planejados | **92,9%** em critério estrito na Sprint 3 | **100%** em critério estrito na Sprint 4 (**32/32 issues concluídas**) | **Melhoria** | A Sprint 4 concluiu as 32 issues consideradas após a estabilização incorporada na `v0.4.1`. |
 | Cobertura de testes automatizados | **Backend: 75,5%** geral (**694/919** linhas); **68,6%** no pacote `service` (**188/274**). Frontend: **70,3%** linhas, **67,6%** statements, **58,7%** funções, **61,2%** branches | **Backend: 86,0%** geral (**936/1088** linhas); **88,6%** no pacote `service` (**343/387**). Frontend: **72,1%** linhas (**710/985**), **69,3%** statements (**783/1129**), **66,1%** funções (**170/257**) e **61,4%** branches (**437/712**) | **Melhoria em relação à Sprint 3, com queda em relação à medição intermediária da Sprint 4** | A Sprint 4 segue melhor que a Sprint 3 em todas as métricas de cobertura acompanhadas. Porém, após a implementação das novas issues, a cobertura caiu em relação à medição intermediária anterior da própria Sprint 4, pois houve aumento do volume de código coberto pelo denominador. |
 | Lead time de resolução de defeitos | **Não aplicável / amostra vazia** | **1 bug funcional relevante resolvido até a `v0.4.1` (`#170`)** | **Métrica passa a ter amostra** | A issue `#170` foi registrada como bug funcional relevante da Sprint 4 e resolvida na estabilização da `v0.4.1`. |
 | Percentual de escopo entregue no MVP | **50,0%** (4 de 8 funcionalidades principais) | **85%** do MVP entregue | **Melhoria** | A Sprint 4 consolidou categorização pela interface, filtros/listagem, resumo por forma de pagamento, edição/exclusão de transações, edição/exclusão de contas, CI, cobertura e documentação. A importação de extratos/NF-e é contabilizada como concluída com ressalva, e o extrato futuro permanece pendente. |
@@ -436,20 +436,23 @@ Leitura adotada:
 | #165 - Tela de gerenciamento de contas bancárias | Concluído | Consolida a gestão de contas no frontend. |
 | #170 - Bug no fluxo de importação de extrato | Concluído na `v0.4.1` | Registra regressão funcional identificada na importação e resolvida na estabilização, reforçando a necessidade de monitorar autenticação, tratamento de erro e importação de arquivos. |
 | #174 - Contrato comum dos parsers de importação | Concluído | Melhora organização/manutenção do fluxo de importação e reduz acoplamento entre parsers. |
+| #175 - Testes de contrato dos parsers de importação | Concluído na `v0.4.1` | Reforça validação dos parsers de importação e reduz risco de regressões no processamento de extratos. |
+| #176 - Ajuste de modelagem de `TipoTransacao` | Concluído na `v0.4.1` | Simplifica o sentido financeiro de crédito e débito, reduzindo ambiguidades no domínio. |
 | #177 - Relatório de cobertura dos testes frontend | Concluído | Torna a cobertura do frontend mensurável no pipeline com Vitest. |
 | #184 - Testes da tela Primeira Conta | Concluído | Amplia a cobertura do frontend no fluxo de onboarding após cadastro. |
 | #194 - Backend para editar conta bancária | Concluído | Completa o suporte de backend para edição de contas, com validação de propriedade da conta e atualização dos dados permitidos. |
 | #195 - Frontend para editar e deletar contas bancárias | Concluído | Complementa a gestão de contas na interface, permitindo ações de edição e exclusão, confirmação antes de remover, atualização da listagem e tratamento de loading/erro. |
+| Correção de CORS em produção | Concluído na `v0.4.1` | Ajusta integração entre frontend e backend publicados, permitindo comunicação adequada no ambiente de produção. |
 
 
 ### Resumo quantitativo da Sprint 4
 
 | Indicador | Valor |
 |----------|-------|
-| Issues únicas consideradas na Sprint 4 | **30** |
-| Issues concluídas após merge deste PR | **30** |
+| Issues consideradas na Sprint 4 | **32** |
+| Issues concluídas na Sprint 4 | **32** |
 | Issues não concluídas/replanejadas ou parciais | **0** |
-| Issues não concluídas identificadas | **#67** e **#170** finalizadas na 0.4.1 |
+| Pendências inicialmente parciais finalizadas na `v0.4.1` | **#67** e **#170** |
 | Taxa de conclusão em critério estrito | **100%** |
 | Velocity formal em story points | **Não medida** |
 | Forma alternativa de acompanhamento de velocidade | **Contagem de issues concluídas** |
@@ -470,7 +473,7 @@ Leitura adotada:
 
 **O que foi planejado:** A Sprint 4 teve foco na consolidação do MVP, fechamento de pendências funcionais, manutenção do CI, documentação de deploy, atualização das métricas, reengenharia do `TransacaoService`, registro de ADR, ampliação de testes frontend/backend, gestão de contas, manutenção de transações e preparação do marco `v0.4.0`.
 
-**O que foi executado:** Foram consideradas 30 issues únicas no recorte da Sprint 4, e as 30 foram concluídas após a estabilização incorporada na `v0.4.1`. A sprint evidenciou avanços em categorização pela interface, filtros e listagem de transações, resumo por forma de pagamento, edição/exclusão de transações no backend e no frontend, edição/exclusão de contas no backend e no frontend, gestão de contas, testes frontend, testes backend, CI com Gradle Wrapper, lint, cobertura com Vitest, documentação de deploy/staging reprodutível, documentação de padrões arquiteturais e refatoração do `TransacaoService`. Também foi identificado e resolvido o bug `#170` no fluxo de importação.
+**O que foi executado:** Foram consideradas 32 issues no recorte da Sprint 4, todas concluídas após a estabilização incorporada na `v0.4.1`. A sprint evidenciou avanços em categorização pela interface, filtros e listagem de transações, resumo por forma de pagamento, edição/exclusão de transações no backend e no frontend, edição/exclusão de contas no backend e no frontend, gestão de contas, testes frontend, testes backend, CI com Gradle Wrapper, lint, cobertura com Vitest, documentação de deploy/staging reprodutível, documentação de padrões arquiteturais e refatoração do `TransacaoService`. Também foi identificado e resolvido o bug `#170` no fluxo de importação.
 
 **Melhorias observadas:** A cobertura backend permanece significativamente superior à Sprint 3, saindo de **75,5%** para **86,0%** no projeto como um todo e de **68,6%** para **88,6%** no pacote `service`. No frontend, a cobertura também evoluiu em relação à Sprint 3: linhas passaram de **70,3%** para **72,1%**, statements de **67,6%** para **69,3%**, funções de **58,7%** para **66,1%** e branches de **61,2%** para **61,4%**. Além disso, a refatoração do `TransacaoService` reduziu concentração de responsabilidades, melhorando a manutenibilidade do backend. A conclusão das issues `#135`, `#194` e `#195` fortaleceu os fluxos de manutenção de transações e contas. A atualização da documentação arquitetural também melhorou a rastreabilidade dos padrões aplicados, especialmente ao diferenciar arquitetura em camadas de design pattern e registrar o uso de Strategy nos parsers de importação. Além disso, a disponibilização de ambiente de staging ou alternativa reprodutível fortaleceu a capacidade de validação externa do MVP.
 
@@ -507,7 +510,7 @@ Obs: não cobre dados da 0.4.1.
 ### Limitações da medição
 
 - A velocity continua não medida em story points; a comparação usa contagem de issues concluídas como aproximação operacional.
-- A taxa de conclusão da Sprint 4 considera o recorte de issues informado e o estado esperado após o merge deste PR de métricas.
+- A taxa de conclusão da Sprint 4 considera o recorte de 32 issues concluídas.
 - A métrica de percentual do MVP foi recalculada usando as **8 funcionalidades principais** registradas no `README.md` e em `docs/baseline.md`.
 - A leitura oficial desta atualização considera **funcionalidades prontas + com ressalva**, resultando em **85%** do MVP entregue.
 - A issue `#170` foi registrada como bug válido da Sprint 4 e resolvida até a `v0.4.1`. Por isso, a importação de extratos/NF-e foi contabilizada como funcionalidade concluída com ressalva.

--- a/docs/metricas.md
+++ b/docs/metricas.md
@@ -505,7 +505,7 @@ Cobertura de branches (frontend): 61,4% (437/712)
 
 A medição atual substitui a medição intermediária anterior da Sprint 4. A queda percentual em algumas métricas é explicada pelo aumento do volume de código testável após a entrada de novas issues no escopo do marco `v0.4.0`.
 
-Obs: não cobre dados da 0.4.1.
+Obs.: os valores de cobertura foram obtidos do último CI verde disponível antes da consolidação final da v0.4.1; por isso, podem não refletir alterações posteriores exclusivamente documentais.
 
 ### Limitações da medição
 

--- a/docs/metricas.md
+++ b/docs/metricas.md
@@ -363,11 +363,11 @@ A mudança não alterou o contrato externo da API e foi validada por testes auto
 
 ## Valores observados - Sprint 4
 
-> **Recorte usado para esta atualização:** entregas associadas à consolidação da Sprint 4 e ao marco `v0.4.0`, incluindo evolução funcional do MVP, manutenção do CI, medição de cobertura do frontend, refatoração/reengenharia do `TransacaoService`, documentação técnica associada, documentação de deploy, gestão de contas, manutenção de transações e preparação da entrega `v0.4.0`.
+> **Recorte usado para esta atualização:** entregas associadas à consolidação da Sprint 4 e ao marco `v0.4.1`, incluindo evolução funcional do MVP, manutenção do CI, medição de cobertura do frontend, refatoração/reengenharia do `TransacaoService`, documentação técnica associada, documentação de deploy, gestão de contas, manutenção de transações e preparação da entrega estável da Sprint 4.
 
 Como o projeto ainda não usa story points padronizados no GitHub Projects, as métricas de velocidade e taxa de conclusão continuam usando contagem de issues como aproximação operacional. Essa limitação deve ser considerada na interpretação dos resultados.
 
-> Observação: a contagem da Sprint 4 considera issues únicas. As issues `#67` e `#170` foram consideradas no recorte da Sprint 4, porém não foram concluídas. A issue `#127` corresponde a esta própria atualização de métricas e deve ser considerada concluída após o merge deste PR.
+> Observação: a contagem da Sprint 4 considera issues únicas. Após a estabilização na `v0.4.1`, as 30 issues consideradas no recorte da Sprint 4 foram concluídas.
 
 ## Referência de escopo do MVP usada nas métricas
 
@@ -377,89 +377,56 @@ A partir da revisão da documentação do projeto, o percentual de escopo entreg
 |----|---------------------------------|--------------------------|
 | 1 | Criação de perfil pessoal, com autenticação | **Concluída** |
 | 2 | Adicionar gastos manualmente | **Concluída** |
-| 3 | Leitura de extratos bancários e notas fiscais (`xml`, `csv`, `txt`) | **Concluída com ressalva** — existe implementação de importação, tela, parsers e testes, mas o bug `#170` ainda impacta o fluxo em determinados cenários |
+| 3 | Leitura de extratos bancários e notas fiscais (`xml`, `csv`, `txt`) | **Concluída com ressalva** — existe implementação de importação, tela, parsers e testes, e o bug `#170` foi resolvido até a `v0.4.1` |
 | 4 | Categorizar gastos em subdivisões, como lazer, alimentação etc. | **Concluída** |
 | 5 | Categorizar gastos por forma de pagamento, como cartão, PIX, dinheiro e boleto | **Concluída** |
 | 6 | Categorizar gastos por cartão, conta ou banco utilizado | **Concluída** |
-| 7 | Visualização de gastos do mês em texto, gráficos e dashboards | **Não concluída** — relacionada à issue `#67` |
+| 7 | Visualização de gastos do mês em texto, gráficos e dashboards | **Concluída** — backend de resumo mensal consolidado na `v0.4.1` |
 | 8 | Visualização do extrato dos próximos meses em texto, gráficos e dashboards | **Não concluída** |
 
 Leitura adotada:
 
 - Funcionalidades **concluídas** contam integralmente no percentual do MVP.
 - Funcionalidades **concluídas com ressalva** também entram no percentual de avanço funcional, desde que a limitação seja explicitada.
-- Bugs abertos que afetam fluxo principal, como a issue `#170`, devem aparecer nas limitações e na análise qualitativa.
-- Funcionalidades não implementadas ou sem evidência no código, como a issue `#67` e o extrato futuro, não são contabilizadas como concluídas.
+- Bugs que afetaram fluxo principal, como a issue `#170`, devem aparecer nas limitações e na análise qualitativa.
+- Funcionalidades não implementadas ou sem evidência no código, como o extrato futuro, não são contabilizadas como concluídas.
 
 ### Comparação Sprint 3 x Sprint 4
 
 | Métrica | Sprint 3 | Sprint 4 | Comparação | Leitura |
 |--------|----------|----------|------------|---------|
-| Taxa de sucesso na importação de arquivos | **100% nos cenários automatizados válidos do backend** | **Parcialmente comprometida por bug identificado na `#170`** | **Regressão operacional identificada** | A Sprint 4 identificou um bug no fluxo de importação em que o usuário podia ser redirecionado para login e a importação não era concluída corretamente. Houve PR com correção parcial, mas a issue ainda não foi concluída; por isso, a métrica de importação não deve ser registrada como plenamente estável nesta sprint. |
+| Taxa de sucesso na importação de arquivos | **100% nos cenários automatizados válidos do backend** | **Bug funcional identificado e resolvido até a `v0.4.1` (`#170`)** | **Estabilização após regressão operacional** | A Sprint 4 identificou um bug no fluxo de importação em que o usuário podia ser redirecionado para login e a importação não era concluída corretamente. A pendência foi resolvida até a versão `v0.4.1`. |
 | Eficiência de categorização automática | **Parcialmente mensurável: funcionalidade implementada, sem amostra real de produção** | **Parcialmente mensurável: regras e fluxo de categorização evoluídos, ainda sem base real suficiente para percentual operacional** | **Melhoria qualitativa** | A Sprint 4 avançou no fluxo de categorização pela interface e em testes relacionados. Porém, a métrica percentual ainda depende de uma base real de transações importadas para medir quantas foram categorizadas automaticamente sem intervenção manual. |
-| Taxa de erros reportados por usuários | **0 bugs válidos reportados/fechados como bug no recorte consultado** | **1 bug válido registrado (`#170`), com correção parcial em PR e ainda não concluído** | **Regressão** | A `#170` registra falha no fluxo de importação de extrato, incluindo redirecionamento indevido para login e tratamento incorreto de erros que não deveriam encerrar a sessão. |
+| Taxa de erros reportados por usuários | **0 bugs válidos reportados/fechados como bug no recorte consultado** | **1 bug válido registrado e resolvido até a `v0.4.1` (`#170`)** | **Regressão tratada** | A `#170` registrou falha no fluxo de importação de extrato, incluindo redirecionamento indevido para login e tratamento incorreto de erros que não deveriam encerrar a sessão. |
 | Velocidade do time (Velocity) | **Não medida em story points; 14 itens relevantes considerados na Sprint 3** | **Não medida em story points; 30 issues únicas consideradas na Sprint 4** | **Melhoria operacional, sem comparação formal em SP** | O volume de issues trabalhadas aumentou, mas a ausência de story points impede comparação formal de velocity Scrum. A contagem de issues serve apenas como aproximação operacional. |
-| Taxa de conclusão de itens planejados | **92,9%** em critério estrito na Sprint 3 | **93,3%** em critério estrito na Sprint 4 (**28/30 issues concluídas após merge deste PR**) | **Estável, com leve melhoria** | A Sprint 4 conclui 28 das 30 issues únicas consideradas se este PR fechar a `#127`. As issues `#67` e `#170` permaneceram não concluídas; a `#170` teve correção parcial, mas ainda não deve contar como entrega finalizada. |
+| Taxa de conclusão de itens planejados | **92,9%** em critério estrito na Sprint 3 | **100%** em critério estrito na Sprint 4 (**30/30 issues concluídas**) | **Melhoria** | A Sprint 4 concluiu as 30 issues únicas consideradas após a estabilização incorporada na `v0.4.1`. |
 | Cobertura de testes automatizados | **Backend: 75,5%** geral (**694/919** linhas); **68,6%** no pacote `service` (**188/274**). Frontend: **70,3%** linhas, **67,6%** statements, **58,7%** funções, **61,2%** branches | **Backend: 86,0%** geral (**936/1088** linhas); **88,6%** no pacote `service` (**343/387**). Frontend: **72,1%** linhas (**710/985**), **69,3%** statements (**783/1129**), **66,1%** funções (**170/257**) e **61,4%** branches (**437/712**) | **Melhoria em relação à Sprint 3, com queda em relação à medição intermediária da Sprint 4** | A Sprint 4 segue melhor que a Sprint 3 em todas as métricas de cobertura acompanhadas. Porém, após a implementação das novas issues, a cobertura caiu em relação à medição intermediária anterior da própria Sprint 4, pois houve aumento do volume de código coberto pelo denominador. |
-| Lead time de resolução de defeitos | **Não aplicável / amostra vazia** | **Ainda não calculável: 1 bug válido aberto/parcial (`#170`)** | **Pendente de fechamento** | Como a issue `#170` ainda não foi concluída, não há lead time final de resolução. A métrica deve ser atualizada quando o bug for fechado. |
-| Percentual de escopo entregue no MVP | **50,0%** (4 de 8 funcionalidades principais) | **75,0%** (6 de 8 funcionalidades principais, considerando funcionalidades prontas + com ressalva) | **Melhoria** | A Sprint 4 consolidou categorização pela interface, filtros/listagem, resumo por forma de pagamento, edição/exclusão de transações, edição/exclusão de contas, CI, cobertura e documentação. A importação de extratos/NF-e é contabilizada como concluída com ressalva, pois há implementação, mas o bug `#170` ainda impacta o fluxo em determinados cenários. O dashboard mensal (`#67`) e o extrato futuro permanecem pendentes. |
+| Lead time de resolução de defeitos | **Não aplicável / amostra vazia** | **1 bug funcional relevante resolvido até a `v0.4.1` (`#170`)** | **Métrica passa a ter amostra** | A issue `#170` foi registrada como bug funcional relevante da Sprint 4 e resolvida na estabilização da `v0.4.1`. |
+| Percentual de escopo entregue no MVP | **50,0%** (4 de 8 funcionalidades principais) | **85%** do MVP entregue | **Melhoria** | A Sprint 4 consolidou categorização pela interface, filtros/listagem, resumo por forma de pagamento, edição/exclusão de transações, edição/exclusão de contas, CI, cobertura e documentação. A importação de extratos/NF-e é contabilizada como concluída com ressalva, e o extrato futuro permanece pendente. |
 | Índice de participação e presença da equipe | **100%** | **100%** | **Estável** | A sprint apresentou contribuição distribuída em funcionalidades, testes, documentação, CI, refatoração, correções e reviews. |
 | Riscos identificados vs. mitigados | **100% dos riscos documentados com plano de mitigação registrado** | **100% dos riscos documentados com plano de mitigação registrado** | **Estável, com novo ponto de atenção operacional** | Os riscos documentados permanecem com plano de mitigação. A `#170` reforça a necessidade de monitorar riscos ligados à importação, autenticação e tratamento de erros no frontend. |
 
-### Itens considerados na Sprint 4
-
-| Item | Situação observada | Impacto nas métricas |
-|------|--------------------|----------------------|
-| #65 - Interface de categorização de transações | Concluído no recorte da sprint | Melhora a usabilidade do histórico de transações e fecha o fluxo de categorização manual pela interface. |
-| #66 - Resumo por forma de pagamento e gestão de contas | Concluído no recorte da sprint | Avança a visualização agregada por forma de pagamento e complementa regras de contas. |
-| #67 - Resumo mensal/backend do dashboard | **Não concluído / replanejado** | Não deve ser contabilizado como funcionalidade finalizada do MVP nesta sprint. Na fonte atual, `ResumoMensalDTO` e `GrupoCategoriaDTO` ainda estão vazios e o `ResumoController` não expõe `GET /resumo` nem `GET /resumo/categorias`. |
-| #106 - Filtros/listagem paginada de transações | Concluído no recorte da sprint | Melhora a consulta de movimentações por filtros e paginação. |
-| #107 - Testes de categorização de transações | Concluído | Reforça a confiabilidade das regras de categorização e reduz risco de regressão. |
-| #122 - Manutenção do CI com Gradle Wrapper e lint frontend | Concluído | Melhora a reprodutibilidade do pipeline e reduz divergência entre ambiente local e CI. |
-| #124 - Documentação de padrões arquiteturais aplicados | Concluído | Atualiza a documentação arquitetural para explicar melhor a arquitetura MVC/camadas e o uso real do padrão Strategy nos parsers de importação. Melhora a rastreabilidade das decisões de design e corrige a justificativa genérica apontada na avaliação da `v0.2.0`. |
-| #125 - Ambiente de staging ou alternativa reprodutível | Concluído | Atende ao requisito da Sprint 4 de disponibilizar o MVP para validação em ambiente acessível ou por execução reprodutível, com instruções de acesso, credenciais de teste e cuidados para não expor segredos no repositório. |
-| #126 - Deploy/documentação de deploy | Concluído no controle da sprint | Atende ao requisito de documentação de implantação/reprodução do ambiente para a entrega. |
-| #127 - Atualização de métricas da Sprint 4 | Em andamento neste PR | Atualiza o acompanhamento quantitativo e qualitativo do projeto ao final da Sprint 4. Deve ser contabilizada como concluída após o merge deste PR. |
-| #128 - Refatoração/reengenharia do `TransacaoService` | Concluído | Melhora manutenibilidade, reduz responsabilidades concentradas e sustenta a comparação antes/depois registrada no documento. |
-| #129 - Comparação de métrica antes/depois da refatoração | Concluído | Atende ao requisito de registrar métrica antes/depois da reengenharia. |
-| #130 - ADR da refatoração da Sprint 4 | Concluído | Registra a decisão de design relacionada à decomposição do `TransacaoService` em ADR própria. |
-| #134 - Backend para editar e excluir transações | Concluído | Implementa suporte backend para manutenção de transações do usuário autenticado, incluindo edição, exclusão, validação de propriedade da transação, validação da conta informada e retorno adequado de erros. Complementa o fluxo de gerenciamento do histórico financeiro. |
-| #135 - Frontend para editar e excluir transações | Concluído | Consolida a manutenção de transações pela interface, permitindo que o usuário edite e exclua movimentações sem depender de chamadas manuais à API. |
-| #136 - Tela para cadastro de nova conta bancária | Concluído | Contribui para o fluxo de contas no frontend e melhora a experiência de onboarding/gestão de contas. |
-| #146 - Testes da tela de registro manual de transações | Concluído | Amplia a cobertura de frontend em fluxo essencial do MVP. |
-| #147 - Testes da tela de cadastro de nova conta bancária | Concluído | Amplia a cobertura de frontend em fluxo de contas. |
-| #151 - Testes da tela de importação de extratos | Concluído | Reforça a cobertura do fluxo de importação no frontend. |
-| #155 - Testes da tela de listagem de transações | Concluído | Reforça a confiabilidade da listagem/histórico de movimentações. |
-| #157 - Frontend do resumo por forma de pagamento | Concluído | Complementa a entrega da #66 na interface, exibindo os agrupamentos por pagamento. |
-| #158 - Testes do resumo por pagamento e contas | Concluído | Reforça a confiança sobre agrupamento por pagamento e regras de contas. |
-| #162 - Testes para edição e exclusão de transações | Concluído | Reforça a cobertura de fluxos de manutenção de transações. |
-| #165 - Tela de gerenciamento de contas bancárias | Concluído | Consolida a gestão de contas no frontend. |
-| #170 - Bug no fluxo de importação de extrato | **Não concluído / correção parcial em PR** | Registra regressão funcional na importação: usuário podia ser redirecionado para login e a importação não era concluída corretamente. Impacta a métrica de sucesso de importação e impede contabilizar a importação como plenamente estável, embora a funcionalidade exista e seja considerada concluída com ressalva no recorte do MVP. |
-| #174 - Contrato comum dos parsers de importação | Concluído | Melhora organização/manutenção do fluxo de importação e reduz acoplamento entre parsers. |
-| #177 - Relatório de cobertura dos testes frontend | Concluído | Torna a cobertura do frontend mensurável no pipeline com Vitest. |
-| #184 - Testes da tela Primeira Conta | Concluído | Amplia a cobertura do frontend no fluxo de onboarding após cadastro. |
-| #194 - Backend para editar conta bancária | Concluído | Completa o suporte de backend para edição de contas, com validação de propriedade da conta e atualização dos dados permitidos. |
-| #195 - Frontend para editar e deletar contas bancárias | Concluído | Complementa a gestão de contas na interface, permitindo ações de edição e exclusão, confirmação antes de remover, atualização da listagem e tratamento de loading/erro. |
 
 ### Resumo quantitativo da Sprint 4
 
 | Indicador | Valor |
 |----------|-------|
 | Issues únicas consideradas na Sprint 4 | **30** |
-| Issues concluídas após merge deste PR | **28** |
-| Issues não concluídas/replanejadas ou parciais | **2** |
-| Issues não concluídas identificadas | **#67** e **#170** |
-| Taxa de conclusão em critério estrito | **93,3%** |
+| Issues concluídas após merge deste PR | **30** |
+| Issues não concluídas/replanejadas ou parciais | **0** |
+| Issues não concluídas identificadas | **#67** e **#170** finalizadas na 0.4.1 |
+| Taxa de conclusão em critério estrito | **100%** |
 | Velocity formal em story points | **Não medida** |
 | Forma alternativa de acompanhamento de velocidade | **Contagem de issues concluídas** |
 | Funcionalidades principais do MVP consideradas | **8** |
-| Funcionalidades principais concluídas sem ressalva até a Sprint 4 | **5** |
-| Funcionalidades principais concluídas com ressalva até a Sprint 4 | **1** |
-| Funcionalidades principais contabilizadas no avanço do MVP | **6** |
-| Percentual estimado de escopo entregue no MVP — prontas + com ressalva | **75,0%** |
-| Bugs válidos reportados por usuários | **1** |
-| Bugs válidos totalmente resolvidos na sprint | **0** |
-| Bugs com correção parcial em PR | **1** |
+| Funcionalidades principais concluídas sem ressalva | **6** |
+| Funcionalidades principais concluídas parcialmente/com ressalva | **1** |
+| Funcionalidades principais não concluídas | **1** |
+| Funcionalidades principais contabilizadas no avanço do MVP | **7** |
+| Percentual estimado de escopo entregue no MVP | **85%** |
+| Bugs funcionais relevantes registrados na Sprint 4 | **1** (`#170`) |
+| Bugs funcionais relevantes resolvidos até a `v0.4.1` | **1** |
+| Correções técnicas/de ambiente incorporadas na `v0.4.1` | **1** correção de CORS em produção |
 | Participação da equipe | **100%** |
 | Cobertura backend | **86,0%** geral (**936/1088** linhas); **88,6%** no pacote `service` (**343/387**) |
 | Cobertura frontend | **72,1%** linhas (**710/985**); **69,3%** statements (**783/1129**); **66,1%** funções (**170/257**); **61,4%** branches (**437/712**) |
@@ -468,13 +435,13 @@ Leitura adotada:
 
 **O que foi planejado:** A Sprint 4 teve foco na consolidação do MVP, fechamento de pendências funcionais, manutenção do CI, documentação de deploy, atualização das métricas, reengenharia do `TransacaoService`, registro de ADR, ampliação de testes frontend/backend, gestão de contas, manutenção de transações e preparação do marco `v0.4.0`.
 
-**O que foi executado:** Foram consideradas 30 issues únicas no recorte da Sprint 4. Após o merge deste PR de métricas, 28 delas podem ser consideradas concluídas. A sprint evidenciou avanços em categorização pela interface, filtros e listagem de transações, resumo por forma de pagamento, edição/exclusão de transações no backend e no frontend, edição/exclusão de contas no backend e no frontend, gestão de contas, testes frontend, testes backend, CI com Gradle Wrapper, lint, cobertura com Vitest, documentação de deploy/staging reprodutível, documentação de padrões arquiteturais e refatoração do `TransacaoService`. Também foi identificado o bug `#170` no fluxo de importação, com PR aberto e correção parcial aplicada.
+**O que foi executado:** Foram consideradas 30 issues únicas no recorte da Sprint 4, e as 30 foram concluídas após a estabilização incorporada na `v0.4.1`. A sprint evidenciou avanços em categorização pela interface, filtros e listagem de transações, resumo por forma de pagamento, edição/exclusão de transações no backend e no frontend, edição/exclusão de contas no backend e no frontend, gestão de contas, testes frontend, testes backend, CI com Gradle Wrapper, lint, cobertura com Vitest, documentação de deploy/staging reprodutível, documentação de padrões arquiteturais e refatoração do `TransacaoService`. Também foi identificado e resolvido o bug `#170` no fluxo de importação.
 
 **Melhorias observadas:** A cobertura backend permanece significativamente superior à Sprint 3, saindo de **75,5%** para **86,0%** no projeto como um todo e de **68,6%** para **88,6%** no pacote `service`. No frontend, a cobertura também evoluiu em relação à Sprint 3: linhas passaram de **70,3%** para **72,1%**, statements de **67,6%** para **69,3%**, funções de **58,7%** para **66,1%** e branches de **61,2%** para **61,4%**. Além disso, a refatoração do `TransacaoService` reduziu concentração de responsabilidades, melhorando a manutenibilidade do backend. A conclusão das issues `#135`, `#194` e `#195` fortaleceu os fluxos de manutenção de transações e contas. A atualização da documentação arquitetural também melhorou a rastreabilidade dos padrões aplicados, especialmente ao diferenciar arquitetura em camadas de design pattern e registrar o uso de Strategy nos parsers de importação. Além disso, a disponibilização de ambiente de staging ou alternativa reprodutível fortaleceu a capacidade de validação externa do MVP.
 
-**Regressões ou pontos de atenção:** A métrica de MVP foi recalculada com base nas **8 funcionalidades principais** registradas no `README.md` e em `docs/baseline.md`. Considerando funcionalidades prontas + com ressalva, o MVP está em **75,0%**. A importação de extratos/NF-e entra como funcionalidade concluída com ressalva por causa do bug `#170`, que ainda afeta o fluxo em determinados cenários. A issue `#67`, relacionada ao resumo mensal/backend do dashboard, não foi concluída, e a visualização do extrato dos próximos meses permanece pendente. Também houve queda em algumas métricas de cobertura quando comparadas à medição intermediária anterior da própria Sprint 4. Essa queda não representa necessariamente perda de testes existentes, mas sim aumento do denominador de linhas, funções, branches e statements após a implementação das novas issues do marco `v0.4.0`. Ainda assim, a cobertura final permanece superior à Sprint 3.
+**Regressões ou pontos de atenção:** A métrica de MVP foi recalculada com base nas **8 funcionalidades principais** registradas no `README.md` e em `docs/baseline.md`. Considerando funcionalidades prontas + com ressalva, o MVP está em **85%**. A importação de extratos/NF-e entra como funcionalidade concluída com ressalva por causa do bug `#170`, resolvido até a `v0.4.1`. A visualização do extrato dos próximos meses permanece pendente. Também houve queda em algumas métricas de cobertura quando comparadas à medição intermediária anterior da própria Sprint 4. Essa queda não representa necessariamente perda de testes existentes, mas sim aumento do denominador de linhas, funções, branches e statements após a implementação das novas issues do marco `v0.4.0`. Ainda assim, a cobertura final permanece superior à Sprint 3.
 
-**Fatores que influenciaram o resultado:** A Sprint 4 combinou atividades funcionais, técnicas, documentais, correções de bug e qualidade. A entrada das issues `#135`, `#194` e `#195` ampliou o escopo do marco `v0.4.0`, especialmente nos fluxos de manutenção de transações e contas. Apesar do avanço relevante e da alta taxa de conclusão de issues, as pendências da `#67` e da `#170` indicam que ainda existem pontos importantes para consolidar o dashboard mensal e estabilizar totalmente o fluxo de importação.
+**Fatores que influenciaram o resultado:** A Sprint 4 combinou atividades funcionais, técnicas, documentais, correções de bug e qualidade. A entrada das issues `#135`, `#194` e `#195` ampliou o escopo do marco `v0.4.0`, especialmente nos fluxos de manutenção de transações e contas. A estabilização na `v0.4.1` permitiu fechar as pendências restantes do recorte, incluindo o resumo mensal e o bug de importação.
 
 ### Referência de cobertura da Sprint 4
 
@@ -500,20 +467,18 @@ Cobertura de branches (frontend): 61,4% (437/712)
 
 A medição atual substitui a medição intermediária anterior da Sprint 4. A queda percentual em algumas métricas é explicada pelo aumento do volume de código testável após a entrada de novas issues no escopo do marco `v0.4.0`.
 
+Obs: não cobre dados da 0.4.1.
+
 ### Limitações da medição
 
 - A velocity continua não medida em story points; a comparação usa contagem de issues concluídas como aproximação operacional.
 - A taxa de conclusão da Sprint 4 considera o recorte de issues informado e o estado esperado após o merge deste PR de métricas.
 - A métrica de percentual do MVP foi recalculada usando as **8 funcionalidades principais** registradas no `README.md` e em `docs/baseline.md`.
-- A leitura oficial desta atualização considera **funcionalidades prontas + com ressalva**, resultando em **75,0%** do MVP entregue.
-- A issue `#170` foi registrada como bug válido da Sprint 4 e teve correção parcial em PR. Por isso, a importação de extratos/NF-e foi contabilizada como funcionalidade concluída com ressalva, e não como fluxo plenamente estável.
-- A issue `#67` não foi concluída no recorte da Sprint 4; por isso, o dashboard mensal/backend de resumo não foi contabilizado como funcionalidade principal finalizada.
+- A leitura oficial desta atualização considera **funcionalidades prontas + com ressalva**, resultando em **85%** do MVP entregue.
+- A issue `#170` foi registrada como bug válido da Sprint 4 e resolvida até a `v0.4.1`. Por isso, a importação de extratos/NF-e foi contabilizada como funcionalidade concluída com ressalva.
+- A issue `#67` foi finalizada até a `v0.4.1`, consolidando o backend de resumo mensal do dashboard.
 - A visualização do extrato dos próximos meses permanece pendente e não foi contabilizada no percentual de MVP entregue.
-- A taxa de sucesso da importação não deve ser tratada como plenamente estável na Sprint 4, pois a `#170` indica falha no fluxo de importação e logout indevido em erros que não deveriam encerrar a sessão.
+- A taxa de sucesso da importação deve considerar que a `#170` indicou falha no fluxo de importação e logout indevido em erros que não deveriam encerrar a sessão, mas foi resolvida até a `v0.4.1`.
 - A eficiência de categorização automática depende de base real de transações importadas e categorizadas automaticamente.
 - Os valores finais de cobertura da Sprint 4 substituem a medição intermediária anterior. A inclusão de novas issues aumentou o volume de código testável, o que reduziu percentuais de cobertura em algumas categorias mesmo com aumento absoluto de linhas/funções/statements cobertos.
 - Os valores de cobertura foram lidos a partir dos relatórios do último CI verde após a implementação das novas issues incluídas no marco `v0.4.0`.
-
-
-
-

--- a/docs/metricas.md
+++ b/docs/metricas.md
@@ -406,6 +406,41 @@ Leitura adotada:
 | Índice de participação e presença da equipe | **100%** | **100%** | **Estável** | A sprint apresentou contribuição distribuída em funcionalidades, testes, documentação, CI, refatoração, correções e reviews. |
 | Riscos identificados vs. mitigados | **100% dos riscos documentados com plano de mitigação registrado** | **100% dos riscos documentados com plano de mitigação registrado** | **Estável, com novo ponto de atenção operacional** | Os riscos documentados permanecem com plano de mitigação. A `#170` reforça a necessidade de monitorar riscos ligados à importação, autenticação e tratamento de erros no frontend. |
 
+### Itens considerados na Sprint 4
+
+| Item | Situação observada | Impacto nas métricas |
+|------|--------------------|----------------------|
+| #65 - Interface de categorização de transações | Concluído no recorte da sprint | Melhora a usabilidade do histórico de transações e fecha o fluxo de categorização manual pela interface. |
+| #66 - Resumo por forma de pagamento e gestão de contas | Concluído no recorte da sprint | Avança a visualização agregada por forma de pagamento e complementa regras de contas. |
+| #67 - Resumo mensal/backend do dashboard | Concluído na `v0.4.1` | Consolida o backend do resumo mensal e passa a contribuir para o avanço funcional do MVP. |
+| #106 - Filtros/listagem paginada de transações | Concluído no recorte da sprint | Melhora a consulta de movimentações por filtros e paginação. |
+| #107 - Testes de categorização de transações | Concluído | Reforça a confiabilidade das regras de categorização e reduz risco de regressão. |
+| #122 - Manutenção do CI com Gradle Wrapper e lint frontend | Concluído | Melhora a reprodutibilidade do pipeline e reduz divergência entre ambiente local e CI. |
+| #124 - Documentação de padrões arquiteturais aplicados | Concluído | Atualiza a documentação arquitetural para explicar melhor a arquitetura MVC/camadas e o uso real do padrão Strategy nos parsers de importação. Melhora a rastreabilidade das decisões de design e corrige a justificativa genérica apontada na avaliação da `v0.2.0`. |
+| #125 - Ambiente de staging ou alternativa reprodutível | Concluído | Atende ao requisito da Sprint 4 de disponibilizar o MVP para validação em ambiente acessível ou por execução reprodutível, com instruções de acesso, credenciais de teste e cuidados para não expor segredos no repositório. |
+| #126 - Deploy/documentação de deploy | Concluído no controle da sprint | Atende ao requisito de documentação de implantação/reprodução do ambiente para a entrega. |
+| #127 - Atualização de métricas da Sprint 4 | Concluído | Atualiza o acompanhamento quantitativo e qualitativo do projeto ao final da Sprint 4. |
+| #128 - Refatoração/reengenharia do `TransacaoService` | Concluído | Melhora manutenibilidade, reduz responsabilidades concentradas e sustenta a comparação antes/depois registrada no documento. |
+| #129 - Comparação de métrica antes/depois da refatoração | Concluído | Atende ao requisito de registrar métrica antes/depois da reengenharia. |
+| #130 - ADR da refatoração da Sprint 4 | Concluído | Registra a decisão de design relacionada à decomposição do `TransacaoService` em ADR própria. |
+| #134 - Backend para editar e excluir transações | Concluído | Implementa suporte backend para manutenção de transações do usuário autenticado, incluindo edição, exclusão, validação de propriedade da transação, validação da conta informada e retorno adequado de erros. Complementa o fluxo de gerenciamento do histórico financeiro. |
+| #135 - Frontend para editar e excluir transações | Concluído | Consolida a manutenção de transações pela interface, permitindo que o usuário edite e exclua movimentações sem depender de chamadas manuais à API. |
+| #136 - Tela para cadastro de nova conta bancária | Concluído | Contribui para o fluxo de contas no frontend e melhora a experiência de onboarding/gestão de contas. |
+| #146 - Testes da tela de registro manual de transações | Concluído | Amplia a cobertura de frontend em fluxo essencial do MVP. |
+| #147 - Testes da tela de cadastro de nova conta bancária | Concluído | Amplia a cobertura de frontend em fluxo de contas. |
+| #151 - Testes da tela de importação de extratos | Concluído | Reforça a cobertura do fluxo de importação no frontend. |
+| #155 - Testes da tela de listagem de transações | Concluído | Reforça a confiabilidade da listagem/histórico de movimentações. |
+| #157 - Frontend do resumo por forma de pagamento | Concluído | Complementa a entrega da #66 na interface, exibindo os agrupamentos por pagamento. |
+| #158 - Testes do resumo por pagamento e contas | Concluído | Reforça a confiança sobre agrupamento por pagamento e regras de contas. |
+| #162 - Testes para edição e exclusão de transações | Concluído | Reforça a cobertura de fluxos de manutenção de transações. |
+| #165 - Tela de gerenciamento de contas bancárias | Concluído | Consolida a gestão de contas no frontend. |
+| #170 - Bug no fluxo de importação de extrato | Concluído na `v0.4.1` | Registra regressão funcional identificada na importação e resolvida na estabilização, reforçando a necessidade de monitorar autenticação, tratamento de erro e importação de arquivos. |
+| #174 - Contrato comum dos parsers de importação | Concluído | Melhora organização/manutenção do fluxo de importação e reduz acoplamento entre parsers. |
+| #177 - Relatório de cobertura dos testes frontend | Concluído | Torna a cobertura do frontend mensurável no pipeline com Vitest. |
+| #184 - Testes da tela Primeira Conta | Concluído | Amplia a cobertura do frontend no fluxo de onboarding após cadastro. |
+| #194 - Backend para editar conta bancária | Concluído | Completa o suporte de backend para edição de contas, com validação de propriedade da conta e atualização dos dados permitidos. |
+| #195 - Frontend para editar e deletar contas bancárias | Concluído | Complementa a gestão de contas na interface, permitindo ações de edição e exclusão, confirmação antes de remover, atualização da listagem e tratamento de loading/erro. |
+
 
 ### Resumo quantitativo da Sprint 4
 


### PR DESCRIPTION
## O que mudou

- Atualização da documentação da Sprint 4 para refletir a consolidação da versão `v0.4.1`.
- Inclusão de uma seção complementar explicando o que foi entregue após a `v0.4.0`.
- Registro dos PRs incorporados na `v0.4.1` e dos responsáveis pela abertura:
  - `#212` - backend do resumo mensal e gastos por categoria;
  - `#208` - ajuste de modelagem de `TipoTransacao`;
  - `#211` - correção do fluxo de importação e pequenas melhorias de UX;
  - `#209` - testes de contrato dos parsers de importação;
  - `#210` - correção de CORS para o frontend em produção.
- Atualização do documento de métricas da Sprint 4 considerando a versão `v0.4.1`.
- Atualização das estatísticas consolidadas da Sprint 4:
  - taxa de conclusão;
  - percentual estimado do MVP entregue;
  - itens considerados;
  - itens concluídos;
  - bugs funcionais relevantes;
  - observações sobre cobertura de testes.
- Inclusão das URLs publicadas consideradas para validação:
  - API: `https://smartbudget-api-kbze.onrender.com`;
  - Web: `https://smartbudget-web-0sic.onrender.com`.

## Por quê

- Para registrar formalmente a entrega complementar da versão `v0.4.1`.
- Para manter a documentação da Sprint 4 alinhada ao estado atual da branch `dev` antes da consolidação na `main`.
- Para documentar as pendências fechadas após a `v0.4.0`, especialmente:
  - `#67`, backend do resumo mensal e gastos por categoria;
  - `#170`, correção do fluxo de importação;
  - `#175`, testes de contrato dos parsers;
  - `#176`, ajuste de modelagem de `TipoTransacao`.
- Para atualizar as métricas do projeto com os dados consolidados da Sprint 4 após a `v0.4.1`.
- Para melhorar a rastreabilidade entre issues, PRs, release e documentação.
- Para deixar claro o estado atual do MVP e quais pontos ainda permanecem como evolução futura.

## Como testar

1. Abrir o documento da Sprint 4 atualizado.
2. Verificar se existe uma seção sobre os complementos incorporados na versão `v0.4.1`.
3. Conferir se os PRs `#208`, `#209`, `#210`, `#211` e `#212` estão listados com seus respectivos responsáveis e entregas.
4. Verificar se a issue `#67` aparece como concluída na `v0.4.1`.
5. Verificar se a issue `#170` aparece como concluída na `v0.4.1`.
6. Abrir o documento de métricas atualizado.
7. Conferir se a Sprint 4 considera a versão `v0.4.1` no recorte da análise.
8. Conferir se as estatísticas foram atualizadas, incluindo:
   1. itens considerados;
   2. itens concluídos;
   3. taxa de conclusão;
   4. percentual estimado de escopo entregue no MVP;
   5. bugs funcionais relevantes;
   6. comparação entre `v0.4.0` e `v0.4.1`.
9. Verificar se as URLs publicadas estão registradas corretamente:
   1. API: `https://smartbudget-api-kbze.onrender.com`;
   2. Web: `https://smartbudget-web-0sic.onrender.com`.
10. Conferir se o markdown renderiza corretamente no GitHub, especialmente:
    1. tabelas;
    2. listas;
    3. blocos de código;
    4. títulos e subtítulos.

## Auto-review (checklist)

- [x] Descrição clara (o que/por quê/como testar)
- [x] PR pequeno e focado
- [x] Casos limite considerados (pendências da `v0.4.0`, itens concluídos na `v0.4.1`, métricas sem cobertura final recalculada)
- [x] Evidência de teste manual ou automatizado
- [x] Não quebrou funcionalidades existentes
- [x] Código revisado e limpo

## Comentários técnicos