### PR TITLE
Fix/200 importacao extratos reais

### DIFF
--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -10,11 +10,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.nio.charset.*;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -22,37 +25,16 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Parser para extratos bancários no formato CSV.
- *
- * Detecta automaticamente o delimitador (vírgula, ponto e vírgula ou tabulação)
- * lendo a primeira linha do arquivo antes de processá-lo.
- *
- * Formato esperado das colunas (ordem obrigatória):
- *   data | descricao | valor | tipo
- *
- * Exemplos de linha válida:
- *   2024-01-15;Supermercado Extra;-150,00;DEBITO
- *   2024-01-20,Salário,5000.00,CREDITO
- *
- * Regras de interpretação:
- * - Valores negativos são sempre tratados como DEBITO, independente do campo tipo
- * - Datas aceitas: yyyy-MM-dd, dd/MM/yyyy, dd-MM-yyyy
- * - Separador decimal aceito: ponto ou vírgula
- * - Linhas de cabeçalho são ignoradas automaticamente (detecção por ausência de data válida)
- * Linhas inválidas não interrompem a importação. Elas são ignoradas e
- * contabilizadas em ResultadoParser.linhasInvalidas.
- */
 @Component
 public class ParserCSV implements ParserExtrato {
+
+    private static final String BOM = "\uFEFF";
 
     private static final List<DateTimeFormatter> FORMATADORES = List.of(
             DateTimeFormatter.ofPattern("yyyy-MM-dd"),
             DateTimeFormatter.ofPattern("dd/MM/yyyy"),
             DateTimeFormatter.ofPattern("dd-MM-yyyy")
     );
-
-    private static final String BOM = "\uFEFF";
 
     @Override
     public boolean aceita(MultipartFile arquivo) {
@@ -87,56 +69,10 @@ public class ParserCSV implements ParserExtrato {
             }
 
             return processarCsvLegado(registros, conta);
-//        try {
-//            String conteudo = lerConteudoDoArquivo(arquivo);
-//            conteudo = removerBom(conteudo);
-//            char delimitador = quebrarEmLinhasUteis(conteudo);
-//
-//            try (CSVReader reader = new CSVReaderBuilder(
-//                    new InputStreamReader(arquivo.getInputStream(), StandardCharsets.UTF_8))
-//                    .withCSVParser(new CSVParserBuilder().withSeparator(delimitador).build())
-//                    .build()) {
-//
-//                String[] linha;
-//                while ((linha = reader.readNext()) != null) {
-//                    totalLinhas++;
-//                    if (linha.length != 4) {
-//                        linhasInvalidas++;
-//                        continue;
-//                    }
-//
-//                    // Ignora cabeçalho: primeira coluna não é uma data válida
-//                    LocalDate data = parsearData(linha[0].trim());
-//                    if (data == null) {
-//                        linhasInvalidas++;
-//                        continue;
-//                    }
-//
-//                    String descricao = linha[1].trim();
-//                    BigDecimal valor = parsearValor(linha[2].trim());
-//                    if (valor == null) {
-//                        linhasInvalidas++;
-//                        continue;
-//                    };
-//
-//                    TipoTransacao tipo = parsearTipo(linha[3].trim(), valor);
-//
-//                    // Valor sempre positivo na entidade; o tipo indica a direção
-//                    Transacao transacao = new Transacao();
-//                    transacao.setConta(conta);
-//                    transacao.setData(data);
-//                    transacao.setDescricao(descricao);
-//                    transacao.setValor(valor.abs());
-//                    transacao.setTipo(tipo);
-//                    transacao.setCategorizada(false);
-//
-//                    transacoes.add(transacao);
-//                }
-//            }
-        }catch (Exception e) {
+
+        } catch (Exception e) {
             throw new RuntimeException("Erro ao processar arquivo CSV: " + e.getMessage(), e);
         }
-
     }
 
     /**
@@ -147,15 +83,8 @@ public class ParserCSV implements ParserExtrato {
      * Isso ajuda em extratos reais, porque alguns bancos exportam arquivos com
      * acentos e caracteres especiais fora de UTF-8.
      */
-
-    private String lerConteudoDoArquivo(MultipartFile arquivo) {
-        byte[] bytes;
-
-        try {
-            bytes = arquivo.getBytes();
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Não foi possível ler o arquivo CSV.", e);
-        }
+    private String lerConteudoDoArquivo(MultipartFile arquivo) throws IOException {
+        byte[] bytes = arquivo.getBytes();
 
         String textoUtf8 = tentarConverter(bytes, StandardCharsets.UTF_8);
 
@@ -179,7 +108,6 @@ public class ParserCSV implements ParserExtrato {
      * new String(bytes, UTF_8) pode mascarar erro de encoding,
      * enquanto o decoder consegue reportar que a conversão falhou.
      */
-
     private String tentarConverter(byte[] bytes, Charset charset) {
         CharsetDecoder decoder = charset.newDecoder()
                 .onMalformedInput(CodingErrorAction.REPORT)
@@ -192,6 +120,15 @@ public class ParserCSV implements ParserExtrato {
         }
     }
 
+    /**
+     * Remove o BOM quando ele aparece no início do arquivo.
+     *
+     * Sem isso, a primeira coluna pode ser lida como:
+     * "﻿date"
+     *
+     * em vez de:
+     * "date"
+     */
     private String removerBom(String conteudo) {
         if (conteudo == null) {
             return "";

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -233,6 +233,7 @@ public class ParserCSV implements ParserExtrato {
     private boolean ehCabecalhoNubankConta(String[] cabecalho) {
         return encontrarIndiceDaColuna(cabecalho, "data") >= 0
                 && encontrarIndiceDaColuna(cabecalho, "valor") >= 0
+                && encontrarIndiceDaColuna(cabecalho, "identificador") >= 0
                 && encontrarIndiceDaColuna(cabecalho, "descricao") >= 0;
     }
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -222,13 +222,13 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Detecta se o CSV possui o cabeçalho do extrato bancário Nubank.
+     * Verifica se o cabeçalho corresponde ao formato do extrato bancário Nubank.
      *
-     * Formato esperado:
-     * Data,Valor,Identificador,Descrição
+     * Para reconhecer esse layout, são obrigatórias as colunas:
+     * Data, Valor, Identificador e Descrição.
      *
-     * O campo Identificador é ignorado na criação da transação, mas pode existir
-     * no arquivo. Para processar, o mínimo necessário é: Data, Valor e Descrição.
+     * O Identificador é utilizado apenas para reconhecer o formato do arquivo
+     * neste momento e não é persistido na entidade Transacao.
      */
     private boolean ehCabecalhoNubankConta(String[] cabecalho) {
         return encontrarIndiceDaColuna(cabecalho, "data") >= 0
@@ -241,11 +241,12 @@ public class ParserCSV implements ParserExtrato {
      * Processa o extrato bancário real do Nubank.
      *
      * Mapeamento:
-     * Data      -> data da transação
-     * Valor     -> valor e tipo da transação
-     * Descrição -> descrição da transação
+     * Data          -> data da transação
+     * Valor         -> valor e tipo da transação
+     * Descrição     -> descrição da transação
+     * Identificador -> usado apenas para identificar o layout e ignorado no domínio
      *
-     * Regra:
+     * Regra do extrato bancário:
      * Valor positivo -> CREDITO
      * Valor negativo -> DEBITO
      * Valor salvo    -> sempre positivo

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -85,6 +85,8 @@ public class ParserCSV implements ParserExtrato {
             if (ehCabecalhoNubank(cabecalho)) {
                 return processarCsvNubank(registros, conta);
             }
+
+            return processarCsvLegado(registros, conta);
 //        try {
 //            String conteudo = lerConteudoDoArquivo(arquivo);
 //            conteudo = removerBom(conteudo);
@@ -367,6 +369,59 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
+     * Mantém o comportamento antigo do parser.
+     *
+     * Formato legado:
+     * data,descricao,valor,tipo
+     *
+     * Isso evita quebrar arquivos e testes que já funcionavam antes.
+     */
+    private ResultadoParser processarCsvLegado(List<String[]> registros, Conta conta) {
+        ResultadoParser resultado = new ResultadoParser();
+
+        List<Transacao> transacoes = new ArrayList<>();
+        int totalLinhas = 0;
+        int linhasInvalidas = 0;
+
+        for (String[] linha : registros) {
+            totalLinhas++;
+
+            if (linha.length != 4) {
+                linhasInvalidas++;
+                continue;
+            }
+
+            LocalDate data = parsearData(linha[0]);
+            BigDecimal valor = parsearValor(linha[2]);
+
+            if (data == null || valor == null) {
+                linhasInvalidas++;
+                continue;
+            }
+
+            String descricao = limparDescricao(linha[1]);
+
+            TipoTransacao tipo = parsearTipoLegado(linha[3], valor);
+
+            Transacao transacao = criarTransacao(
+                    conta,
+                    data,
+                    descricao,
+                    valor.abs(),
+                    tipo
+            );
+
+            transacoes.add(transacao);
+        }
+
+        resultado.setTransacoes(transacoes);
+        resultado.setTotalLinhas(totalLinhas);
+        resultado.setLinhasInvalidas(linhasInvalidas);
+
+        return resultado;
+    }
+
+    /**
      * Encontra o índice de uma coluna dentro do cabeçalho.
      *
      * Exemplo:
@@ -468,55 +523,113 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Tenta parsear a data nos formatos suportados.
-     * Retorna null se nenhum formato for compatível (indica cabeçalho ou linha inválida).
+     * Tenta converter uma string em LocalDate.
+     *
+     * O Nubank usa yyyy-MM-dd.
+     * O formato legado do projeto também aceitava dd/MM/yyyy e dd-MM-yyyy.
      */
     private LocalDate parsearData(String valor) {
-        for (DateTimeFormatter fmt : FORMATADORES) {
+        if (valor == null) {
+            return null;
+        }
+
+        String valorLimpo = valor
+                .replace(BOM, "")
+                .trim();
+
+        for (DateTimeFormatter formatter : FORMATADORES) {
             try {
-                return LocalDate.parse(valor, fmt);
+                return LocalDate.parse(valorLimpo, formatter);
             } catch (DateTimeParseException ignored) {
             }
         }
+
         return null;
     }
 
     /**
-     * Parseia o valor monetário aceitando ponto ou vírgula como separador decimal.
-     * Retorna null se o valor não puder ser interpretado.
+     * Converte textos monetários em BigDecimal.
+     *
+     * Casos aceitos:
+     * "7,00"      -> 7.00
+     * "- 866,89"  -> -866.89
+     * "15,99"     -> 15.99
+     * "104,90"    -> 104.90
+     * "1.234,56"  -> 1234.56
+     * "1234.56"   -> 1234.56
      */
     private BigDecimal parsearValor(String valor) {
+        if (valor == null) {
+            return null;
+        }
+
         try {
-            // Remove separadores de milhar e normaliza o decimal
             String normalizado = valor
+                    .replace(BOM, "")
+                    .replace("\"", "")
                     .replace("R$", "")
-                    .replace(" ", "")
                     .trim();
 
-            // Se tiver vírgula e ponto, o ponto é separador de milhar (ex: 1.500,00)
+            boolean negativo = false;
+
+            if (normalizado.startsWith("(") && normalizado.endsWith(")")) {
+                negativo = true;
+                normalizado = normalizado.substring(1, normalizado.length() - 1).trim();
+            }
+
+            if (normalizado.startsWith("-")) {
+                negativo = true;
+                normalizado = normalizado.substring(1).trim();
+            }
+
+            if (normalizado.endsWith("-")) {
+                negativo = true;
+                normalizado = normalizado.substring(0, normalizado.length() - 1).trim();
+            }
+
+            normalizado = normalizado.replace(" ", "");
+
+            if (normalizado.isBlank()) {
+                return null;
+            }
+
             if (normalizado.contains(",") && normalizado.contains(".")) {
-                normalizado = normalizado.replace(".", "").replace(",", ".");
-            } else {
+                normalizado = normalizado
+                        .replace(".", "")
+                        .replace(",", ".");
+            } else if (normalizado.contains(",")) {
                 normalizado = normalizado.replace(",", ".");
             }
 
-            return new BigDecimal(normalizado);
+            BigDecimal valorDecimal = new BigDecimal(normalizado);
+
+            if (negativo) {
+                return valorDecimal.negate();
+            }
+
+            return valorDecimal;
+
         } catch (NumberFormatException e) {
             return null;
         }
     }
 
     /**
-     * Determina o TipoTransacao. Valores negativos são sempre DEBITO.
-     * Para valores positivos, tenta interpretar o campo tipo do CSV.
+     * Regra antiga do CSV legado.
+     *
+     * Mantém compatibilidade com os testes e arquivos anteriores:
+     * - valor negativo continua sendo DEBITO;
+     * - se o tipo informado existir no enum, usa ele;
+     * - se o tipo não for reconhecido, valor positivo vira CREDITO.
      */
-    private TipoTransacao parsearTipo(String tipoStr, BigDecimal valor) {
-        if (valor.compareTo(BigDecimal.ZERO) < 0) return TipoTransacao.DEBITO;
+    private TipoTransacao parsearTipoLegado(String tipoTexto, BigDecimal valor) {
+        if (valor.compareTo(BigDecimal.ZERO) < 0) {
+            return TipoTransacao.DEBITO;
+        }
 
         try {
-            return TipoTransacao.valueOf(tipoStr.toUpperCase());
+            return TipoTransacao.valueOf(normalizarTexto(tipoTexto).toUpperCase());
         } catch (IllegalArgumentException e) {
-            // Fallback: positivo sem tipo reconhecido é CREDITO
             return TipoTransacao.CREDITO;
         }
     }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -15,6 +15,7 @@ import java.io.StringReader;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.*;
+import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -72,6 +73,18 @@ public class ParserCSV implements ParserExtrato {
             }
 
             char delimitador = detectarDelimitador(linhas);
+
+            List<String[]> registros = lerRegistrosCsv(linhas, delimitador);
+
+            if (registros.isEmpty()) {
+                return new ResultadoParser();
+            }
+
+            String[] cabecalho = registros.getFirst();
+
+            if (ehCabecalhoNubank(cabecalho)) {
+                return processarCsvNubank(registros, conta);
+            }
 //        try {
 //            String conteudo = lerConteudoDoArquivo(arquivo);
 //            conteudo = removerBom(conteudo);
@@ -275,6 +288,69 @@ public class ParserCSV implements ParserExtrato {
         }
 
         return registros;
+    }
+
+    /**
+     * Verifica se o CSV tem o layout real do Nubank.
+     *
+     * Layout esperado:
+     * date,title,amount
+     */
+    private boolean ehCabecalhoNubank(String[] cabecalho) {
+        return encontrarIndiceDaColuna(cabecalho, "date") >= 0
+                && encontrarIndiceDaColuna(cabecalho, "title") >= 0
+                && encontrarIndiceDaColuna(cabecalho, "amount") >= 0;
+    }
+
+    private ResultadoParser processarCsvNubank(List<String[]> registros, Conta conta) {
+        
+    }
+
+    /**
+     * Encontra o índice de uma coluna dentro do cabeçalho.
+     *
+     * Exemplo:
+     * date,title,amount
+     *
+     * encontrarIndiceDaColuna(cabecalho, "amount")
+     * retorna 2.
+     */
+    private int encontrarIndiceDaColuna(String[] cabecalho, String nomeProcurado) {
+        for (int i = 0; i < cabecalho.length; i++) {
+            String colunaNormalizada = normalizarTexto(cabecalho[i]);
+
+            if (colunaNormalizada.equals(nomeProcurado)) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Normaliza textos para comparação.
+     *
+     * Usado principalmente para comparar cabeçalhos, como:
+     * "﻿date" -> "date"
+     * " Date " -> "date"
+     * "Descrição" -> "descricao"
+     */
+    private String normalizarTexto(String texto) {
+        if (texto == null) {
+            return "";
+        }
+
+        String normalizado = texto
+                .replace(BOM, "")
+                .replace("\"", "")
+                .trim()
+                .toLowerCase();
+
+        normalizado = Normalizer
+                .normalize(normalizado, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "");
+
+        return normalizado;
     }
 
     /**

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -9,9 +9,11 @@ import com.opencsv.CSVReaderBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
+import java.nio.charset.*;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -48,6 +50,8 @@ public class ParserCSV implements ParserExtrato {
             DateTimeFormatter.ofPattern("dd-MM-yyyy")
     );
 
+    private static final String BOM = "\uFEFF";
+
     @Override
     public boolean aceita(MultipartFile arquivo) {
         String nome = arquivo.getOriginalFilename();
@@ -62,9 +66,7 @@ public class ParserCSV implements ParserExtrato {
         int totalLinhas = resultadoParser.getTotalLinhas();
 
         try {
-            // Lê o conteúdo bruto para detectar o delimitador
-            byte[] bytes = arquivo.getBytes();
-            String conteudo = new String(bytes, StandardCharsets.UTF_8);
+            String conteudo = lerConteudoDoArquivo(arquivo);
             char delimitador = detectarDelimitador(conteudo);
 
             try (CSVReader reader = new CSVReaderBuilder(
@@ -116,6 +118,43 @@ public class ParserCSV implements ParserExtrato {
         resultadoParser.setTotalLinhas(totalLinhas);
         return resultadoParser;
     }
+
+    private String lerConteudoDoArquivo(MultipartFile arquivo) {
+        byte[] bytes;
+
+        try {
+            bytes = arquivo.getBytes();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Não foi possível ler o arquivo CSV.", e);
+        }
+
+        String textoUtf8 = tentarConverter(bytes, StandardCharsets.UTF_8);
+
+        if (textoUtf8 != null) {
+            return textoUtf8;
+        }
+
+        String textoWindows1252 = tentarConverter(bytes, Charset.forName("Windows-1252"));
+
+        if (textoWindows1252 != null) {
+            return textoWindows1252;
+        }
+
+        return new String(bytes, StandardCharsets.ISO_8859_1);
+    }
+
+    private String tentarConverter(byte[] bytes, Charset charset) {
+        CharsetDecoder decoder = charset.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+
+        try {
+            return decoder.decode(ByteBuffer.wrap(bytes)).toString();
+        } catch (CharacterCodingException e) {
+            return null;
+        }
+    }
+
 
     /**
      * Detecta o delimitador mais provável analisando a primeira linha do arquivo.

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -134,10 +134,7 @@ public class ParserCSV implements ParserExtrato {
         }catch (Exception e) {
             throw new RuntimeException("Erro ao processar arquivo CSV: " + e.getMessage(), e);
         }
-        resultadoParser.setTransacoes(transacoes);
-        resultadoParser.setLinhasInvalidas(linhasInvalidas);
-        resultadoParser.setTotalLinhas(totalLinhas);
-        return resultadoParser;
+
     }
 
     /**
@@ -302,8 +299,71 @@ public class ParserCSV implements ParserExtrato {
                 && encontrarIndiceDaColuna(cabecalho, "amount") >= 0;
     }
 
+    /**
+     * Processa o CSV real do Nubank.
+     *
+     * Regras:
+     * - date vira data da transação;
+     * - title vira descrição;
+     * - amount vira valor;
+     * - amount positivo vira DEBITO, porque representa compra/gasto;
+     * - amount negativo vira CREDITO, porque representa pagamento recebido;
+     * - valor é salvo sempre positivo na entidade.
+     */
     private ResultadoParser processarCsvNubank(List<String[]> registros, Conta conta) {
-        
+        ResultadoParser resultado = new ResultadoParser();
+
+        List<Transacao> transacoes = new ArrayList<>();
+        int totalLinhas = 0;
+        int linhasInvalidas = 0;
+
+        String[] cabecalho = registros.getFirst();
+
+        int indiceData = encontrarIndiceDaColuna(cabecalho, "date");
+        int indiceDescricao = encontrarIndiceDaColuna(cabecalho, "title");
+        int indiceValor = encontrarIndiceDaColuna(cabecalho, "amount");
+
+        if (indiceData < 0 || indiceDescricao < 0 || indiceValor < 0) {
+            throw new IllegalArgumentException("Cabeçalho Nubank inválido");
+        }
+
+        for (int i = 1; i < registros.size(); i++) {
+            String[] linha = registros.get(i);
+
+            totalLinhas++;
+
+            if (!possuiIndicesObrigatorios(linha, indiceData, indiceDescricao, indiceValor)) {
+                linhasInvalidas++;
+                continue;
+            }
+
+            LocalDate data = parsearData(linha[indiceData]);
+            String descricao = limparDescricao(linha[indiceDescricao]);
+            BigDecimal valor = parsearValor(linha[indiceValor]);
+
+            if (data == null || valor == null || valor.compareTo(BigDecimal.ZERO) == 0) {
+                linhasInvalidas++;
+                continue;
+            }
+
+            TipoTransacao tipo = resolverTipoNubank(valor);
+
+            Transacao transacao = criarTransacao(
+                    conta,
+                    data,
+                    descricao,
+                    valor.abs(),
+                    tipo
+            );
+
+            transacoes.add(transacao);
+        }
+
+        resultado.setTransacoes(transacoes);
+        resultado.setTotalLinhas(totalLinhas);
+        resultado.setLinhasInvalidas(linhasInvalidas);
+
+        return resultado;
     }
 
     /**
@@ -351,6 +411,60 @@ public class ParserCSV implements ParserExtrato {
                 .replaceAll("\\p{M}", "");
 
         return normalizado;
+    }
+
+    /**
+     * Garante que a linha tem as posições que serão acessadas.
+     *
+     * Isso evita ArrayIndexOutOfBoundsException quando uma linha vier quebrada
+     * ou com colunas faltando.
+     */
+    private boolean possuiIndicesObrigatorios(String[] linha, int... indices) {
+        for (int indice : indices) {
+            if (indice < 0 || indice >= linha.length) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Limpa a descrição da transação.
+     *
+     * Se a descrição vier vazia, usa um fallback para evitar salvar descrição nula
+     * ou em branco.
+     */
+    private String limparDescricao(String descricao) {
+        if (descricao == null) {
+            return "Transação importada";
+        }
+
+        String descricaoLimpa = descricao
+                .replace(BOM, "")
+                .replace("\"", "")
+                .trim();
+
+        if (descricaoLimpa.isBlank()) {
+            return "Transação importada";
+        }
+
+        return descricaoLimpa;
+    }
+
+    /**
+     * Regra específica do extrato Nubank de cartão.
+     *
+     * No arquivo enviado:
+     * - compras aparecem com amount positivo;
+     * - pagamento recebido aparece com amount negativo.
+     */
+    private TipoTransacao resolverTipoNubank(BigDecimal valor) {
+        if (valor.compareTo(BigDecimal.ZERO) > 0) {
+            return TipoTransacao.DEBITO;
+        }
+
+        return TipoTransacao.CREDITO;
     }
 
     /**
@@ -405,5 +519,30 @@ public class ParserCSV implements ParserExtrato {
             // Fallback: positivo sem tipo reconhecido é CREDITO
             return TipoTransacao.CREDITO;
         }
+    }
+
+    /**
+     * Centraliza a criação da Transacao.
+     *
+     * Assim, tanto o fluxo Nubank quanto o fluxo legado criam transações com
+     * a mesma estrutura mínima.
+     */
+    private Transacao criarTransacao(
+            Conta conta,
+            LocalDate data,
+            String descricao,
+            BigDecimal valor,
+            TipoTransacao tipo
+    ) {
+        Transacao transacao = new Transacao();
+
+        transacao.setConta(conta);
+        transacao.setData(data);
+        transacao.setDescricao(descricao);
+        transacao.setValor(valor);
+        transacao.setTipo(tipo);
+        transacao.setCategorizada(false);
+
+        return transacao;
     }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -54,7 +54,7 @@ public class ParserCSV implements ParserExtrato {
                 return new ResultadoParser();
             }
 
-            char delimitador = detectarDelimitador(linhas);
+            char delimitador = detectarDelimitador(linhas.getFirst());
 
             List<String[]> registros = lerRegistrosCsv(linhas, delimitador);
 
@@ -64,8 +64,8 @@ public class ParserCSV implements ParserExtrato {
 
             String[] cabecalho = registros.getFirst();
 
-            if (ehCabecalhoNubank(cabecalho)) {
-                return processarCsvNubank(registros, conta);
+            if (ehCabecalhoNubankConta(cabecalho)) {
+                return processarCsvNubankConta(registros, conta);
             }
 
             return processarCsvLegado(registros, conta);
@@ -76,12 +76,13 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Lê os bytes do arquivo tentando UTF-8 primeiro.
-     * Se UTF-8 não funcionar, tenta Windows-1252.
-     * Se também não funcionar, usa ISO-8859-1 como fallback final.
+     * Lê o conteúdo do arquivo tentando UTF-8 primeiro.
      *
-     * Isso ajuda em extratos reais, porque alguns bancos exportam arquivos com
-     * acentos e caracteres especiais fora de UTF-8.
+     * Se UTF-8 não funcionar, tenta Windows-1252.
+     * Se Windows-1252 também não funcionar, usa ISO-8859-1 como fallback final.
+     *
+     * Isso ajuda em extratos reais, porque arquivos exportados por bancos podem
+     * vir com acentos em diferentes encodings.
      */
     private String lerConteudoDoArquivo(MultipartFile arquivo) throws IOException {
         byte[] bytes = arquivo.getBytes();
@@ -104,9 +105,8 @@ public class ParserCSV implements ParserExtrato {
     /**
      * Tenta converter os bytes usando um charset específico.
      *
-     * O uso de CharsetDecoder é importante porque:
-     * new String(bytes, UTF_8) pode mascarar erro de encoding,
-     * enquanto o decoder consegue reportar que a conversão falhou.
+     * O CharsetDecoder é usado para detectar erro real de encoding.
+     * Usar new String(bytes, UTF_8) diretamente pode mascarar caracteres inválidos.
      */
     private String tentarConverter(byte[] bytes, Charset charset) {
         CharsetDecoder decoder = charset.newDecoder()
@@ -121,13 +121,10 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Remove o BOM quando ele aparece no início do arquivo.
+     * Remove o BOM do início do arquivo, quando existir.
      *
-     * Sem isso, a primeira coluna pode ser lida como:
-     * "﻿date"
-     *
-     * em vez de:
-     * "date"
+     * Sem isso, um cabeçalho como "Data" pode ser lido como "﻿Data",
+     * fazendo a comparação de nomes de coluna falhar.
      */
     private String removerBom(String conteudo) {
         if (conteudo == null) {
@@ -142,12 +139,11 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Quebra o conteúdo em linhas úteis.
+     * Quebra o conteúdo do arquivo em linhas úteis.
      *
-     * Linhas em branco são ignoradas para não virarem falhas falsas
-     * na importação.
+     * Linhas em branco são ignoradas para não serem contabilizadas como falhas
+     * falsas no parser.
      */
-
     private List<String> quebrarEmLinhasUteis(String conteudo) {
         List<String> linhasUteis = new ArrayList<>();
 
@@ -166,24 +162,28 @@ public class ParserCSV implements ParserExtrato {
         return linhasUteis;
     }
 
-
     /**
-     * Detecta o delimitador comparando vírgula, ponto e vírgula e tabulação.
+     * Detecta o delimitador mais provável usando a primeira linha útil.
      *
-     * Para o Nubank, a linha:
-     * date,title,amount
+     * Para o extrato bancário Nubank:
+     * Data,Valor,Identificador,Descrição
      *
-     * gera 3 colunas com vírgula, então a vírgula será escolhida.
+     * O delimitador detectado será vírgula.
      */
-    private char detectarDelimitador(List<String> linhas) throws Exception {
+    private char detectarDelimitador(String primeiraLinha) throws Exception {
         char melhorDelimitador = ',';
         int maiorQuantidadeColunas = 1;
 
         char[] candidatos = new char[]{',', ';', '\t'};
 
         for (char candidato : candidatos) {
-            List<String[]> registros = lerRegistrosCsv(List.of(linhas.get(0)), candidato);
-            int quantidadeColunas = registros.get(0).length;
+            List<String[]> registros = lerRegistrosCsv(List.of(primeiraLinha), candidato);
+
+            if (registros.isEmpty()) {
+                continue;
+            }
+
+            int quantidadeColunas = registros.getFirst().length;
 
             if (quantidadeColunas > maiorQuantidadeColunas) {
                 maiorQuantidadeColunas = quantidadeColunas;
@@ -195,16 +195,11 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Lê as linhas com OpenCSV.
+     * Lê as linhas usando OpenCSV.
      *
-     * Isso é importante porque o Nubank usa valores assim:
-     * "7,00"
-     *
-     * Se você usar split(",") simples, esse valor quebra em duas colunas:
-     * "7"
-     * "00"
-     *
-     * Com OpenCSV, o conteúdo entre aspas é preservado corretamente.
+     * Isso evita erro com campos que possuem vírgula dentro de aspas.
+     * Mesmo que o extrato bancário Nubank não dependa muito disso, é mais seguro
+     * manter a leitura robusta para CSV real.
      */
     private List<String[]> lerRegistrosCsv(List<String> linhas, char delimitador) throws Exception {
         String conteudo = String.join("\n", linhas);
@@ -227,29 +222,34 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Verifica se o CSV tem o layout real do Nubank.
+     * Detecta se o CSV possui o cabeçalho do extrato bancário Nubank.
      *
-     * Layout esperado:
-     * date,title,amount
+     * Formato esperado:
+     * Data,Valor,Identificador,Descrição
+     *
+     * O campo Identificador é ignorado na criação da transação, mas pode existir
+     * no arquivo. Para processar, o mínimo necessário é: Data, Valor e Descrição.
      */
-    private boolean ehCabecalhoNubank(String[] cabecalho) {
-        return encontrarIndiceDaColuna(cabecalho, "date") >= 0
-                && encontrarIndiceDaColuna(cabecalho, "title") >= 0
-                && encontrarIndiceDaColuna(cabecalho, "amount") >= 0;
+    private boolean ehCabecalhoNubankConta(String[] cabecalho) {
+        return encontrarIndiceDaColuna(cabecalho, "data") >= 0
+                && encontrarIndiceDaColuna(cabecalho, "valor") >= 0
+                && encontrarIndiceDaColuna(cabecalho, "descricao") >= 0;
     }
 
     /**
-     * Processa o CSV real do Nubank.
+     * Processa o extrato bancário real do Nubank.
      *
-     * Regras:
-     * - date vira data da transação;
-     * - title vira descrição;
-     * - amount vira valor;
-     * - amount positivo vira DEBITO, porque representa compra/gasto;
-     * - amount negativo vira CREDITO, porque representa pagamento recebido;
-     * - valor é salvo sempre positivo na entidade.
+     * Mapeamento:
+     * Data      -> data da transação
+     * Valor     -> valor e tipo da transação
+     * Descrição -> descrição da transação
+     *
+     * Regra:
+     * Valor positivo -> CREDITO
+     * Valor negativo -> DEBITO
+     * Valor salvo    -> sempre positivo
      */
-    private ResultadoParser processarCsvNubank(List<String[]> registros, Conta conta) {
+    private ResultadoParser processarCsvNubankConta(List<String[]> registros, Conta conta) {
         ResultadoParser resultado = new ResultadoParser();
 
         List<Transacao> transacoes = new ArrayList<>();
@@ -258,12 +258,12 @@ public class ParserCSV implements ParserExtrato {
 
         String[] cabecalho = registros.getFirst();
 
-        int indiceData = encontrarIndiceDaColuna(cabecalho, "date");
-        int indiceDescricao = encontrarIndiceDaColuna(cabecalho, "title");
-        int indiceValor = encontrarIndiceDaColuna(cabecalho, "amount");
+        int indiceData = encontrarIndiceDaColuna(cabecalho, "data");
+        int indiceValor = encontrarIndiceDaColuna(cabecalho, "valor");
+        int indiceDescricao = encontrarIndiceDaColuna(cabecalho, "descricao");
 
-        if (indiceData < 0 || indiceDescricao < 0 || indiceValor < 0) {
-            throw new IllegalArgumentException("Cabeçalho Nubank inválido");
+        if (indiceData < 0 || indiceValor < 0 || indiceDescricao < 0) {
+            throw new IllegalArgumentException("Cabeçalho Nubank Conta inválido");
         }
 
         for (int i = 1; i < registros.size(); i++) {
@@ -271,21 +271,21 @@ public class ParserCSV implements ParserExtrato {
 
             totalLinhas++;
 
-            if (!possuiIndicesObrigatorios(linha, indiceData, indiceDescricao, indiceValor)) {
+            if (!possuiIndicesObrigatorios(linha, indiceData, indiceValor, indiceDescricao)) {
                 linhasInvalidas++;
                 continue;
             }
 
             LocalDate data = parsearData(linha[indiceData]);
-            String descricao = limparDescricao(linha[indiceDescricao]);
             BigDecimal valor = parsearValor(linha[indiceValor]);
+            String descricao = limparDescricao(linha[indiceDescricao]);
 
             if (data == null || valor == null || valor.compareTo(BigDecimal.ZERO) == 0) {
                 linhasInvalidas++;
                 continue;
             }
 
-            TipoTransacao tipo = resolverTipoNubank(valor);
+            TipoTransacao tipo = resolverTipoNubankConta(valor);
 
             Transacao transacao = criarTransacao(
                     conta,
@@ -306,12 +306,12 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Mantém o comportamento antigo do parser.
+     * Mantém o comportamento legado do CSV já aceito pelo sistema.
      *
      * Formato legado:
      * data,descricao,valor,tipo
      *
-     * Isso evita quebrar arquivos e testes que já funcionavam antes.
+     * A manutenção desse fallback evita quebrar testes e arquivos antigos.
      */
     private ResultadoParser processarCsvLegado(List<String[]> registros, Conta conta) {
         ResultadoParser resultado = new ResultadoParser();
@@ -331,13 +331,12 @@ public class ParserCSV implements ParserExtrato {
             LocalDate data = parsearData(linha[0]);
             BigDecimal valor = parsearValor(linha[2]);
 
-            if (data == null || valor == null) {
+            if (data == null || valor == null || valor.compareTo(BigDecimal.ZERO) == 0) {
                 linhasInvalidas++;
                 continue;
             }
 
             String descricao = limparDescricao(linha[1]);
-
             TipoTransacao tipo = parsearTipoLegado(linha[3], valor);
 
             Transacao transacao = criarTransacao(
@@ -359,13 +358,13 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Encontra o índice de uma coluna dentro do cabeçalho.
+     * Encontra o índice de uma coluna no cabeçalho.
      *
-     * Exemplo:
-     * date,title,amount
-     *
-     * encontrarIndiceDaColuna(cabecalho, "amount")
-     * retorna 2.
+     * A comparação usa normalização para aceitar:
+     * "Descrição"
+     * "descricao"
+     * " Descrição "
+     * "﻿Descrição"
      */
     private int encontrarIndiceDaColuna(String[] cabecalho, String nomeProcurado) {
         for (int i = 0; i < cabecalho.length; i++) {
@@ -380,35 +379,9 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Normaliza textos para comparação.
+     * Verifica se a linha tem todos os índices que serão acessados.
      *
-     * Usado principalmente para comparar cabeçalhos, como:
-     * "﻿date" -> "date"
-     * " Date " -> "date"
-     * "Descrição" -> "descricao"
-     */
-    private String normalizarTexto(String texto) {
-        if (texto == null) {
-            return "";
-        }
-
-        String normalizado = texto
-                .replace(BOM, "")
-                .replace("\"", "")
-                .trim()
-                .toLowerCase();
-
-        normalizado = Normalizer
-                .normalize(normalizado, Normalizer.Form.NFD)
-                .replaceAll("\\p{M}", "");
-
-        return normalizado;
-    }
-
-    /**
-     * Garante que a linha tem as posições que serão acessadas.
-     *
-     * Isso evita ArrayIndexOutOfBoundsException quando uma linha vier quebrada
+     * Isso evita ArrayIndexOutOfBoundsException quando o CSV possui linha quebrada
      * ou com colunas faltando.
      */
     private boolean possuiIndicesObrigatorios(String[] linha, int... indices) {
@@ -422,10 +395,32 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Limpa a descrição da transação.
+     * Normaliza texto para comparação.
      *
-     * Se a descrição vier vazia, usa um fallback para evitar salvar descrição nula
-     * ou em branco.
+     * Exemplo:
+     * "Descrição" vira "descricao"
+     * "﻿Data" vira "data"
+     */
+    private String normalizarTexto(String texto) {
+        if (texto == null) {
+            return "";
+        }
+
+        String normalizado = texto
+                .replace(BOM, "")
+                .replace("\"", "")
+                .trim()
+                .toLowerCase();
+
+        return Normalizer
+                .normalize(normalizado, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "");
+    }
+
+    /**
+     * Limpa a descrição que será salva na transação.
+     *
+     * Se a descrição vier vazia, usa um texto padrão para evitar descrição nula.
      */
     private String limparDescricao(String descricao) {
         if (descricao == null) {
@@ -445,25 +440,10 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Regra específica do extrato Nubank de cartão.
+     * Converte texto em LocalDate.
      *
-     * No arquivo enviado:
-     * - compras aparecem com amount positivo;
-     * - pagamento recebido aparece com amount negativo.
-     */
-    private TipoTransacao resolverTipoNubank(BigDecimal valor) {
-        if (valor.compareTo(BigDecimal.ZERO) > 0) {
-            return TipoTransacao.DEBITO;
-        }
-
-        return TipoTransacao.CREDITO;
-    }
-
-    /**
-     * Tenta converter uma string em LocalDate.
-     *
-     * O Nubank usa yyyy-MM-dd.
-     * O formato legado do projeto também aceitava dd/MM/yyyy e dd-MM-yyyy.
+     * O extrato bancário Nubank usa dd/MM/yyyy.
+     * O CSV legado também pode usar yyyy-MM-dd ou dd-MM-yyyy.
      */
     private LocalDate parsearData(String valor) {
         if (valor == null) {
@@ -485,15 +465,20 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Converte textos monetários em BigDecimal.
+     * Converte texto monetário em BigDecimal.
      *
      * Casos aceitos:
-     * "7,00"      -> 7.00
-     * "- 866,89"  -> -866.89
-     * "15,99"     -> 15.99
-     * "104,90"    -> 104.90
-     * "1.234,56"  -> 1234.56
-     * "1234.56"   -> 1234.56
+     * 80        -> 80
+     * -80       -> -80
+     * -8.91     -> -8.91
+     * -494.1    -> -494.1
+     * 1.234,56  -> 1234.56
+     * 1234,56   -> 1234.56
+     * R$ 100,00 -> 100.00
+     *
+     * Importante:
+     * se o valor contém apenas ponto, o ponto é tratado como decimal.
+     * Isso evita transformar -8.91 em -891.
      */
     private BigDecimal parsearValor(String valor) {
         if (valor == null) {
@@ -552,12 +537,25 @@ public class ParserCSV implements ParserExtrato {
     }
 
     /**
-     * Regra antiga do CSV legado.
+     * Regra do extrato bancário Nubank.
      *
-     * Mantém compatibilidade com os testes e arquivos anteriores:
-     * - valor negativo continua sendo DEBITO;
-     * - se o tipo informado existir no enum, usa ele;
-     * - se o tipo não for reconhecido, valor positivo vira CREDITO.
+     * Valor positivo significa entrada de dinheiro na conta.
+     * Valor negativo significa saída de dinheiro da conta.
+     */
+    private TipoTransacao resolverTipoNubankConta(BigDecimal valor) {
+        if (valor.compareTo(BigDecimal.ZERO) > 0) {
+            return TipoTransacao.CREDITO;
+        }
+
+        return TipoTransacao.DEBITO;
+    }
+
+    /**
+     * Regra do CSV legado.
+     *
+     * Valores negativos continuam sendo DEBITO.
+     * Para valores positivos, tenta usar o campo tipo informado no CSV.
+     * Se o tipo não for reconhecido, faz fallback para CREDITO.
      */
     private TipoTransacao parsearTipoLegado(String tipoTexto, BigDecimal valor) {
         if (valor.compareTo(BigDecimal.ZERO) < 0) {
@@ -574,8 +572,8 @@ public class ParserCSV implements ParserExtrato {
     /**
      * Centraliza a criação da Transacao.
      *
-     * Assim, tanto o fluxo Nubank quanto o fluxo legado criam transações com
-     * a mesma estrutura mínima.
+     * O parser define apenas os dados extraídos do arquivo.
+     * Categoria e Importacao continuam sendo responsabilidades do ImportacaoService.
      */
     private Transacao criarTransacao(
             Conta conta,

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -60,57 +60,63 @@ public class ParserCSV implements ParserExtrato {
 
     @Override
     public ResultadoParser parsear(MultipartFile arquivo, Conta conta) {
-        List<Transacao> transacoes = new ArrayList<>();
-        ResultadoParser resultadoParser = new ResultadoParser();
-        int linhasInvalidas = resultadoParser.getLinhasInvalidas();
-        int totalLinhas = resultadoParser.getTotalLinhas();
-
         try {
             String conteudo = lerConteudoDoArquivo(arquivo);
-            char delimitador = detectarDelimitador(conteudo);
+            conteudo = removerBom(conteudo);
 
-            try (CSVReader reader = new CSVReaderBuilder(
-                    new InputStreamReader(arquivo.getInputStream(), StandardCharsets.UTF_8))
-                    .withCSVParser(new CSVParserBuilder().withSeparator(delimitador).build())
-                    .build()) {
+            List<String> linhas = quebrarEmLinhasUteis(conteudo);
 
-                String[] linha;
-                while ((linha = reader.readNext()) != null) {
-                    totalLinhas++;
-                    if (linha.length != 4) {
-                        linhasInvalidas++;
-                        continue;
-                    }
-
-                    // Ignora cabeçalho: primeira coluna não é uma data válida
-                    LocalDate data = parsearData(linha[0].trim());
-                    if (data == null) {
-                        linhasInvalidas++;
-                        continue;
-                    }
-
-                    String descricao = linha[1].trim();
-                    BigDecimal valor = parsearValor(linha[2].trim());
-                    if (valor == null) {
-                        linhasInvalidas++;
-                        continue;
-                    };
-
-                    TipoTransacao tipo = parsearTipo(linha[3].trim(), valor);
-
-                    // Valor sempre positivo na entidade; o tipo indica a direção
-                    Transacao transacao = new Transacao();
-                    transacao.setConta(conta);
-                    transacao.setData(data);
-                    transacao.setDescricao(descricao);
-                    transacao.setValor(valor.abs());
-                    transacao.setTipo(tipo);
-                    transacao.setCategorizada(false);
-
-                    transacoes.add(transacao);
-                }
+            if (linhas.isEmpty()) {
+                return new ResultadoParser();
             }
-        } catch (Exception e) {
+        }
+//        try {
+//            String conteudo = lerConteudoDoArquivo(arquivo);
+//            conteudo = removerBom(conteudo);
+//            char delimitador = quebrarEmLinhasUteis(conteudo);
+//
+//            try (CSVReader reader = new CSVReaderBuilder(
+//                    new InputStreamReader(arquivo.getInputStream(), StandardCharsets.UTF_8))
+//                    .withCSVParser(new CSVParserBuilder().withSeparator(delimitador).build())
+//                    .build()) {
+//
+//                String[] linha;
+//                while ((linha = reader.readNext()) != null) {
+//                    totalLinhas++;
+//                    if (linha.length != 4) {
+//                        linhasInvalidas++;
+//                        continue;
+//                    }
+//
+//                    // Ignora cabeçalho: primeira coluna não é uma data válida
+//                    LocalDate data = parsearData(linha[0].trim());
+//                    if (data == null) {
+//                        linhasInvalidas++;
+//                        continue;
+//                    }
+//
+//                    String descricao = linha[1].trim();
+//                    BigDecimal valor = parsearValor(linha[2].trim());
+//                    if (valor == null) {
+//                        linhasInvalidas++;
+//                        continue;
+//                    };
+//
+//                    TipoTransacao tipo = parsearTipo(linha[3].trim(), valor);
+//
+//                    // Valor sempre positivo na entidade; o tipo indica a direção
+//                    Transacao transacao = new Transacao();
+//                    transacao.setConta(conta);
+//                    transacao.setData(data);
+//                    transacao.setDescricao(descricao);
+//                    transacao.setValor(valor.abs());
+//                    transacao.setTipo(tipo);
+//                    transacao.setCategorizada(false);
+//
+//                    transacoes.add(transacao);
+//                }
+//            }
+         catch (Exception e) {
             throw new RuntimeException("Erro ao processar arquivo CSV: " + e.getMessage(), e);
         }
         resultadoParser.setTransacoes(transacoes);
@@ -118,6 +124,15 @@ public class ParserCSV implements ParserExtrato {
         resultadoParser.setTotalLinhas(totalLinhas);
         return resultadoParser;
     }
+
+    /**
+     * Lê os bytes do arquivo tentando UTF-8 primeiro.
+     * Se UTF-8 não funcionar, tenta Windows-1252.
+     * Se também não funcionar, usa ISO-8859-1 como fallback final.
+     *
+     * Isso ajuda em extratos reais, porque alguns bancos exportam arquivos com
+     * acentos e caracteres especiais fora de UTF-8.
+     */
 
     private String lerConteudoDoArquivo(MultipartFile arquivo) {
         byte[] bytes;
@@ -143,6 +158,14 @@ public class ParserCSV implements ParserExtrato {
         return new String(bytes, StandardCharsets.ISO_8859_1);
     }
 
+    /**
+     * Tenta converter os bytes usando um charset específico.
+     *
+     * O uso de CharsetDecoder é importante porque:
+     * new String(bytes, UTF_8) pode mascarar erro de encoding,
+     * enquanto o decoder consegue reportar que a conversão falhou.
+     */
+
     private String tentarConverter(byte[] bytes, Charset charset) {
         CharsetDecoder decoder = charset.newDecoder()
                 .onMalformedInput(CodingErrorAction.REPORT)
@@ -153,6 +176,43 @@ public class ParserCSV implements ParserExtrato {
         } catch (CharacterCodingException e) {
             return null;
         }
+    }
+
+    private String removerBom(String conteudo) {
+        if (conteudo == null) {
+            return "";
+        }
+
+        if (conteudo.startsWith(BOM)) {
+            return conteudo.substring(1);
+        }
+
+        return conteudo;
+    }
+
+    /**
+     * Quebra o conteúdo em linhas úteis.
+     *
+     * Linhas em branco são ignoradas para não virarem falhas falsas
+     * na importação.
+     */
+
+    private List<String> quebrarEmLinhasUteis(String conteudo) {
+        List<String> linhasUteis = new ArrayList<>();
+
+        String conteudoNormalizado = conteudo
+                .replace("\r\n", "\n")
+                .replace("\r", "\n");
+
+        for (String linha : conteudoNormalizado.split("\n")) {
+            String linhaLimpa = linha.trim();
+
+            if (!linhaLimpa.isBlank()) {
+                linhasUteis.add(linhaLimpa);
+            }
+        }
+
+        return linhasUteis;
     }
 
 

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/parser/ParserCSV.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.*;
@@ -69,7 +70,8 @@ public class ParserCSV implements ParserExtrato {
             if (linhas.isEmpty()) {
                 return new ResultadoParser();
             }
-        }
+
+            char delimitador = detectarDelimitador(linhas);
 //        try {
 //            String conteudo = lerConteudoDoArquivo(arquivo);
 //            conteudo = removerBom(conteudo);
@@ -116,7 +118,7 @@ public class ParserCSV implements ParserExtrato {
 //                    transacoes.add(transacao);
 //                }
 //            }
-         catch (Exception e) {
+        }catch (Exception e) {
             throw new RuntimeException("Erro ao processar arquivo CSV: " + e.getMessage(), e);
         }
         resultadoParser.setTransacoes(transacoes);
@@ -217,14 +219,62 @@ public class ParserCSV implements ParserExtrato {
 
 
     /**
-     * Detecta o delimitador mais provável analisando a primeira linha do arquivo.
-     * Prioridade: ponto e vírgula > vírgula > tabulação.
+     * Detecta o delimitador comparando vírgula, ponto e vírgula e tabulação.
+     *
+     * Para o Nubank, a linha:
+     * date,title,amount
+     *
+     * gera 3 colunas com vírgula, então a vírgula será escolhida.
      */
-    private char detectarDelimitador(String conteudo) {
-        String primeiraLinha = conteudo.split("\n")[0];
-        if (primeiraLinha.contains(";")) return ';';
-        if (primeiraLinha.contains(",")) return ',';
-        return '\t';
+    private char detectarDelimitador(List<String> linhas) throws Exception {
+        char melhorDelimitador = ',';
+        int maiorQuantidadeColunas = 1;
+
+        char[] candidatos = new char[]{',', ';', '\t'};
+
+        for (char candidato : candidatos) {
+            List<String[]> registros = lerRegistrosCsv(List.of(linhas.get(0)), candidato);
+            int quantidadeColunas = registros.get(0).length;
+
+            if (quantidadeColunas > maiorQuantidadeColunas) {
+                maiorQuantidadeColunas = quantidadeColunas;
+                melhorDelimitador = candidato;
+            }
+        }
+
+        return melhorDelimitador;
+    }
+
+    /**
+     * Lê as linhas com OpenCSV.
+     *
+     * Isso é importante porque o Nubank usa valores assim:
+     * "7,00"
+     *
+     * Se você usar split(",") simples, esse valor quebra em duas colunas:
+     * "7"
+     * "00"
+     *
+     * Com OpenCSV, o conteúdo entre aspas é preservado corretamente.
+     */
+    private List<String[]> lerRegistrosCsv(List<String> linhas, char delimitador) throws Exception {
+        String conteudo = String.join("\n", linhas);
+        List<String[]> registros = new ArrayList<>();
+
+        try (CSVReader reader = new CSVReaderBuilder(new StringReader(conteudo))
+                .withCSVParser(new CSVParserBuilder()
+                        .withSeparator(delimitador)
+                        .build())
+                .build()) {
+
+            String[] linha;
+
+            while ((linha = reader.readNext()) != null) {
+                registros.add(linha);
+            }
+        }
+
+        return registros;
     }
 
     /**

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ImportacaoService.java
@@ -89,6 +89,16 @@ public class ImportacaoService {
         int sucessos = 0, falhas = 0;
         try {
             ResultadoParser resultado = parser.parsear(arquivo, conta);
+            if(resultado.getTransacoes().isEmpty()){
+                importacao.setStatusImportacao(StatusImportacao.ERRO);
+                importacao.setTotal_linhas(resultado.getTotalLinhas());
+                importacao.setSucessos(0);
+                importacao.setFalhas(resultado.getLinhasInvalidas());
+                importacao.
+                setMensagemErro("Nenhuma transação valida foi encontrada no arquivo. Verifique o formato das colunas de data, descrição e valor");
+                importacaoRepository.save(importacao);
+                return toResponse(importacao);
+            }
             falhas = resultado.getLinhasInvalidas();
             for (Transacao t: resultado.getTransacoes()){
                 try {

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/parser/ParserCSVTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/parser/ParserCSVTest.java
@@ -117,6 +117,88 @@ class ParserCSVTest {
         }
 
         @Test
+        @DisplayName("extrato real Nubank: importa date,title,amount inferindo tipo pelo sinal do amount")
+        void extratoRealNubank_importaDateTitleAmount() {
+            String conteudo = """
+            date,title,amount
+            2026-05-30,Mais Natural,"7,00"
+            2026-05-24,Mercado Compre Facil P,"15,99"
+            2026-05-08,Pagamento recebido,"- 866,89"
+            """;
+
+            MockMultipartFile arquivo = fromString("nubank-real.csv", conteudo);
+
+            ResultadoParser resultado = parser.parsear(arquivo, conta);
+
+            assertAll(
+                    () -> assertEquals(3, resultado.getTransacoes().size()),
+                    () -> assertEquals(3, resultado.getTotalLinhas()),
+                    () -> assertEquals(0, resultado.getLinhasInvalidas()),
+
+                    () -> assertEquals("Mais Natural", resultado.getTransacoes().get(0).getDescricao()),
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(0).getTipo()),
+                    () -> assertEquals(0, resultado.getTransacoes().get(0).getValor()
+                            .compareTo(new BigDecimal("7.00"))),
+
+                    () -> assertEquals("Mercado Compre Facil P", resultado.getTransacoes().get(1).getDescricao()),
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(1).getTipo()),
+                    () -> assertEquals(0, resultado.getTransacoes().get(1).getValor()
+                            .compareTo(new BigDecimal("15.99"))),
+
+                    () -> assertEquals("Pagamento recebido", resultado.getTransacoes().get(2).getDescricao()),
+                    () -> assertEquals(TipoTransacao.CREDITO, resultado.getTransacoes().get(2).getTipo()),
+                    () -> assertEquals(0, resultado.getTransacoes().get(2).getValor()
+                            .compareTo(new BigDecimal("866.89")))
+            );
+        }
+
+        @Test
+        @DisplayName("extrato Nubank com BOM no cabeçalho é reconhecido corretamente")
+        void extratoNubankComBom_noCabecalho_eReconhecido() {
+            String conteudo = "\uFEFFdate,title,amount\n"
+                    + "2026-05-30,Mais Natural,\"7,00\"\n";
+
+            MockMultipartFile arquivo = fromString("nubank-real.csv", conteudo);
+
+            ResultadoParser resultado = parser.parsear(arquivo, conta);
+
+            assertAll(
+                    () -> assertEquals(1, resultado.getTransacoes().size()),
+                    () -> assertEquals(1, resultado.getTotalLinhas()),
+                    () -> assertEquals(0, resultado.getLinhasInvalidas()),
+                    () -> assertEquals("Mais Natural", resultado.getTransacoes().get(0).getDescricao()),
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(0).getTipo()),
+                    () -> assertEquals(0, resultado.getTransacoes().get(0).getValor()
+                            .compareTo(new BigDecimal("7.00")))
+            );
+        }
+
+        @Test
+        @DisplayName("extrato Nubank com linhas inválidas não interrompe importação")
+        void extratoNubankComLinhasInvalidas_naoInterrompeImportacao() {
+            String conteudo = """
+            date,title,amount
+            2026-05-30,Mais Natural,"7,00"
+            data-invalida,Mercado,"15,99"
+            2026-05-08,Pagamento recebido,"- 866,89"
+            2026-05-10,Linha Valor Invalido,abc
+            """;
+
+            MockMultipartFile arquivo = fromString("nubank-real.csv", conteudo);
+
+            ResultadoParser resultado = parser.parsear(arquivo, conta);
+
+            assertAll(
+                    () -> assertEquals(2, resultado.getTransacoes().size()),
+                    () -> assertEquals(4, resultado.getTotalLinhas()),
+                    () -> assertEquals(2, resultado.getLinhasInvalidas()),
+
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(0).getTipo()),
+                    () -> assertEquals(TipoTransacao.CREDITO, resultado.getTransacoes().get(1).getTipo())
+            );
+        }
+
+        @Test
         @DisplayName("delimitador ponto-e-vírgula é detectado automaticamente")
         void delimitadorPontoVirgula_detectadoAutomaticamente() throws IOException {
             MockMultipartFile arquivo = fromFixture("extrato-ponto-virgula.csv");

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/parser/ParserCSVTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/parser/ParserCSVTest.java
@@ -117,38 +117,72 @@ class ParserCSVTest {
         }
 
         @Test
-        @DisplayName("extrato real Nubank: importa date,title,amount inferindo tipo pelo sinal do amount")
-        void extratoRealNubank_importaDateTitleAmount() {
+        @DisplayName("extrato bancário Nubank: valores negativos com ponto decimal viram DEBITO")
+        void extratoBancarioNubank_valoresNegativosComPontoDecimal_viramDebito() {
             String conteudo = """
-            date,title,amount
-            2026-05-30,Mais Natural,"7,00"
-            2026-05-24,Mercado Compre Facil P,"15,99"
-            2026-05-08,Pagamento recebido,"- 866,89"
+            Data,Valor,Identificador,Descrição
+            08/06/2026,-8.91,6a26e7fc-e0ff-459a-bcbc-e8a5b774f068,Transferência enviada pelo Pix
+            08/06/2026,-494.1,6a26fb54-15a4-4ad4-9dd7-82c8324803e3,Pagamento de fatura
             """;
 
-            MockMultipartFile arquivo = fromString("nubank-real.csv", conteudo);
+            MockMultipartFile arquivo = fromString("nubank-conta.csv", conteudo);
 
             ResultadoParser resultado = parser.parsear(arquivo, conta);
 
             assertAll(
-                    () -> assertEquals(3, resultado.getTransacoes().size()),
-                    () -> assertEquals(3, resultado.getTotalLinhas()),
+                    () -> assertEquals(2, resultado.getTransacoes().size()),
+                    () -> assertEquals(2, resultado.getTotalLinhas()),
                     () -> assertEquals(0, resultado.getLinhasInvalidas()),
 
-                    () -> assertEquals("Mais Natural", resultado.getTransacoes().get(0).getDescricao()),
                     () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(0).getTipo()),
                     () -> assertEquals(0, resultado.getTransacoes().get(0).getValor()
-                            .compareTo(new BigDecimal("7.00"))),
+                            .compareTo(new BigDecimal("8.91"))),
 
-                    () -> assertEquals("Mercado Compre Facil P", resultado.getTransacoes().get(1).getDescricao()),
                     () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(1).getTipo()),
                     () -> assertEquals(0, resultado.getTransacoes().get(1).getValor()
-                            .compareTo(new BigDecimal("15.99"))),
+                            .compareTo(new BigDecimal("494.1")))
+            );
+        }
 
-                    () -> assertEquals("Pagamento recebido", resultado.getTransacoes().get(2).getDescricao()),
+        @Test
+        @DisplayName("extrato bancário Nubank: importa Data,Valor,Identificador,Descrição")
+        void extratoBancarioNubank_importaDataValorIdentificadorDescricao() {
+            String conteudo = """
+            Data,Valor,Identificador,Descrição
+            03/06/2026,80,6a1fb213-a773-4548-a024-b4470e91312a,Resgate RDB
+            03/06/2026,-80,6a1fb229-140f-475c-b676-7295f4258c0f,Transferência enviada pelo Pix
+            08/06/2026,500,6a26e7e1-75af-454d-9f60-8324dda51a05,Transferência recebida pelo Pix
+            08/06/2026,-494.1,6a26fb54-15a4-4ad4-9dd7-82c8324803e3,Pagamento de fatura
+            """;
+
+            MockMultipartFile arquivo = fromString("nubank-conta.csv", conteudo);
+
+            ResultadoParser resultado = parser.parsear(arquivo, conta);
+
+            assertAll(
+                    () -> assertEquals(4, resultado.getTransacoes().size()),
+                    () -> assertEquals(4, resultado.getTotalLinhas()),
+                    () -> assertEquals(0, resultado.getLinhasInvalidas()),
+
+                    () -> assertEquals("Resgate RDB", resultado.getTransacoes().get(0).getDescricao()),
+                    () -> assertEquals(TipoTransacao.CREDITO, resultado.getTransacoes().get(0).getTipo()),
+                    () -> assertEquals(0, resultado.getTransacoes().get(0).getValor()
+                            .compareTo(new BigDecimal("80"))),
+
+                    () -> assertEquals("Transferência enviada pelo Pix", resultado.getTransacoes().get(1).getDescricao()),
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(1).getTipo()),
+                    () -> assertEquals(0, resultado.getTransacoes().get(1).getValor()
+                            .compareTo(new BigDecimal("80"))),
+
+                    () -> assertEquals("Transferência recebida pelo Pix", resultado.getTransacoes().get(2).getDescricao()),
                     () -> assertEquals(TipoTransacao.CREDITO, resultado.getTransacoes().get(2).getTipo()),
                     () -> assertEquals(0, resultado.getTransacoes().get(2).getValor()
-                            .compareTo(new BigDecimal("866.89")))
+                            .compareTo(new BigDecimal("500"))),
+
+                    () -> assertEquals("Pagamento de fatura", resultado.getTransacoes().get(3).getDescricao()),
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(3).getTipo()),
+                    () -> assertEquals(0, resultado.getTransacoes().get(3).getValor()
+                            .compareTo(new BigDecimal("494.1")))
             );
         }
 

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/parser/ParserCSVTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/parser/ParserCSVTest.java
@@ -187,12 +187,12 @@ class ParserCSVTest {
         }
 
         @Test
-        @DisplayName("extrato Nubank com BOM no cabeçalho é reconhecido corretamente")
-        void extratoNubankComBom_noCabecalho_eReconhecido() {
-            String conteudo = "\uFEFFdate,title,amount\n"
-                    + "2026-05-30,Mais Natural,\"7,00\"\n";
+        @DisplayName("extrato bancário Nubank: BOM no cabeçalho não impede importação")
+        void extratoBancarioNubank_comBomNoCabecalho_importaCorretamente() {
+            String conteudo = "\uFEFFData,Valor,Identificador,Descrição\n"
+                    + "03/06/2026,80,6a1fb213-a773-4548-a024-b4470e91312a,Resgate RDB\n";
 
-            MockMultipartFile arquivo = fromString("nubank-real.csv", conteudo);
+            MockMultipartFile arquivo = fromString("nubank-conta.csv", conteudo);
 
             ResultadoParser resultado = parser.parsear(arquivo, conta);
 
@@ -200,25 +200,25 @@ class ParserCSVTest {
                     () -> assertEquals(1, resultado.getTransacoes().size()),
                     () -> assertEquals(1, resultado.getTotalLinhas()),
                     () -> assertEquals(0, resultado.getLinhasInvalidas()),
-                    () -> assertEquals("Mais Natural", resultado.getTransacoes().get(0).getDescricao()),
-                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(0).getTipo()),
+                    () -> assertEquals("Resgate RDB", resultado.getTransacoes().get(0).getDescricao()),
+                    () -> assertEquals(TipoTransacao.CREDITO, resultado.getTransacoes().get(0).getTipo()),
                     () -> assertEquals(0, resultado.getTransacoes().get(0).getValor()
-                            .compareTo(new BigDecimal("7.00")))
+                            .compareTo(new BigDecimal("80")))
             );
         }
 
         @Test
-        @DisplayName("extrato Nubank com linhas inválidas não interrompe importação")
-        void extratoNubankComLinhasInvalidas_naoInterrompeImportacao() {
+        @DisplayName("extrato bancário Nubank: linhas inválidas são contabilizadas sem interromper parse")
+        void extratoBancarioNubank_linhasInvalidas_naoInterrompemParse() {
             String conteudo = """
-            date,title,amount
-            2026-05-30,Mais Natural,"7,00"
-            data-invalida,Mercado,"15,99"
-            2026-05-08,Pagamento recebido,"- 866,89"
-            2026-05-10,Linha Valor Invalido,abc
+            Data,Valor,Identificador,Descrição
+            03/06/2026,80,6a1fb213-a773-4548-a024-b4470e91312a,Resgate RDB
+            data-invalida,-80,6a1fb229-140f-475c-b676-7295f4258c0f,Transferência enviada pelo Pix
+            08/06/2026,abc,6a26e7e1-75af-454d-9f60-8324dda51a05,Valor inválido
+            08/06/2026,-8.91,6a26e7fc-e0ff-459a-bcbc-e8a5b774f068,Transferência enviada pelo Pix
             """;
 
-            MockMultipartFile arquivo = fromString("nubank-real.csv", conteudo);
+            MockMultipartFile arquivo = fromString("nubank-conta.csv", conteudo);
 
             ResultadoParser resultado = parser.parsear(arquivo, conta);
 
@@ -227,8 +227,13 @@ class ParserCSVTest {
                     () -> assertEquals(4, resultado.getTotalLinhas()),
                     () -> assertEquals(2, resultado.getLinhasInvalidas()),
 
-                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(0).getTipo()),
-                    () -> assertEquals(TipoTransacao.CREDITO, resultado.getTransacoes().get(1).getTipo())
+                    () -> assertEquals("Resgate RDB", resultado.getTransacoes().get(0).getDescricao()),
+                    () -> assertEquals(TipoTransacao.CREDITO, resultado.getTransacoes().get(0).getTipo()),
+
+                    () -> assertEquals("Transferência enviada pelo Pix", resultado.getTransacoes().get(1).getDescricao()),
+                    () -> assertEquals(TipoTransacao.DEBITO, resultado.getTransacoes().get(1).getTipo()),
+                    () -> assertEquals(0, resultado.getTransacoes().get(1).getValor()
+                            .compareTo(new BigDecimal("8.91")))
             );
         }
 

--- a/app-financeiro-back-end/src/test/resources/extratos/csv/nubank-real.csv
+++ b/app-financeiro-back-end/src/test/resources/extratos/csv/nubank-real.csv
@@ -1,0 +1,5 @@
+date,title,amount
+2026-05-30,Mais Natural,"7,00"
+2026-05-28,Mais Natural,"7,00"
+2026-05-24,Mercado Compre Facil P,"15,99"
+2026-05-08,Pagamento recebido,"- 866,89"

--- a/app-financeiro-back-end/src/test/resources/extratos/csv/nubank-real.csv
+++ b/app-financeiro-back-end/src/test/resources/extratos/csv/nubank-real.csv
@@ -1,5 +1,0 @@
-date,title,amount
-2026-05-30,Mais Natural,"7,00"
-2026-05-28,Mais Natural,"7,00"
-2026-05-24,Mercado Compre Facil P,"15,99"
-2026-05-08,Pagamento recebido,"- 866,89"


### PR DESCRIPTION
## O que mudou

- Ajustado o `ParserCSV` para reconhecer o formato real do extrato bancário Nubank:
  `Data,Valor,Identificador,Descrição`.
- Valores positivos são importados como `CREDITO`.
- Valores negativos são importados como `DEBITO`.
- O valor da transação é armazenado como valor absoluto.
- A coluna `Identificador` é utilizada para reconhecer o layout, mas não é persistida neste momento.
- Mantido o suporte ao formato CSV legado já aceito pelo sistema.
- Adicionada remoção de BOM no início do arquivo/cabeçalho para evitar falha na identificação da primeira coluna.
- Ajustada a leitura do CSV para respeitar campos entre aspas, evitando quebra incorreta de valores com vírgula.
- Mantida compatibilidade com o formato CSV legado já aceito pelo sistema.
- Ajustado o fluxo de importação para marcar como erro arquivos que não geram nenhuma transação válida.
- Adicionados/ajustados testes para cobrir o novo formato real do Nubank e casos limite relacionados.

## Por quê

* Correção necessária para atender à issue #200.
* O parser anterior esperava um CSV em formato rígido, com colunas como `data`, `descricao`, `valor` e `tipo`.
* O extrato real do Nubank possui outro layout: `date,title,amount`, sem coluna explícita de tipo.
* Sem esse ajuste, o sistema recusava ou não processava corretamente um extrato real válido.
* A mudança aumenta a robustez da importação sem alterar o modelo de domínio nem o fluxo de autenticação/autorização existente.

Closes #200

## Como testar

1. Suba o backend da aplicação.

2. Faça login com um usuário válido.

3. Garanta que o usuário possui uma conta cadastrada.

4. Acesse a funcionalidade de importação de extrato.

5. Selecione uma conta pertencente ao usuário autenticado.

6. Importe um CSV do Nubank no formato:

   `Data,Valor,Identificador,Descrição`

7. Verifique se as linhas com valores positivos foram importadas como `CREDITO`.

8. Verifique se a linha de pagamento recebido com valor negativo foi importada como `DEBITO`.

9. Verifique se valores como `"7,00"` foram convertidos corretamente para `7.00`.

10. Verifique se valores como `"- 866,89"` foram convertidos corretamente para `866.89`.

11. Verifique se as transações importadas aparecem na listagem de transações.

12. Verifique se as transações ficaram vinculadas à conta selecionada.

13. Teste um CSV inválido ou sem transações válidas e confirme que a importação é marcada como `ERRO`, com mensagem adequada.

14. Rode os testes automatizados do backend:

`./gradlew test`

## Auto-review (checklist)

* [x] Descrição clara (o que/por quê/como testar)
* [x] PR pequeno e focado
* [x] Casos limite considerados (ex.: vazio, 0, erro)
* [x] Evidência de teste (manual ou automatizado)
* [x] Não quebrou funcionalidades existentes
* [x] Código revisado e limpo

## Comentários técnicos (mínimo 3)

* [Risco] A regra de tipo para o Nubank depende do sinal do campo `amount`: valores positivos foram tratados como `DEBITO` e valores negativos como `CREDITO`.
* [Risco] A alteração no `ParserCSV` mantém fallback para o CSV legado para evitar regressão nos formatos que já eram aceitos anteriormente.
* [Manutenção] A leitura do CSV foi organizada em funções auxiliares para separar responsabilidades como remoção de BOM, detecção de delimitador, parse de valor, parse de data e criação da transação.
* [Manutenção] O tratamento de valores monetários foi ampliado para aceitar vírgula decimal e valores negativos com espaço, o que facilita suporte a outros extratos reais no futuro.
* [Teste] Foram adicionados/ajustados testes para validar importação do CSV real do Nubank no formato `date,title,amount`.
* [Teste] Foram considerados casos de BOM no cabeçalho, valores monetários com vírgula, valor negativo com espaço e linhas inválidas sem interrupção completa da importação.
* [Teste] O fluxo de importação sem transações válidas foi tratado para retornar erro em vez de concluir uma importação vazia.
