### PR TITLE
ci: atualizando o CI para rodar na main, não só em PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
 
 jobs:
   backend:


### PR DESCRIPTION
## O que mudou

* Atualizado o workflow de CI para executar também em alterações na branch `main`.
* Mantida a execução automática do pipeline em eventos de `pull_request`.
* Adicionado o gatilho `push` para a branch principal no arquivo `.github/workflows/ci.yml`.
* Preservados os jobs já existentes do pipeline, sem alterar as etapas de build, testes, lint, validação YAML e verificação de arquivos obrigatórios.

## Por quê

* Correção necessária para atender à issue #214.
* A Entrega 9 exige que o pipeline de CI seja executado automaticamente tanto em pull requests quanto em alterações na branch principal.
* Antes deste ajuste, o workflow era executado apenas em `pull_request`, deixando de gerar evidência automática após merge/push na `main`.
* A mudança garante que, após a integração de PRs, a branch principal continue sendo validada automaticamente pelo CI.

Closes #214

## Como testar

1. Abrir este PR normalmente.
2. Verificar se o workflow de CI executa automaticamente no evento de `pull_request`.
3. Conferir se os jobs existentes continuam sendo executados:

   * build/testes do backend;
   * build/lint/testes do frontend;
   * validação de arquivos YAML;
   * verificação de arquivos obrigatórios.
4. Validar se todos os checks do PR passam com sucesso.
5. Após aprovação e merge na branch `main`, acessar a aba **Actions** do GitHub.
6. Verificar se o workflow **CI** foi executado automaticamente por evento de `push` na branch `main`.
7. Confirmar que a execução pós-merge finalizou com sucesso.

## Auto-review (checklist)

* [x] Descrição clara (o que/por quê/como testar)
* [x] PR pequeno e focado
* [x] Casos limite considerados (ex.: vazio, 0, erro)
* [x] Evidência de teste (manual ou automatizado)
* [x] Não quebrou funcionalidades existentes
* [x] Código revisado e limpo

## Comentários técnicos (mínimo 3)

* [Risco] A alteração impacta o gatilho de execução do CI, então é importante validar se o workflow continua rodando normalmente em pull requests.
* [Risco] A evidência completa da issue só poderá ser confirmada após o merge, quando o evento `push` na branch `main` disparar o pipeline.
* [Manutenção] A mudança foi limitada ao bloco `on` do workflow, mantendo os jobs existentes sem refatoração desnecessária.
* [Manutenção] O ajuste melhora a rastreabilidade da branch principal, garantindo validação automática após integrações.
* [Teste] A validação inicial deve ser feita observando a execução do CI neste PR.
* [Teste] A validação final deve ser feita na aba Actions após o merge, confirmando uma execução bem-sucedida causada por `push` na `main`.
