### PR TITLE
feat: (closes #68) extrato futuro com projeção de parcelas, boletos e faturas

### DIFF
--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ExtratoFuturoController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ExtratoFuturoController.java
@@ -25,7 +25,7 @@ public class ExtratoFuturoController {
     @GetMapping
     public ResponseEntity<List<ProjecaoMensalDTO>> obterExtratoFuturo(
             @AuthenticationPrincipal Usuario usuarioAutenticado,
-            @RequestParam(required = false, defaultValue = "" + ExtratoFuturoService.MESES_PADRAO) int meses) {
+            @RequestParam(required = false) Integer meses) {
         return ResponseEntity.ok(extratoFuturoService.calcularProjecao(usuarioAutenticado, meses));
     }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ExtratoFuturoController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/ExtratoFuturoController.java
@@ -1,4 +1,31 @@
 package bcd.appfinanceirobackend.controller;
 
+import bcd.appfinanceirobackend.dto.extrato.ProjecaoMensalDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.service.ExtratoFuturoService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/extrato-futuro")
 public class ExtratoFuturoController {
+
+    private final ExtratoFuturoService extratoFuturoService;
+
+    public ExtratoFuturoController(ExtratoFuturoService extratoFuturoService) {
+        this.extratoFuturoService = extratoFuturoService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ProjecaoMensalDTO>> obterExtratoFuturo(
+            @AuthenticationPrincipal Usuario usuarioAutenticado,
+            @RequestParam(required = false, defaultValue = "" + ExtratoFuturoService.MESES_PADRAO) int meses) {
+        return ResponseEntity.ok(extratoFuturoService.calcularProjecao(usuarioAutenticado, meses));
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/FaturaController.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/controller/FaturaController.java
@@ -1,4 +1,45 @@
 package bcd.appfinanceirobackend.controller;
 
+import bcd.appfinanceirobackend.dto.fatura.FaturaResumoDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.service.FaturaService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
 public class FaturaController {
+
+    private final FaturaService faturaService;
+
+    public FaturaController(FaturaService faturaService) {
+        this.faturaService = faturaService;
+    }
+
+    @GetMapping("/contas/{contaId}/faturas")
+    public ResponseEntity<List<FaturaResumoDTO>> listarFaturasDaConta(
+            @PathVariable UUID contaId,
+            @AuthenticationPrincipal Usuario usuarioAutenticado) {
+        return ResponseEntity.ok(faturaService.buscarPorConta(contaId, usuarioAutenticado));
+    }
+
+    @GetMapping("/faturas/{faturaId}")
+    public ResponseEntity<FaturaResumoDTO> buscarFatura(
+            @PathVariable UUID faturaId,
+            @AuthenticationPrincipal Usuario usuarioAutenticado) {
+        return ResponseEntity.ok(faturaService.buscarPorId(faturaId, usuarioAutenticado));
+    }
+
+    @PatchMapping("/faturas/{faturaId}/pagar")
+    public ResponseEntity<FaturaResumoDTO> pagarFatura(
+            @PathVariable UUID faturaId,
+            @AuthenticationPrincipal Usuario usuarioAutenticado) {
+        return ResponseEntity.ok(faturaService.pagar(faturaId, usuarioAutenticado));
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/conta/CartaoCreditoRequestDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/conta/CartaoCreditoRequestDTO.java
@@ -1,4 +1,14 @@
 package bcd.appfinanceirobackend.dto.conta;
 
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
 public class CartaoCreditoRequestDTO {
+    private BigDecimal limite;
+    private Integer diaFechamento;
+    private Integer diaVencimento;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/extrato/ProjecaoMensalDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/extrato/ProjecaoMensalDTO.java
@@ -1,4 +1,24 @@
 package bcd.appfinanceirobackend.dto.extrato;
 
+import bcd.appfinanceirobackend.dto.fatura.FaturaResumoDTO;
+import bcd.appfinanceirobackend.dto.transacao.TransacaoResponseDTO;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
 public class ProjecaoMensalDTO {
+    private Integer ano;
+    private Integer mes;
+    private LocalDate dataInicio;
+    private LocalDate dataFim;
+    private BigDecimal saldoPrevisto;
+    private BigDecimal totalDebitos;
+    private BigDecimal totalCreditos;
+    private List<FaturaResumoDTO> faturas;
+    private List<TransacaoResponseDTO> transacoes;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/fatura/FaturaResumoDTO.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/dto/fatura/FaturaResumoDTO.java
@@ -1,4 +1,21 @@
 package bcd.appfinanceirobackend.dto.fatura;
 
+import bcd.appfinanceirobackend.model.enums.StatusFatura;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Setter
 public class FaturaResumoDTO {
+    private UUID faturaId;
+    private UUID contaId;
+    private String contaNome;
+    private String mesReferencia;
+    private LocalDate dataVencimento;
+    private BigDecimal valorTotal;
+    private StatusFatura status;
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/mapper/FaturaMapper.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/mapper/FaturaMapper.java
@@ -4,6 +4,8 @@ import bcd.appfinanceirobackend.dto.fatura.FaturaResumoDTO;
 import bcd.appfinanceirobackend.model.Fatura;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+
 @Component
 public class FaturaMapper {
 
@@ -16,7 +18,7 @@ public class FaturaMapper {
                 fatura.getMesReferencia() != null ? fatura.getMesReferencia().toString() : null
         );
         resumoDTO.setDataVencimento(fatura.getDataVencimento());
-        resumoDTO.setValorTotal(fatura.getValorTotal());
+        resumoDTO.setValorTotal(fatura.getValorTotal() != null ? fatura.getValorTotal() : BigDecimal.ZERO);
         resumoDTO.setStatus(fatura.getStatus());
         if (fatura.getConta() != null) {
             resumoDTO.setContaId(fatura.getConta().getId());

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/mapper/FaturaMapper.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/mapper/FaturaMapper.java
@@ -1,0 +1,27 @@
+package bcd.appfinanceirobackend.mapper;
+
+import bcd.appfinanceirobackend.dto.fatura.FaturaResumoDTO;
+import bcd.appfinanceirobackend.model.Fatura;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FaturaMapper {
+
+    public FaturaMapper() {}
+
+    public FaturaResumoDTO toResumo(Fatura fatura) {
+        FaturaResumoDTO resumoDTO = new FaturaResumoDTO();
+        resumoDTO.setFaturaId(fatura.getId());
+        resumoDTO.setMesReferencia(
+                fatura.getMesReferencia() != null ? fatura.getMesReferencia().toString() : null
+        );
+        resumoDTO.setDataVencimento(fatura.getDataVencimento());
+        resumoDTO.setValorTotal(fatura.getValorTotal());
+        resumoDTO.setStatus(fatura.getStatus());
+        if (fatura.getConta() != null) {
+            resumoDTO.setContaId(fatura.getConta().getId());
+            resumoDTO.setContaNome(fatura.getConta().getNome());
+        }
+        return resumoDTO;
+    }
+}

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/CartaoCreditoRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/CartaoCreditoRepository.java
@@ -4,8 +4,10 @@ import bcd.appfinanceirobackend.model.CartaoCredito;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface CartaoCreditoRepository extends JpaRepository<CartaoCredito, UUID> {
+    Optional<CartaoCredito> findByContaId(UUID contaId);
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/FaturaRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/FaturaRepository.java
@@ -1,11 +1,18 @@
 package bcd.appfinanceirobackend.repository;
 
 import bcd.appfinanceirobackend.model.Fatura;
+import bcd.appfinanceirobackend.model.enums.StatusFatura;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface FaturaRepository extends JpaRepository<Fatura, UUID> {
+    List<Fatura> findAllByContaIdOrderByMesReferenciaDesc(UUID contaId);
+    List<Fatura> findAllByContaUsuarioIdAndStatusNot(UUID usuarioId, StatusFatura status);
+    Optional<Fatura> findByContaIdAndMesReferencia(UUID contaId, YearMonth mesReferencia);
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/TransacaoRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/TransacaoRepository.java
@@ -16,5 +16,6 @@ public interface TransacaoRepository
     List<Transacao> findAllByContaUsuarioId(UUID usuarioId);
     boolean existsByContaId(UUID contaId);
     List<Transacao> findAllByContaUsuarioIdAndDataBetween(UUID usuarioId, LocalDate dataInicio, LocalDate dataFim);
+    List<Transacao> findAllByContaUsuarioIdAndDataLessThanEqual(UUID usuarioId, LocalDate data);
     List<Transacao> findAllByFaturaId(UUID faturaId);
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/TransacaoRepository.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/repository/TransacaoRepository.java
@@ -16,4 +16,5 @@ public interface TransacaoRepository
     List<Transacao> findAllByContaUsuarioId(UUID usuarioId);
     boolean existsByContaId(UUID contaId);
     List<Transacao> findAllByContaUsuarioIdAndDataBetween(UUID usuarioId, LocalDate dataInicio, LocalDate dataFim);
+    List<Transacao> findAllByFaturaId(UUID faturaId);
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/CartaoCreditoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/CartaoCreditoService.java
@@ -1,4 +1,83 @@
 package bcd.appfinanceirobackend.service;
 
+import bcd.appfinanceirobackend.dto.conta.CartaoCreditoRequestDTO;
+import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
+import bcd.appfinanceirobackend.model.CartaoCredito;
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.repository.CartaoCreditoRepository;
+import bcd.appfinanceirobackend.repository.ContaRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Service
 public class CartaoCreditoService {
+
+    private final CartaoCreditoRepository cartaoCreditoRepository;
+    private final ContaRepository contaRepository;
+
+    public CartaoCreditoService(
+            CartaoCreditoRepository cartaoCreditoRepository,
+            ContaRepository contaRepository) {
+        this.cartaoCreditoRepository = cartaoCreditoRepository;
+        this.contaRepository = contaRepository;
+    }
+
+    public CartaoCredito associar(UUID contaId, CartaoCreditoRequestDTO requestDTO, Usuario usuarioAutenticado) {
+        Conta conta = buscarContaDoUsuario(contaId, usuarioAutenticado);
+
+        if (cartaoCreditoRepository.findByContaId(conta.getId()).isPresent()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Conta já possui cartão de crédito associado");
+        }
+
+        validarCampos(requestDTO);
+
+        CartaoCredito cartaoCredito = new CartaoCredito();
+        cartaoCredito.setConta(conta);
+        cartaoCredito.setLimite(requestDTO.getLimite());
+        cartaoCredito.setDia_fechamento(requestDTO.getDiaFechamento());
+        cartaoCredito.setDia_vencimento(requestDTO.getDiaVencimento());
+
+        return cartaoCreditoRepository.save(cartaoCredito);
+    }
+
+    public CartaoCredito buscarPorConta(UUID contaId, Usuario usuarioAutenticado) {
+        Conta conta = buscarContaDoUsuario(contaId, usuarioAutenticado);
+
+        return cartaoCreditoRepository.findByContaId(conta.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Conta não possui cartão de crédito associado"));
+    }
+
+    private Conta buscarContaDoUsuario(UUID contaId, Usuario usuarioAutenticado) {
+        Conta conta = contaRepository.findById(contaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));
+
+        if (!conta.getUsuario().getId().equals(usuarioAutenticado.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Acesso negado a esta conta");
+        }
+
+        return conta;
+    }
+
+    private void validarCampos(CartaoCreditoRequestDTO requestDTO) {
+        if (requestDTO.getDiaFechamento() == null || requestDTO.getDiaVencimento() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Dia de fechamento e dia de vencimento são obrigatórios");
+        }
+        if (foraDoIntervaloDeDias(requestDTO.getDiaFechamento()) || foraDoIntervaloDeDias(requestDTO.getDiaVencimento())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Dias de fechamento e vencimento devem estar entre 1 e 31");
+        }
+        if (requestDTO.getLimite() != null && requestDTO.getLimite().compareTo(BigDecimal.ZERO) < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Limite não pode ser negativo");
+        }
+    }
+
+    private boolean foraDoIntervaloDeDias(int dia) {
+        return dia < 1 || dia > 31;
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/CartaoCreditoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/CartaoCreditoService.java
@@ -5,6 +5,7 @@ import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
 import bcd.appfinanceirobackend.model.CartaoCredito;
 import bcd.appfinanceirobackend.model.Conta;
 import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.TipoConta;
 import bcd.appfinanceirobackend.repository.CartaoCreditoRepository;
 import bcd.appfinanceirobackend.repository.ContaRepository;
 import org.springframework.http.HttpStatus;
@@ -29,6 +30,11 @@ public class CartaoCreditoService {
 
     public CartaoCredito associar(UUID contaId, CartaoCreditoRequestDTO requestDTO, Usuario usuarioAutenticado) {
         Conta conta = buscarContaDoUsuario(contaId, usuarioAutenticado);
+
+        if (conta.getTipoConta() != TipoConta.CARTAO_CREDITO) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "A conta informada não é uma conta de cartão de crédito");
+        }
 
         if (cartaoCreditoRepository.findByContaId(conta.getId()).isPresent()) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Conta já possui cartão de crédito associado");

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ExtratoFuturoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ExtratoFuturoService.java
@@ -43,8 +43,8 @@ public class ExtratoFuturoService {
         this.faturaMapper = faturaMapper;
     }
 
-    public List<ProjecaoMensalDTO> calcularProjecao(Usuario usuario, int meses) {
-        return calcularProjecao(usuario, meses, LocalDate.now());
+    public List<ProjecaoMensalDTO> calcularProjecao(Usuario usuario, Integer meses) {
+        return calcularProjecao(usuario, meses != null ? meses : MESES_PADRAO, LocalDate.now());
     }
 
     public List<ProjecaoMensalDTO> calcularProjecao(Usuario usuario, int meses, LocalDate hoje) {
@@ -65,7 +65,8 @@ public class ExtratoFuturoService {
 
         List<ProjecaoMensalDTO> projecao = new ArrayList<>();
         for (YearMonth mes = mesInicial; !mes.isAfter(mesFinal); mes = mes.plusMonths(1)) {
-            ProjecaoMensalDTO projecaoMensal = montarProjecaoDoMes(mes, transacoesFuturas, faturasEmAberto, saldoCorrente);
+            ProjecaoMensalDTO projecaoMensal =
+                    montarProjecaoDoMes(mes, mesInicial, transacoesFuturas, faturasEmAberto, saldoCorrente);
             saldoCorrente = projecaoMensal.getSaldoPrevisto();
             projecao.add(projecaoMensal);
         }
@@ -79,6 +80,7 @@ public class ExtratoFuturoService {
 
     private ProjecaoMensalDTO montarProjecaoDoMes(
             YearMonth mes,
+            YearMonth mesInicial,
             List<Transacao> transacoesFuturas,
             List<Fatura> faturasEmAberto,
             BigDecimal saldoAnterior) {
@@ -88,20 +90,21 @@ public class ExtratoFuturoService {
                 .sorted(Comparator.comparing(Transacao::getData))
                 .toList();
 
+        // Fatura atrasada (não paga, vencida antes da janela) ainda é saída de caixa pendente:
+        // pesa no primeiro mês projetado
         List<Fatura> faturasDoMes = faturasEmAberto.stream()
-                .filter(fatura -> fatura.getDataVencimento() != null
-                        && YearMonth.from(fatura.getDataVencimento()).equals(mes))
+                .filter(fatura -> fatura.getDataVencimento() != null)
+                .filter(fatura -> {
+                    YearMonth vencimento = YearMonth.from(fatura.getDataVencimento());
+                    return mes.equals(mesInicial) ? !vencimento.isAfter(mesInicial) : vencimento.equals(mes);
+                })
                 .sorted(Comparator.comparing(Fatura::getDataVencimento))
                 .toList();
 
-        BigDecimal totalCreditos = somarPorTipo(transacoesDoMes, TipoTransacao.CREDITO);
-
-        // Débitos já vinculados a uma fatura entram pelo valor da fatura (não pelo lançamento),
-        // para não contar duas vezes a mesma despesa
-        BigDecimal debitosAvulsos = transacoesDoMes.stream()
-                .filter(transacao -> transacao.getTipo() == TipoTransacao.DEBITO && transacao.getFatura() == null)
-                .map(Transacao::getValor)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        // Lançamentos vinculados a fatura (compras e estornos) entram pelo valorTotal da fatura,
+        // não pelo lançamento individual, para não contar duas vezes
+        BigDecimal totalCreditos = somarAvulsosPorTipo(transacoesDoMes, TipoTransacao.CREDITO);
+        BigDecimal debitosAvulsos = somarAvulsosPorTipo(transacoesDoMes, TipoTransacao.DEBITO);
 
         BigDecimal totalFaturas = faturasDoMes.stream()
                 .map(Fatura::getValorTotal)
@@ -125,8 +128,11 @@ public class ExtratoFuturoService {
 
     private BigDecimal calcularSaldoAtual(Usuario usuario, LocalDate hoje) {
         BigDecimal saldo = BigDecimal.ZERO;
-        for (Transacao transacao : transacaoRepository.findAllByContaUsuarioId(usuario.getId())) {
-            if (transacao.getData().isAfter(hoje)) {
+        for (Transacao transacao :
+                transacaoRepository.findAllByContaUsuarioIdAndDataLessThanEqual(usuario.getId(), hoje)) {
+            // Lançamento de fatura em aberto ainda não saiu do caixa — sai no vencimento,
+            // quando a fatura inteira é descontada pelo valorTotal
+            if (transacao.getFatura() != null && transacao.getFatura().getStatus() != StatusFatura.PAGA) {
                 continue;
             }
             saldo = transacao.getTipo() == TipoTransacao.CREDITO
@@ -136,9 +142,9 @@ public class ExtratoFuturoService {
         return saldo;
     }
 
-    private BigDecimal somarPorTipo(List<Transacao> transacoes, TipoTransacao tipo) {
+    private BigDecimal somarAvulsosPorTipo(List<Transacao> transacoes, TipoTransacao tipo) {
         return transacoes.stream()
-                .filter(transacao -> transacao.getTipo() == tipo)
+                .filter(transacao -> transacao.getTipo() == tipo && transacao.getFatura() == null)
                 .map(Transacao::getValor)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
     }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ExtratoFuturoService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/ExtratoFuturoService.java
@@ -1,4 +1,145 @@
 package bcd.appfinanceirobackend.service;
 
+import bcd.appfinanceirobackend.dto.extrato.ProjecaoMensalDTO;
+import bcd.appfinanceirobackend.mapper.FaturaMapper;
+import bcd.appfinanceirobackend.mapper.TransacaoMapper;
+import bcd.appfinanceirobackend.model.Fatura;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.StatusFatura;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import bcd.appfinanceirobackend.repository.FaturaRepository;
+import bcd.appfinanceirobackend.repository.TransacaoRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
 public class ExtratoFuturoService {
+
+    public static final int MESES_PADRAO = 3;
+    private static final int MESES_MAXIMO = 12;
+
+    private final TransacaoRepository transacaoRepository;
+    private final FaturaRepository faturaRepository;
+    private final TransacaoMapper transacaoMapper;
+    private final FaturaMapper faturaMapper;
+
+    public ExtratoFuturoService(
+            TransacaoRepository transacaoRepository,
+            FaturaRepository faturaRepository,
+            TransacaoMapper transacaoMapper,
+            FaturaMapper faturaMapper) {
+        this.transacaoRepository = transacaoRepository;
+        this.faturaRepository = faturaRepository;
+        this.transacaoMapper = transacaoMapper;
+        this.faturaMapper = faturaMapper;
+    }
+
+    public List<ProjecaoMensalDTO> calcularProjecao(Usuario usuario, int meses) {
+        return calcularProjecao(usuario, meses, LocalDate.now());
+    }
+
+    public List<ProjecaoMensalDTO> calcularProjecao(Usuario usuario, int meses, LocalDate hoje) {
+        if (meses < 1 || meses > MESES_MAXIMO) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Quantidade de meses deve estar entre 1 e " + MESES_MAXIMO);
+        }
+
+        YearMonth mesInicial = YearMonth.from(hoje);
+        YearMonth mesFinal = mesInicial.plusMonths(meses - 1);
+
+        List<Transacao> transacoesFuturas = listarTransacoesFuturas(usuario, hoje, mesFinal.atEndOfMonth());
+        List<Fatura> faturasEmAberto =
+                faturaRepository.findAllByContaUsuarioIdAndStatusNot(usuario.getId(), StatusFatura.PAGA);
+
+        // O saldo previsto é acumulado: parte do saldo real até hoje e propaga mês a mês
+        BigDecimal saldoCorrente = calcularSaldoAtual(usuario, hoje);
+
+        List<ProjecaoMensalDTO> projecao = new ArrayList<>();
+        for (YearMonth mes = mesInicial; !mes.isAfter(mesFinal); mes = mes.plusMonths(1)) {
+            ProjecaoMensalDTO projecaoMensal = montarProjecaoDoMes(mes, transacoesFuturas, faturasEmAberto, saldoCorrente);
+            saldoCorrente = projecaoMensal.getSaldoPrevisto();
+            projecao.add(projecaoMensal);
+        }
+        return projecao;
+    }
+
+    public List<Transacao> listarTransacoesFuturas(Usuario usuario, LocalDate hoje, LocalDate dataFim) {
+        return transacaoRepository.findAllByContaUsuarioIdAndDataBetween(
+                usuario.getId(), hoje.plusDays(1), dataFim);
+    }
+
+    private ProjecaoMensalDTO montarProjecaoDoMes(
+            YearMonth mes,
+            List<Transacao> transacoesFuturas,
+            List<Fatura> faturasEmAberto,
+            BigDecimal saldoAnterior) {
+
+        List<Transacao> transacoesDoMes = transacoesFuturas.stream()
+                .filter(transacao -> YearMonth.from(transacao.getData()).equals(mes))
+                .sorted(Comparator.comparing(Transacao::getData))
+                .toList();
+
+        List<Fatura> faturasDoMes = faturasEmAberto.stream()
+                .filter(fatura -> fatura.getDataVencimento() != null
+                        && YearMonth.from(fatura.getDataVencimento()).equals(mes))
+                .sorted(Comparator.comparing(Fatura::getDataVencimento))
+                .toList();
+
+        BigDecimal totalCreditos = somarPorTipo(transacoesDoMes, TipoTransacao.CREDITO);
+
+        // Débitos já vinculados a uma fatura entram pelo valor da fatura (não pelo lançamento),
+        // para não contar duas vezes a mesma despesa
+        BigDecimal debitosAvulsos = transacoesDoMes.stream()
+                .filter(transacao -> transacao.getTipo() == TipoTransacao.DEBITO && transacao.getFatura() == null)
+                .map(Transacao::getValor)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal totalFaturas = faturasDoMes.stream()
+                .map(Fatura::getValorTotal)
+                .filter(valor -> valor != null)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        BigDecimal totalDebitos = debitosAvulsos.add(totalFaturas);
+
+        ProjecaoMensalDTO dto = new ProjecaoMensalDTO();
+        dto.setAno(mes.getYear());
+        dto.setMes(mes.getMonthValue());
+        dto.setDataInicio(mes.atDay(1));
+        dto.setDataFim(mes.atEndOfMonth());
+        dto.setTotalCreditos(totalCreditos);
+        dto.setTotalDebitos(totalDebitos);
+        dto.setSaldoPrevisto(saldoAnterior.add(totalCreditos).subtract(totalDebitos));
+        dto.setFaturas(faturasDoMes.stream().map(faturaMapper::toResumo).toList());
+        dto.setTransacoes(transacoesDoMes.stream().map(transacaoMapper::toResponse).toList());
+        return dto;
+    }
+
+    private BigDecimal calcularSaldoAtual(Usuario usuario, LocalDate hoje) {
+        BigDecimal saldo = BigDecimal.ZERO;
+        for (Transacao transacao : transacaoRepository.findAllByContaUsuarioId(usuario.getId())) {
+            if (transacao.getData().isAfter(hoje)) {
+                continue;
+            }
+            saldo = transacao.getTipo() == TipoTransacao.CREDITO
+                    ? saldo.add(transacao.getValor())
+                    : saldo.subtract(transacao.getValor());
+        }
+        return saldo;
+    }
+
+    private BigDecimal somarPorTipo(List<Transacao> transacoes, TipoTransacao tipo) {
+        return transacoes.stream()
+                .filter(transacao -> transacao.getTipo() == tipo)
+                .map(Transacao::getValor)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/FaturaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/FaturaService.java
@@ -129,7 +129,7 @@ public class FaturaService {
     }
 
     private void validarAcesso(Conta conta, Usuario usuarioAutenticado) {
-        if (!conta.getUsuario().getId().equals(usuarioAutenticado.getId())) {
+        if (conta == null || !conta.getUsuario().getId().equals(usuarioAutenticado.getId())) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Acesso negado a esta conta");
         }
     }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/FaturaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/FaturaService.java
@@ -1,4 +1,136 @@
 package bcd.appfinanceirobackend.service;
 
+import bcd.appfinanceirobackend.dto.fatura.FaturaResumoDTO;
+import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
+import bcd.appfinanceirobackend.mapper.FaturaMapper;
+import bcd.appfinanceirobackend.model.CartaoCredito;
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Fatura;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.StatusFatura;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import bcd.appfinanceirobackend.repository.CartaoCreditoRepository;
+import bcd.appfinanceirobackend.repository.ContaRepository;
+import bcd.appfinanceirobackend.repository.FaturaRepository;
+import bcd.appfinanceirobackend.repository.TransacaoRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.UUID;
+
+@Service
 public class FaturaService {
+
+    private final FaturaRepository faturaRepository;
+    private final ContaRepository contaRepository;
+    private final CartaoCreditoRepository cartaoCreditoRepository;
+    private final TransacaoRepository transacaoRepository;
+    private final FaturaMapper faturaMapper;
+
+    public FaturaService(
+            FaturaRepository faturaRepository,
+            ContaRepository contaRepository,
+            CartaoCreditoRepository cartaoCreditoRepository,
+            TransacaoRepository transacaoRepository,
+            FaturaMapper faturaMapper) {
+        this.faturaRepository = faturaRepository;
+        this.contaRepository = contaRepository;
+        this.cartaoCreditoRepository = cartaoCreditoRepository;
+        this.transacaoRepository = transacaoRepository;
+        this.faturaMapper = faturaMapper;
+    }
+
+    public Fatura gerarFatura(UUID contaId, YearMonth mesReferencia) {
+        return faturaRepository.findByContaIdAndMesReferencia(contaId, mesReferencia)
+                .orElseGet(() -> criarFatura(contaId, mesReferencia));
+    }
+
+    public List<FaturaResumoDTO> buscarPorConta(UUID contaId, Usuario usuarioAutenticado) {
+        Conta conta = contaRepository.findById(contaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));
+        validarAcesso(conta, usuarioAutenticado);
+
+        return faturaRepository.findAllByContaIdOrderByMesReferenciaDesc(conta.getId()).stream()
+                .map(faturaMapper::toResumo)
+                .toList();
+    }
+
+    public FaturaResumoDTO buscarPorId(UUID faturaId, Usuario usuarioAutenticado) {
+        return faturaMapper.toResumo(buscarFaturaDoUsuario(faturaId, usuarioAutenticado));
+    }
+
+    public BigDecimal calcularTotal(UUID faturaId) {
+        Fatura fatura = faturaRepository.findById(faturaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Fatura não encontrada"));
+
+        // Débitos somam ao total da fatura; créditos (estornos) abatem
+        BigDecimal total = BigDecimal.ZERO;
+        for (Transacao transacao : transacaoRepository.findAllByFaturaId(fatura.getId())) {
+            if (transacao.getTipo() == TipoTransacao.DEBITO) {
+                total = total.add(transacao.getValor());
+            } else {
+                total = total.subtract(transacao.getValor());
+            }
+        }
+
+        fatura.setValorTotal(total);
+        faturaRepository.save(fatura);
+        return total;
+    }
+
+    public FaturaResumoDTO pagar(UUID faturaId, Usuario usuarioAutenticado) {
+        Fatura fatura = buscarFaturaDoUsuario(faturaId, usuarioAutenticado);
+
+        if (fatura.getStatus() == StatusFatura.PAGA) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Fatura já está paga");
+        }
+
+        fatura.setStatus(StatusFatura.PAGA);
+        return faturaMapper.toResumo(faturaRepository.save(fatura));
+    }
+
+    private Fatura criarFatura(UUID contaId, YearMonth mesReferencia) {
+        Conta conta = contaRepository.findById(contaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));
+
+        CartaoCredito cartao = cartaoCreditoRepository.findByContaId(contaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Conta não possui cartão de crédito associado"));
+
+        Fatura fatura = new Fatura();
+        fatura.setConta(conta);
+        fatura.setMesReferencia(mesReferencia);
+        fatura.setDataVencimento(calcularVencimento(cartao, mesReferencia));
+        fatura.setValorTotal(BigDecimal.ZERO);
+        fatura.setStatus(StatusFatura.ABERTA);
+        return faturaRepository.save(fatura);
+    }
+
+    // A fatura fecha no mês de referência; se o dia de vencimento é depois do fechamento,
+    // vence no próprio mês, senão vence no mês seguinte.
+    private LocalDate calcularVencimento(CartaoCredito cartao, YearMonth mesReferencia) {
+        YearMonth mesVencimento = cartao.getDia_vencimento() > cartao.getDia_fechamento()
+                ? mesReferencia
+                : mesReferencia.plusMonths(1);
+        int dia = Math.min(cartao.getDia_vencimento(), mesVencimento.lengthOfMonth());
+        return mesVencimento.atDay(dia);
+    }
+
+    private Fatura buscarFaturaDoUsuario(UUID faturaId, Usuario usuarioAutenticado) {
+        Fatura fatura = faturaRepository.findById(faturaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Fatura não encontrada"));
+        validarAcesso(fatura.getConta(), usuarioAutenticado);
+        return fatura;
+    }
+
+    private void validarAcesso(Conta conta, Usuario usuarioAutenticado) {
+        if (!conta.getUsuario().getId().equals(usuarioAutenticado.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Acesso negado a esta conta");
+        }
+    }
 }

--- a/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/FaturaService.java
+++ b/app-financeiro-back-end/src/main/java/bcd/appfinanceirobackend/service/FaturaService.java
@@ -46,9 +46,13 @@ public class FaturaService {
         this.faturaMapper = faturaMapper;
     }
 
-    public Fatura gerarFatura(UUID contaId, YearMonth mesReferencia) {
-        return faturaRepository.findByContaIdAndMesReferencia(contaId, mesReferencia)
-                .orElseGet(() -> criarFatura(contaId, mesReferencia));
+    public Fatura gerarFatura(UUID contaId, YearMonth mesReferencia, Usuario usuarioAutenticado) {
+        Conta conta = contaRepository.findById(contaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));
+        validarAcesso(conta, usuarioAutenticado);
+
+        return faturaRepository.findByContaIdAndMesReferencia(conta.getId(), mesReferencia)
+                .orElseGet(() -> criarFatura(conta, mesReferencia));
     }
 
     public List<FaturaResumoDTO> buscarPorConta(UUID contaId, Usuario usuarioAutenticado) {
@@ -65,9 +69,8 @@ public class FaturaService {
         return faturaMapper.toResumo(buscarFaturaDoUsuario(faturaId, usuarioAutenticado));
     }
 
-    public BigDecimal calcularTotal(UUID faturaId) {
-        Fatura fatura = faturaRepository.findById(faturaId)
-                .orElseThrow(() -> new ResourceNotFoundException("Fatura não encontrada"));
+    public BigDecimal calcularTotal(UUID faturaId, Usuario usuarioAutenticado) {
+        Fatura fatura = buscarFaturaDoUsuario(faturaId, usuarioAutenticado);
 
         // Débitos somam ao total da fatura; créditos (estornos) abatem
         BigDecimal total = BigDecimal.ZERO;
@@ -95,11 +98,8 @@ public class FaturaService {
         return faturaMapper.toResumo(faturaRepository.save(fatura));
     }
 
-    private Fatura criarFatura(UUID contaId, YearMonth mesReferencia) {
-        Conta conta = contaRepository.findById(contaId)
-                .orElseThrow(() -> new ResourceNotFoundException("Conta não encontrada"));
-
-        CartaoCredito cartao = cartaoCreditoRepository.findByContaId(contaId)
+    private Fatura criarFatura(Conta conta, YearMonth mesReferencia) {
+        CartaoCredito cartao = cartaoCreditoRepository.findByContaId(conta.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("Conta não possui cartão de crédito associado"));
 
         Fatura fatura = new Fatura();

--- a/app-financeiro-back-end/src/main/resources/db/migration/V5__unique_fatura_conta_mes.sql
+++ b/app-financeiro-back-end/src/main/resources/db/migration/V5__unique_fatura_conta_mes.sql
@@ -1,0 +1,12 @@
+-- ============================================================
+-- SmartBudget - Unicidade de fatura por conta e mês
+-- V5__unique_fatura_conta_mes.sql
+-- ============================================================
+-- `gerarFatura` é get-or-create: duas chamadas concorrentes podem
+-- passar pelo SELECT antes de qualquer INSERT e duplicar a fatura
+-- do mês. A consulta prévia no service não garante unicidade; a
+-- restrição precisa morar no banco.
+-- ============================================================
+
+ALTER TABLE fatura
+    ADD CONSTRAINT uk_fatura_conta_mes UNIQUE (conta_id, mes_referencia);

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/controller/ExtratoFuturoControllerTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/controller/ExtratoFuturoControllerTest.java
@@ -1,0 +1,133 @@
+package bcd.appfinanceirobackend.controller;
+
+import bcd.appfinanceirobackend.config.JwtAuthFilter;
+import bcd.appfinanceirobackend.config.SecurityConfig;
+import bcd.appfinanceirobackend.dto.extrato.ProjecaoMensalDTO;
+import bcd.appfinanceirobackend.dto.fatura.FaturaResumoDTO;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.StatusFatura;
+import bcd.appfinanceirobackend.repository.UsuarioRepository;
+import bcd.appfinanceirobackend.security.JwtUtil;
+import bcd.appfinanceirobackend.service.ExtratoFuturoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ExtratoFuturoController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class})
+@DisplayName("ExtratoFuturoController")
+class ExtratoFuturoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ExtratoFuturoService extratoFuturoService;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @MockBean
+    private UsuarioRepository usuarioRepository;
+
+    private Usuario usuarioAutenticado;
+
+    @BeforeEach
+    void setUp() {
+        usuarioAutenticado = new Usuario();
+        usuarioAutenticado.setId(UUID.randomUUID());
+        usuarioAutenticado.setNome("João Silva");
+        usuarioAutenticado.setEmail("joao@email.com");
+        usuarioAutenticado.setSenha("hash");
+        usuarioAutenticado.setCpf("12345678900");
+    }
+
+    private ProjecaoMensalDTO projecaoDeJulho() {
+        FaturaResumoDTO fatura = new FaturaResumoDTO();
+        fatura.setFaturaId(UUID.randomUUID());
+        fatura.setContaId(UUID.randomUUID());
+        fatura.setContaNome("Cartão Nubank");
+        fatura.setMesReferencia("2026-06");
+        fatura.setDataVencimento(LocalDate.of(2026, 7, 8));
+        fatura.setValorTotal(new BigDecimal("980.00"));
+        fatura.setStatus(StatusFatura.ABERTA);
+
+        ProjecaoMensalDTO projecao = new ProjecaoMensalDTO();
+        projecao.setAno(2026);
+        projecao.setMes(7);
+        projecao.setDataInicio(LocalDate.of(2026, 7, 1));
+        projecao.setDataFim(LocalDate.of(2026, 7, 31));
+        projecao.setSaldoPrevisto(new BigDecimal("-980.00"));
+        projecao.setTotalDebitos(new BigDecimal("980.00"));
+        projecao.setTotalCreditos(BigDecimal.ZERO);
+        projecao.setFaturas(List.of(fatura));
+        projecao.setTransacoes(List.of());
+        return projecao;
+    }
+
+    @Test
+    @DisplayName("deve usar a quantidade padrão de meses quando o parâmetro não é informado")
+    void deveUsarQuantidadePadraoDeMeses() throws Exception {
+        when(extratoFuturoService.calcularProjecao(any(Usuario.class), isNull()))
+                .thenReturn(List.of(projecaoDeJulho()));
+
+        mockMvc.perform(get("/extrato-futuro").with(user(usuarioAutenticado)))
+                .andExpect(status().isOk());
+
+        verify(extratoFuturoService).calcularProjecao(any(Usuario.class), isNull());
+    }
+
+    @Test
+    @DisplayName("deve repassar a quantidade de meses informada")
+    void deveRepassarQuantidadeDeMesesInformada() throws Exception {
+        when(extratoFuturoService.calcularProjecao(any(Usuario.class), eq(6)))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/extrato-futuro").param("meses", "6").with(user(usuarioAutenticado)))
+                .andExpect(status().isOk());
+
+        verify(extratoFuturoService).calcularProjecao(any(Usuario.class), eq(6));
+    }
+
+    @Test
+    @DisplayName("deve serializar a projeção no formato consumido pelo frontend")
+    void deveSerializarProjecaoNoFormatoEsperado() throws Exception {
+        when(extratoFuturoService.calcularProjecao(any(Usuario.class), isNull()))
+                .thenReturn(List.of(projecaoDeJulho()));
+
+        mockMvc.perform(get("/extrato-futuro").with(user(usuarioAutenticado)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].ano").value(2026))
+                .andExpect(jsonPath("$[0].mes").value(7))
+                .andExpect(jsonPath("$[0].dataInicio").value("2026-07-01"))
+                .andExpect(jsonPath("$[0].saldoPrevisto").value(-980.00))
+                .andExpect(jsonPath("$[0].totalDebitos").value(980.00))
+                .andExpect(jsonPath("$[0].totalCreditos").value(0))
+                .andExpect(jsonPath("$[0].faturas[0].contaNome").value("Cartão Nubank"))
+                .andExpect(jsonPath("$[0].faturas[0].mesReferencia").value("2026-06"))
+                .andExpect(jsonPath("$[0].faturas[0].dataVencimento").value("2026-07-08"))
+                .andExpect(jsonPath("$[0].faturas[0].valorTotal").value(980.00))
+                .andExpect(jsonPath("$[0].faturas[0].status").value("ABERTA"))
+                .andExpect(jsonPath("$[0].transacoes").isEmpty());
+    }
+}

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/CartaoCreditoServiceTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/CartaoCreditoServiceTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -110,6 +112,20 @@ class CartaoCreditoServiceTest {
                     .isInstanceOf(ResponseStatusException.class)
                     .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
                     .isEqualTo(HttpStatus.FORBIDDEN);
+        }
+
+        @ParameterizedTest(name = "deve rejeitar conta do tipo {0}")
+        @EnumSource(value = TipoConta.class, names = {"CORRENTE", "POUPANCA", "CARTEIRA"})
+        @DisplayName("deve rejeitar conta que não é de cartão de crédito")
+        void deveRejeitarContaQueNaoEhCartaoDeCredito(TipoConta tipoConta) {
+            conta.setTipoConta(tipoConta);
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+
+            assertThatThrownBy(() -> cartaoCreditoService.associar(conta.getId(), dtoValido, usuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+            verify(cartaoCreditoRepository, never()).save(any());
         }
 
         @Test

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/CartaoCreditoServiceTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/CartaoCreditoServiceTest.java
@@ -1,0 +1,197 @@
+package bcd.appfinanceirobackend.service;
+
+import bcd.appfinanceirobackend.dto.conta.CartaoCreditoRequestDTO;
+import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
+import bcd.appfinanceirobackend.model.CartaoCredito;
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.TipoConta;
+import bcd.appfinanceirobackend.repository.CartaoCreditoRepository;
+import bcd.appfinanceirobackend.repository.ContaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CartaoCreditoService")
+class CartaoCreditoServiceTest {
+
+    @Mock
+    private CartaoCreditoRepository cartaoCreditoRepository;
+
+    @Mock
+    private ContaRepository contaRepository;
+
+    @InjectMocks
+    private CartaoCreditoService cartaoCreditoService;
+
+    private Usuario usuario;
+    private Usuario outroUsuario;
+    private Conta conta;
+    private CartaoCreditoRequestDTO dtoValido;
+
+    @BeforeEach
+    void setUp() {
+        usuario = new Usuario();
+        usuario.setId(UUID.randomUUID());
+
+        outroUsuario = new Usuario();
+        outroUsuario.setId(UUID.randomUUID());
+
+        conta = new Conta();
+        conta.setId(UUID.randomUUID());
+        conta.setNome("Cartão Nubank");
+        conta.setTipoConta(TipoConta.CARTAO_CREDITO);
+        conta.setUsuario(usuario);
+
+        dtoValido = new CartaoCreditoRequestDTO();
+        dtoValido.setLimite(new BigDecimal("2000.00"));
+        dtoValido.setDiaFechamento(20);
+        dtoValido.setDiaVencimento(28);
+    }
+
+    @Nested
+    @DisplayName("associar")
+    class Associar {
+
+        @Test
+        @DisplayName("deve associar cartão de crédito à conta")
+        void deveAssociarCartaoAConta() {
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.empty());
+            when(cartaoCreditoRepository.save(any(CartaoCredito.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            CartaoCredito resultado = cartaoCreditoService.associar(conta.getId(), dtoValido, usuario);
+
+            ArgumentCaptor<CartaoCredito> captor = ArgumentCaptor.forClass(CartaoCredito.class);
+            verify(cartaoCreditoRepository).save(captor.capture());
+            assertThat(captor.getValue().getConta()).isSameAs(conta);
+            assertThat(resultado.getLimite()).isEqualByComparingTo("2000.00");
+            assertThat(resultado.getDia_fechamento()).isEqualTo(20);
+            assertThat(resultado.getDia_vencimento()).isEqualTo(28);
+        }
+
+        @Test
+        @DisplayName("deve falhar quando a conta não existe")
+        void deveFalharQuandoContaNaoExiste() {
+            UUID contaId = UUID.randomUUID();
+            when(contaRepository.findById(contaId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> cartaoCreditoService.associar(contaId, dtoValido, usuario))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("deve negar acesso a conta de outro usuário")
+        void deveNegarAcessoAContaDeOutroUsuario() {
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+
+            assertThatThrownBy(() -> cartaoCreditoService.associar(conta.getId(), dtoValido, outroUsuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("deve rejeitar conta que já possui cartão")
+        void deveRejeitarContaComCartaoExistente() {
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.of(new CartaoCredito()));
+
+            assertThatThrownBy(() -> cartaoCreditoService.associar(conta.getId(), dtoValido, usuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+            verify(cartaoCreditoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("deve rejeitar dias de fechamento ou vencimento inválidos")
+        void deveRejeitarDiasInvalidos() {
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.empty());
+            dtoValido.setDiaVencimento(32);
+
+            assertThatThrownBy(() -> cartaoCreditoService.associar(conta.getId(), dtoValido, usuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+            verify(cartaoCreditoRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("deve rejeitar dias obrigatórios ausentes")
+        void deveRejeitarDiasAusentes() {
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.empty());
+            dtoValido.setDiaFechamento(null);
+
+            assertThatThrownBy(() -> cartaoCreditoService.associar(conta.getId(), dtoValido, usuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("deve rejeitar limite negativo")
+        void deveRejeitarLimiteNegativo() {
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.empty());
+            dtoValido.setLimite(new BigDecimal("-1.00"));
+
+            assertThatThrownBy(() -> cartaoCreditoService.associar(conta.getId(), dtoValido, usuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("buscarPorConta")
+    class BuscarPorConta {
+
+        @Test
+        @DisplayName("deve retornar cartão da conta")
+        void deveRetornarCartaoDaConta() {
+            CartaoCredito cartao = new CartaoCredito();
+            cartao.setId(UUID.randomUUID());
+            cartao.setConta(conta);
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.of(cartao));
+
+            CartaoCredito resultado = cartaoCreditoService.buscarPorConta(conta.getId(), usuario);
+
+            assertThat(resultado).isSameAs(cartao);
+        }
+
+        @Test
+        @DisplayName("deve falhar quando a conta não possui cartão")
+        void deveFalharQuandoContaNaoPossuiCartao() {
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> cartaoCreditoService.buscarPorConta(conta.getId(), usuario))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+    }
+}

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/ExtratoFuturoServiceTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/ExtratoFuturoServiceTest.java
@@ -1,0 +1,265 @@
+package bcd.appfinanceirobackend.service;
+
+import bcd.appfinanceirobackend.dto.extrato.ProjecaoMensalDTO;
+import bcd.appfinanceirobackend.mapper.FaturaMapper;
+import bcd.appfinanceirobackend.mapper.TransacaoMapper;
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Fatura;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.StatusFatura;
+import bcd.appfinanceirobackend.model.enums.TipoConta;
+import bcd.appfinanceirobackend.model.enums.TipoPagamento;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import bcd.appfinanceirobackend.repository.FaturaRepository;
+import bcd.appfinanceirobackend.repository.TransacaoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ExtratoFuturoService")
+class ExtratoFuturoServiceTest {
+
+    private static final LocalDate HOJE = LocalDate.of(2026, 6, 15);
+
+    @Mock
+    private TransacaoRepository transacaoRepository;
+
+    @Mock
+    private FaturaRepository faturaRepository;
+
+    private ExtratoFuturoService extratoFuturoService;
+
+    private Usuario usuario;
+    private Conta conta;
+
+    @BeforeEach
+    void setUp() {
+        extratoFuturoService = new ExtratoFuturoService(
+                transacaoRepository, faturaRepository, new TransacaoMapper(), new FaturaMapper());
+
+        usuario = new Usuario();
+        usuario.setId(UUID.randomUUID());
+
+        conta = new Conta();
+        conta.setId(UUID.randomUUID());
+        conta.setNome("Conta Corrente");
+        conta.setTipoConta(TipoConta.CORRENTE);
+        conta.setUsuario(usuario);
+    }
+
+    private void prepararCenario(List<Transacao> historico, List<Transacao> futuras, List<Fatura> faturasEmAberto) {
+        LocalDate fimPeriodo = YearMonth.from(HOJE).plusMonths(2).atEndOfMonth();
+        when(transacaoRepository.findAllByContaUsuarioIdAndDataBetween(usuario.getId(), HOJE.plusDays(1), fimPeriodo))
+                .thenReturn(futuras);
+        when(transacaoRepository.findAllByContaUsuarioId(usuario.getId())).thenReturn(historico);
+        when(faturaRepository.findAllByContaUsuarioIdAndStatusNot(usuario.getId(), StatusFatura.PAGA))
+                .thenReturn(faturasEmAberto);
+    }
+
+    private Transacao transacao(LocalDate data, TipoTransacao tipo, String valor, TipoPagamento formaPagamento) {
+        Transacao transacao = new Transacao();
+        transacao.setId(UUID.randomUUID());
+        transacao.setConta(conta);
+        transacao.setData(data);
+        transacao.setTipo(tipo);
+        transacao.setValor(new BigDecimal(valor));
+        transacao.setFormaPagamento(formaPagamento);
+        transacao.setCategorizada(false);
+        transacao.setFutura(data.isAfter(HOJE));
+        return transacao;
+    }
+
+    private Fatura fatura(LocalDate dataVencimento, String valorTotal, StatusFatura status) {
+        Fatura fatura = new Fatura();
+        fatura.setId(UUID.randomUUID());
+        fatura.setConta(conta);
+        fatura.setMesReferencia(YearMonth.from(dataVencimento).minusMonths(1));
+        fatura.setDataVencimento(dataVencimento);
+        fatura.setValorTotal(new BigDecimal(valorTotal));
+        fatura.setStatus(status);
+        return fatura;
+    }
+
+    @Nested
+    @DisplayName("calcularProjecao")
+    class CalcularProjecao {
+
+        @Test
+        @DisplayName("deve projetar parcelas futuras agrupadas por mês")
+        void deveProjetarParcelasFuturasPorMes() {
+            Transacao parcelaJulho = transacao(
+                    LocalDate.of(2026, 7, 10), TipoTransacao.DEBITO, "300.00", TipoPagamento.CARTAO_CREDITO);
+            Transacao parcelaAgosto = transacao(
+                    LocalDate.of(2026, 8, 10), TipoTransacao.DEBITO, "300.00", TipoPagamento.CARTAO_CREDITO);
+            prepararCenario(List.of(), List.of(parcelaJulho, parcelaAgosto), List.of());
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            assertThat(projecao).hasSize(3);
+            assertThat(projecao.get(0).getMes()).isEqualTo(6);
+            assertThat(projecao.get(0).getAno()).isEqualTo(2026);
+            assertThat(projecao.get(0).getTransacoes()).isEmpty();
+            assertThat(projecao.get(1).getMes()).isEqualTo(7);
+            assertThat(projecao.get(1).getTransacoes()).hasSize(1);
+            assertThat(projecao.get(1).getTransacoes().getFirst().getTransacaoId()).isEqualTo(parcelaJulho.getId());
+            assertThat(projecao.get(1).getTotalDebitos()).isEqualByComparingTo("300.00");
+            assertThat(projecao.get(2).getMes()).isEqualTo(8);
+            assertThat(projecao.get(2).getTransacoes()).hasSize(1);
+            assertThat(projecao.get(2).getTotalDebitos()).isEqualByComparingTo("300.00");
+        }
+
+        @Test
+        @DisplayName("deve listar boletos futuros no mês correspondente")
+        void deveListarBoletosNoMesCorrespondente() {
+            Transacao boleto = transacao(
+                    LocalDate.of(2026, 7, 5), TipoTransacao.DEBITO, "150.00", TipoPagamento.BOLETO);
+            prepararCenario(List.of(), List.of(boleto), List.of());
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            assertThat(projecao.get(1).getTransacoes()).hasSize(1);
+            assertThat(projecao.get(1).getTransacoes().getFirst().getFormaPagamento())
+                    .isEqualTo(TipoPagamento.BOLETO);
+            assertThat(projecao.get(1).getTotalDebitos()).isEqualByComparingTo("150.00");
+        }
+
+        @Test
+        @DisplayName("deve incluir faturas em aberto no mês do vencimento")
+        void deveIncluirFaturasAbertasComVencimentoNoMes() {
+            Fatura faturaJulho = fatura(LocalDate.of(2026, 7, 10), "500.00", StatusFatura.ABERTA);
+            prepararCenario(List.of(), List.of(), List.of(faturaJulho));
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            assertThat(projecao.get(0).getFaturas()).isEmpty();
+            assertThat(projecao.get(1).getFaturas()).hasSize(1);
+            assertThat(projecao.get(1).getFaturas().getFirst().getFaturaId()).isEqualTo(faturaJulho.getId());
+            assertThat(projecao.get(1).getFaturas().getFirst().getDataVencimento())
+                    .isEqualTo(LocalDate.of(2026, 7, 10));
+            assertThat(projecao.get(1).getTotalDebitos()).isEqualByComparingTo("500.00");
+            assertThat(projecao.get(2).getFaturas()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("não deve contar duas vezes débito já vinculado a fatura")
+        void naoDeveContarDuasVezesDebitoVinculadoAFatura() {
+            Fatura faturaJulho = fatura(LocalDate.of(2026, 7, 10), "500.00", StatusFatura.ABERTA);
+            Transacao parcelaVinculada = transacao(
+                    LocalDate.of(2026, 7, 10), TipoTransacao.DEBITO, "500.00", TipoPagamento.CARTAO_CREDITO);
+            parcelaVinculada.setFatura(faturaJulho);
+            prepararCenario(List.of(), List.of(parcelaVinculada), List.of(faturaJulho));
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            assertThat(projecao.get(1).getTotalDebitos()).isEqualByComparingTo("500.00");
+            assertThat(projecao.get(1).getTransacoes()).hasSize(1);
+            assertThat(projecao.get(1).getFaturas()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("deve acumular saldo previsto a partir do saldo atual")
+        void deveAcumularSaldoPrevistoAPartirDoSaldoAtual() {
+            Transacao salarioPassado = transacao(
+                    LocalDate.of(2026, 6, 1), TipoTransacao.CREDITO, "1000.00", TipoPagamento.PIX);
+            Transacao gastoPassado = transacao(
+                    LocalDate.of(2026, 6, 10), TipoTransacao.DEBITO, "200.00", TipoPagamento.PIX);
+            Transacao salarioFuturo = transacao(
+                    LocalDate.of(2026, 7, 1), TipoTransacao.CREDITO, "500.00", TipoPagamento.PIX);
+            Transacao boletoFuturo = transacao(
+                    LocalDate.of(2026, 8, 5), TipoTransacao.DEBITO, "300.00", TipoPagamento.BOLETO);
+            prepararCenario(
+                    List.of(salarioPassado, gastoPassado),
+                    List.of(salarioFuturo, boletoFuturo),
+                    List.of());
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            assertThat(projecao.get(0).getSaldoPrevisto()).isEqualByComparingTo("800.00");
+            assertThat(projecao.get(1).getSaldoPrevisto()).isEqualByComparingTo("1300.00");
+            assertThat(projecao.get(1).getTotalCreditos()).isEqualByComparingTo("500.00");
+            assertThat(projecao.get(2).getSaldoPrevisto()).isEqualByComparingTo("1000.00");
+        }
+
+        @Test
+        @DisplayName("deve retornar meses vazios quando não há transações futuras")
+        void deveRetornarMesesVaziosQuandoNaoHaTransacoesFuturas() {
+            prepararCenario(List.of(), List.of(), List.of());
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            assertThat(projecao).hasSize(3);
+            for (ProjecaoMensalDTO mes : projecao) {
+                assertThat(mes.getTransacoes()).isEmpty();
+                assertThat(mes.getFaturas()).isEmpty();
+                assertThat(mes.getTotalDebitos()).isEqualByComparingTo("0");
+                assertThat(mes.getTotalCreditos()).isEqualByComparingTo("0");
+                assertThat(mes.getSaldoPrevisto()).isEqualByComparingTo("0");
+            }
+        }
+
+        @Test
+        @DisplayName("deve preencher período de cada mês projetado")
+        void devePreencherPeriodoDeCadaMes() {
+            prepararCenario(List.of(), List.of(), List.of());
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            assertThat(projecao.get(0).getDataInicio()).isEqualTo(LocalDate.of(2026, 6, 1));
+            assertThat(projecao.get(0).getDataFim()).isEqualTo(LocalDate.of(2026, 6, 30));
+            assertThat(projecao.get(2).getDataInicio()).isEqualTo(LocalDate.of(2026, 8, 1));
+            assertThat(projecao.get(2).getDataFim()).isEqualTo(LocalDate.of(2026, 8, 31));
+        }
+
+        @Test
+        @DisplayName("deve rejeitar quantidade de meses fora do intervalo permitido")
+        void deveRejeitarQuantidadeDeMesesInvalida() {
+            assertThatThrownBy(() -> extratoFuturoService.calcularProjecao(usuario, 0, HOJE))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThatThrownBy(() -> extratoFuturoService.calcularProjecao(usuario, 13, HOJE))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+            verifyNoInteractions(transacaoRepository, faturaRepository);
+        }
+    }
+
+    @Nested
+    @DisplayName("listarTransacoesFuturas")
+    class ListarTransacoesFuturas {
+
+        @Test
+        @DisplayName("deve buscar transações a partir do dia seguinte")
+        void deveBuscarTransacoesAPartirDoDiaSeguinte() {
+            LocalDate fimPeriodo = LocalDate.of(2026, 8, 31);
+            Transacao futura = transacao(
+                    LocalDate.of(2026, 7, 1), TipoTransacao.DEBITO, "100.00", TipoPagamento.BOLETO);
+            when(transacaoRepository.findAllByContaUsuarioIdAndDataBetween(
+                    usuario.getId(), HOJE.plusDays(1), fimPeriodo)).thenReturn(List.of(futura));
+
+            List<Transacao> resultado = extratoFuturoService.listarTransacoesFuturas(usuario, HOJE, fimPeriodo);
+
+            assertThat(resultado).containsExactly(futura);
+        }
+    }
+}

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/ExtratoFuturoServiceTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/ExtratoFuturoServiceTest.java
@@ -31,6 +31,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -70,7 +72,8 @@ class ExtratoFuturoServiceTest {
         LocalDate fimPeriodo = YearMonth.from(HOJE).plusMonths(2).atEndOfMonth();
         when(transacaoRepository.findAllByContaUsuarioIdAndDataBetween(usuario.getId(), HOJE.plusDays(1), fimPeriodo))
                 .thenReturn(futuras);
-        when(transacaoRepository.findAllByContaUsuarioId(usuario.getId())).thenReturn(historico);
+        when(transacaoRepository.findAllByContaUsuarioIdAndDataLessThanEqual(usuario.getId(), HOJE))
+                .thenReturn(historico);
         when(faturaRepository.findAllByContaUsuarioIdAndStatusNot(usuario.getId(), StatusFatura.PAGA))
                 .thenReturn(faturasEmAberto);
     }
@@ -197,6 +200,84 @@ class ExtratoFuturoServiceTest {
             assertThat(projecao.get(1).getSaldoPrevisto()).isEqualByComparingTo("1300.00");
             assertThat(projecao.get(1).getTotalCreditos()).isEqualByComparingTo("500.00");
             assertThat(projecao.get(2).getSaldoPrevisto()).isEqualByComparingTo("1000.00");
+        }
+
+        @Test
+        @DisplayName("não deve descontar do saldo débito passado vinculado a fatura em aberto")
+        void naoDeveDescontarDoSaldoDebitoVinculadoAFaturaEmAberto() {
+            Fatura faturaJulho = fatura(LocalDate.of(2026, 7, 10), "500.00", StatusFatura.ABERTA);
+            Transacao salarioPassado = transacao(
+                    LocalDate.of(2026, 6, 1), TipoTransacao.CREDITO, "1000.00", TipoPagamento.PIX);
+            Transacao compraPassada = transacao(
+                    LocalDate.of(2026, 6, 5), TipoTransacao.DEBITO, "500.00", TipoPagamento.CARTAO_CREDITO);
+            compraPassada.setFatura(faturaJulho);
+            prepararCenario(List.of(salarioPassado, compraPassada), List.of(), List.of(faturaJulho));
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            // A compra só sai do caixa no vencimento da fatura, em julho
+            assertThat(projecao.get(0).getSaldoPrevisto()).isEqualByComparingTo("1000.00");
+            assertThat(projecao.get(1).getSaldoPrevisto()).isEqualByComparingTo("500.00");
+        }
+
+        @Test
+        @DisplayName("deve descontar do saldo débito passado vinculado a fatura já paga")
+        void deveDescontarDoSaldoDebitoVinculadoAFaturaPaga() {
+            Fatura faturaPaga = fatura(LocalDate.of(2026, 5, 10), "500.00", StatusFatura.PAGA);
+            Transacao compraPassada = transacao(
+                    LocalDate.of(2026, 5, 2), TipoTransacao.DEBITO, "500.00", TipoPagamento.CARTAO_CREDITO);
+            compraPassada.setFatura(faturaPaga);
+            prepararCenario(List.of(compraPassada), List.of(), List.of());
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            assertThat(projecao.get(0).getSaldoPrevisto()).isEqualByComparingTo("-500.00");
+        }
+
+        @Test
+        @DisplayName("não deve somar crédito futuro vinculado a fatura nos totais")
+        void naoDeveSomarCreditoVinculadoAFatura() {
+            Fatura faturaJulho = fatura(LocalDate.of(2026, 7, 10), "470.00", StatusFatura.ABERTA);
+            Transacao estornoFuturo = transacao(
+                    LocalDate.of(2026, 7, 12), TipoTransacao.CREDITO, "30.00", TipoPagamento.CARTAO_CREDITO);
+            estornoFuturo.setFatura(faturaJulho);
+            prepararCenario(List.of(), List.of(estornoFuturo), List.of(faturaJulho));
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            // O estorno já abate o valorTotal da fatura; somar de novo contaria duas vezes
+            assertThat(projecao.get(1).getTotalCreditos()).isEqualByComparingTo("0");
+            assertThat(projecao.get(1).getTotalDebitos()).isEqualByComparingTo("470.00");
+            assertThat(projecao.get(1).getTransacoes()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("deve incluir fatura atrasada não paga no primeiro mês projetado")
+        void deveIncluirFaturaAtrasadaNoPrimeiroMes() {
+            Fatura faturaAtrasada = fatura(LocalDate.of(2026, 5, 10), "200.00", StatusFatura.FECHADA);
+            prepararCenario(List.of(), List.of(), List.of(faturaAtrasada));
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, 3, HOJE);
+
+            assertThat(projecao.get(0).getFaturas()).hasSize(1);
+            assertThat(projecao.get(0).getTotalDebitos()).isEqualByComparingTo("200.00");
+            assertThat(projecao.get(1).getFaturas()).isEmpty();
+            assertThat(projecao.get(2).getFaturas()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("deve projetar 3 meses por padrão quando a quantidade não é informada")
+        void deveProjetarTresMesesPorPadrao() {
+            when(transacaoRepository.findAllByContaUsuarioIdAndDataBetween(
+                    eq(usuario.getId()), any(LocalDate.class), any(LocalDate.class))).thenReturn(List.of());
+            when(transacaoRepository.findAllByContaUsuarioIdAndDataLessThanEqual(
+                    eq(usuario.getId()), any(LocalDate.class))).thenReturn(List.of());
+            when(faturaRepository.findAllByContaUsuarioIdAndStatusNot(usuario.getId(), StatusFatura.PAGA))
+                    .thenReturn(List.of());
+
+            List<ProjecaoMensalDTO> projecao = extratoFuturoService.calcularProjecao(usuario, (Integer) null);
+
+            assertThat(projecao).hasSize(3);
         }
 
         @Test

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/FaturaServiceTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/FaturaServiceTest.java
@@ -118,12 +118,25 @@ class FaturaServiceTest {
         @DisplayName("deve retornar fatura existente sem criar outra")
         void deveRetornarFaturaExistente() {
             Fatura existente = fatura(StatusFatura.ABERTA);
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
             when(faturaRepository.findByContaIdAndMesReferencia(conta.getId(), YearMonth.of(2026, 7)))
                     .thenReturn(Optional.of(existente));
 
-            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7));
+            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7), usuario);
 
             assertThat(resultado).isSameAs(existente);
+            verify(faturaRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("deve negar geração de fatura em conta de outro usuário")
+        void deveNegarGeracaoParaContaDeOutroUsuario() {
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+
+            assertThatThrownBy(() -> faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7), outroUsuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN);
             verify(faturaRepository, never()).save(any());
         }
 
@@ -136,7 +149,7 @@ class FaturaServiceTest {
             when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.of(cartao(20, 28)));
             when(faturaRepository.save(any(Fatura.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7));
+            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7), usuario);
 
             assertThat(resultado.getStatus()).isEqualTo(StatusFatura.ABERTA);
             assertThat(resultado.getValorTotal()).isEqualByComparingTo("0");
@@ -153,7 +166,7 @@ class FaturaServiceTest {
             when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.of(cartao(25, 5)));
             when(faturaRepository.save(any(Fatura.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7));
+            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7), usuario);
 
             assertThat(resultado.getDataVencimento()).isEqualTo(LocalDate.of(2026, 8, 5));
         }
@@ -167,7 +180,7 @@ class FaturaServiceTest {
             when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.of(cartao(20, 31)));
             when(faturaRepository.save(any(Fatura.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 2));
+            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 2), usuario);
 
             assertThat(resultado.getDataVencimento()).isEqualTo(LocalDate.of(2026, 2, 28));
         }
@@ -180,7 +193,7 @@ class FaturaServiceTest {
             when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
             when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7)))
+            assertThatThrownBy(() -> faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7), usuario))
                     .isInstanceOf(ResourceNotFoundException.class);
             verify(faturaRepository, never()).save(any());
         }
@@ -200,7 +213,7 @@ class FaturaServiceTest {
                     transacaoDaFatura(TipoTransacao.DEBITO, "50.00"),
                     transacaoDaFatura(TipoTransacao.CREDITO, "30.00")));
 
-            BigDecimal total = faturaService.calcularTotal(faturaAberta.getId());
+            BigDecimal total = faturaService.calcularTotal(faturaAberta.getId(), usuario);
 
             assertThat(total).isEqualByComparingTo("120.00");
             ArgumentCaptor<Fatura> captor = ArgumentCaptor.forClass(Fatura.class);
@@ -214,8 +227,21 @@ class FaturaServiceTest {
             UUID faturaId = UUID.randomUUID();
             when(faturaRepository.findById(faturaId)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> faturaService.calcularTotal(faturaId))
+            assertThatThrownBy(() -> faturaService.calcularTotal(faturaId, usuario))
                     .isInstanceOf(ResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("deve negar recálculo de fatura de outro usuário")
+        void deveNegarRecalculoParaFaturaDeOutroUsuario() {
+            Fatura faturaAberta = fatura(StatusFatura.ABERTA);
+            when(faturaRepository.findById(faturaAberta.getId())).thenReturn(Optional.of(faturaAberta));
+
+            assertThatThrownBy(() -> faturaService.calcularTotal(faturaAberta.getId(), outroUsuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN);
+            verify(faturaRepository, never()).save(any());
         }
     }
 

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/FaturaServiceTest.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/FaturaServiceTest.java
@@ -1,0 +1,334 @@
+package bcd.appfinanceirobackend.service;
+
+import bcd.appfinanceirobackend.dto.fatura.FaturaResumoDTO;
+import bcd.appfinanceirobackend.exception.ResourceNotFoundException;
+import bcd.appfinanceirobackend.mapper.FaturaMapper;
+import bcd.appfinanceirobackend.model.CartaoCredito;
+import bcd.appfinanceirobackend.model.Conta;
+import bcd.appfinanceirobackend.model.Fatura;
+import bcd.appfinanceirobackend.model.Transacao;
+import bcd.appfinanceirobackend.model.Usuario;
+import bcd.appfinanceirobackend.model.enums.StatusFatura;
+import bcd.appfinanceirobackend.model.enums.TipoConta;
+import bcd.appfinanceirobackend.model.enums.TipoTransacao;
+import bcd.appfinanceirobackend.repository.CartaoCreditoRepository;
+import bcd.appfinanceirobackend.repository.ContaRepository;
+import bcd.appfinanceirobackend.repository.FaturaRepository;
+import bcd.appfinanceirobackend.repository.TransacaoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FaturaService")
+class FaturaServiceTest {
+
+    @Mock
+    private FaturaRepository faturaRepository;
+
+    @Mock
+    private ContaRepository contaRepository;
+
+    @Mock
+    private CartaoCreditoRepository cartaoCreditoRepository;
+
+    @Mock
+    private TransacaoRepository transacaoRepository;
+
+    private FaturaService faturaService;
+
+    private Usuario usuario;
+    private Usuario outroUsuario;
+    private Conta conta;
+
+    @BeforeEach
+    void setUp() {
+        faturaService = new FaturaService(
+                faturaRepository, contaRepository, cartaoCreditoRepository, transacaoRepository, new FaturaMapper());
+
+        usuario = new Usuario();
+        usuario.setId(UUID.randomUUID());
+
+        outroUsuario = new Usuario();
+        outroUsuario.setId(UUID.randomUUID());
+
+        conta = new Conta();
+        conta.setId(UUID.randomUUID());
+        conta.setNome("Cartão Nubank");
+        conta.setTipoConta(TipoConta.CARTAO_CREDITO);
+        conta.setUsuario(usuario);
+    }
+
+    private CartaoCredito cartao(int diaFechamento, int diaVencimento) {
+        CartaoCredito cartao = new CartaoCredito();
+        cartao.setId(UUID.randomUUID());
+        cartao.setConta(conta);
+        cartao.setDia_fechamento(diaFechamento);
+        cartao.setDia_vencimento(diaVencimento);
+        return cartao;
+    }
+
+    private Fatura fatura(StatusFatura status) {
+        Fatura fatura = new Fatura();
+        fatura.setId(UUID.randomUUID());
+        fatura.setConta(conta);
+        fatura.setMesReferencia(YearMonth.of(2026, 7));
+        fatura.setDataVencimento(LocalDate.of(2026, 7, 28));
+        fatura.setValorTotal(new BigDecimal("500.00"));
+        fatura.setStatus(status);
+        return fatura;
+    }
+
+    private Transacao transacaoDaFatura(TipoTransacao tipo, String valor) {
+        Transacao transacao = new Transacao();
+        transacao.setId(UUID.randomUUID());
+        transacao.setConta(conta);
+        transacao.setData(LocalDate.of(2026, 7, 10));
+        transacao.setTipo(tipo);
+        transacao.setValor(new BigDecimal(valor));
+        return transacao;
+    }
+
+    @Nested
+    @DisplayName("gerarFatura")
+    class GerarFatura {
+
+        @Test
+        @DisplayName("deve retornar fatura existente sem criar outra")
+        void deveRetornarFaturaExistente() {
+            Fatura existente = fatura(StatusFatura.ABERTA);
+            when(faturaRepository.findByContaIdAndMesReferencia(conta.getId(), YearMonth.of(2026, 7)))
+                    .thenReturn(Optional.of(existente));
+
+            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7));
+
+            assertThat(resultado).isSameAs(existente);
+            verify(faturaRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("deve criar fatura aberta com vencimento no próprio mês quando vencimento é após o fechamento")
+        void deveCriarFaturaComVencimentoNoProprioMes() {
+            when(faturaRepository.findByContaIdAndMesReferencia(conta.getId(), YearMonth.of(2026, 7)))
+                    .thenReturn(Optional.empty());
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.of(cartao(20, 28)));
+            when(faturaRepository.save(any(Fatura.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7));
+
+            assertThat(resultado.getStatus()).isEqualTo(StatusFatura.ABERTA);
+            assertThat(resultado.getValorTotal()).isEqualByComparingTo("0");
+            assertThat(resultado.getMesReferencia()).isEqualTo(YearMonth.of(2026, 7));
+            assertThat(resultado.getDataVencimento()).isEqualTo(LocalDate.of(2026, 7, 28));
+        }
+
+        @Test
+        @DisplayName("deve criar fatura com vencimento no mês seguinte quando vencimento é antes do fechamento")
+        void deveCriarFaturaComVencimentoNoMesSeguinte() {
+            when(faturaRepository.findByContaIdAndMesReferencia(conta.getId(), YearMonth.of(2026, 7)))
+                    .thenReturn(Optional.empty());
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.of(cartao(25, 5)));
+            when(faturaRepository.save(any(Fatura.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7));
+
+            assertThat(resultado.getDataVencimento()).isEqualTo(LocalDate.of(2026, 8, 5));
+        }
+
+        @Test
+        @DisplayName("deve ajustar o dia de vencimento ao tamanho do mês")
+        void deveAjustarDiaDeVencimentoAoTamanhoDoMes() {
+            when(faturaRepository.findByContaIdAndMesReferencia(conta.getId(), YearMonth.of(2026, 2)))
+                    .thenReturn(Optional.empty());
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.of(cartao(20, 31)));
+            when(faturaRepository.save(any(Fatura.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            Fatura resultado = faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 2));
+
+            assertThat(resultado.getDataVencimento()).isEqualTo(LocalDate.of(2026, 2, 28));
+        }
+
+        @Test
+        @DisplayName("deve falhar quando a conta não possui cartão de crédito")
+        void deveFalharSemCartaoDeCredito() {
+            when(faturaRepository.findByContaIdAndMesReferencia(conta.getId(), YearMonth.of(2026, 7)))
+                    .thenReturn(Optional.empty());
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(cartaoCreditoRepository.findByContaId(conta.getId())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> faturaService.gerarFatura(conta.getId(), YearMonth.of(2026, 7)))
+                    .isInstanceOf(ResourceNotFoundException.class);
+            verify(faturaRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("calcularTotal")
+    class CalcularTotal {
+
+        @Test
+        @DisplayName("deve somar débitos, abater créditos e persistir o total")
+        void deveSomarDebitosEAbaterCreditos() {
+            Fatura faturaAberta = fatura(StatusFatura.ABERTA);
+            when(faturaRepository.findById(faturaAberta.getId())).thenReturn(Optional.of(faturaAberta));
+            when(transacaoRepository.findAllByFaturaId(faturaAberta.getId())).thenReturn(List.of(
+                    transacaoDaFatura(TipoTransacao.DEBITO, "100.00"),
+                    transacaoDaFatura(TipoTransacao.DEBITO, "50.00"),
+                    transacaoDaFatura(TipoTransacao.CREDITO, "30.00")));
+
+            BigDecimal total = faturaService.calcularTotal(faturaAberta.getId());
+
+            assertThat(total).isEqualByComparingTo("120.00");
+            ArgumentCaptor<Fatura> captor = ArgumentCaptor.forClass(Fatura.class);
+            verify(faturaRepository).save(captor.capture());
+            assertThat(captor.getValue().getValorTotal()).isEqualByComparingTo("120.00");
+        }
+
+        @Test
+        @DisplayName("deve falhar quando a fatura não existe")
+        void deveFalharQuandoFaturaNaoExiste() {
+            UUID faturaId = UUID.randomUUID();
+            when(faturaRepository.findById(faturaId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> faturaService.calcularTotal(faturaId))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("pagar")
+    class Pagar {
+
+        @Test
+        @DisplayName("deve marcar fatura como paga")
+        void deveMarcarFaturaComoPaga() {
+            Fatura faturaAberta = fatura(StatusFatura.ABERTA);
+            when(faturaRepository.findById(faturaAberta.getId())).thenReturn(Optional.of(faturaAberta));
+            when(faturaRepository.save(any(Fatura.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            FaturaResumoDTO resultado = faturaService.pagar(faturaAberta.getId(), usuario);
+
+            assertThat(resultado.getStatus()).isEqualTo(StatusFatura.PAGA);
+            assertThat(resultado.getFaturaId()).isEqualTo(faturaAberta.getId());
+        }
+
+        @Test
+        @DisplayName("deve rejeitar pagamento de fatura já paga")
+        void deveRejeitarFaturaJaPaga() {
+            Fatura faturaPaga = fatura(StatusFatura.PAGA);
+            when(faturaRepository.findById(faturaPaga.getId())).thenReturn(Optional.of(faturaPaga));
+
+            assertThatThrownBy(() -> faturaService.pagar(faturaPaga.getId(), usuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.CONFLICT);
+            verify(faturaRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("deve negar acesso a fatura de outro usuário")
+        void deveNegarAcessoAFaturaDeOutroUsuario() {
+            Fatura faturaAberta = fatura(StatusFatura.ABERTA);
+            when(faturaRepository.findById(faturaAberta.getId())).thenReturn(Optional.of(faturaAberta));
+
+            assertThatThrownBy(() -> faturaService.pagar(faturaAberta.getId(), outroUsuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN);
+        }
+    }
+
+    @Nested
+    @DisplayName("buscarPorConta")
+    class BuscarPorConta {
+
+        @Test
+        @DisplayName("deve listar faturas da conta como resumo")
+        void deveListarFaturasDaConta() {
+            Fatura faturaAberta = fatura(StatusFatura.ABERTA);
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+            when(faturaRepository.findAllByContaIdOrderByMesReferenciaDesc(conta.getId()))
+                    .thenReturn(List.of(faturaAberta));
+
+            List<FaturaResumoDTO> resultado = faturaService.buscarPorConta(conta.getId(), usuario);
+
+            assertThat(resultado).hasSize(1);
+            assertThat(resultado.getFirst().getFaturaId()).isEqualTo(faturaAberta.getId());
+            assertThat(resultado.getFirst().getContaId()).isEqualTo(conta.getId());
+            assertThat(resultado.getFirst().getMesReferencia()).isEqualTo("2026-07");
+        }
+
+        @Test
+        @DisplayName("deve falhar quando a conta não existe")
+        void deveFalharQuandoContaNaoExiste() {
+            UUID contaId = UUID.randomUUID();
+            when(contaRepository.findById(contaId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> faturaService.buscarPorConta(contaId, usuario))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("deve negar acesso a conta de outro usuário")
+        void deveNegarAcessoAContaDeOutroUsuario() {
+            when(contaRepository.findById(conta.getId())).thenReturn(Optional.of(conta));
+
+            assertThatThrownBy(() -> faturaService.buscarPorConta(conta.getId(), outroUsuario))
+                    .isInstanceOf(ResponseStatusException.class)
+                    .extracting(ex -> ((ResponseStatusException) ex).getStatusCode())
+                    .isEqualTo(HttpStatus.FORBIDDEN);
+        }
+    }
+
+    @Nested
+    @DisplayName("buscarPorId")
+    class BuscarPorId {
+
+        @Test
+        @DisplayName("deve retornar resumo da fatura")
+        void deveRetornarResumoDaFatura() {
+            Fatura faturaAberta = fatura(StatusFatura.ABERTA);
+            when(faturaRepository.findById(faturaAberta.getId())).thenReturn(Optional.of(faturaAberta));
+
+            FaturaResumoDTO resultado = faturaService.buscarPorId(faturaAberta.getId(), usuario);
+
+            assertThat(resultado.getFaturaId()).isEqualTo(faturaAberta.getId());
+            assertThat(resultado.getValorTotal()).isEqualByComparingTo("500.00");
+            assertThat(resultado.getContaNome()).isEqualTo("Cartão Nubank");
+        }
+
+        @Test
+        @DisplayName("deve falhar quando a fatura não existe")
+        void deveFalharQuandoFaturaNaoExiste() {
+            UUID faturaId = UUID.randomUUID();
+            when(faturaRepository.findById(faturaId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> faturaService.buscarPorId(faturaId, usuario))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+    }
+}

--- a/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/FaturaUnicidadeIntegrationTests.java
+++ b/app-financeiro-back-end/src/test/java/bcd/appfinanceirobackend/service/FaturaUnicidadeIntegrationTests.java
@@ -1,0 +1,111 @@
+package bcd.appfinanceirobackend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Valida a restrição única da migration V5 com banco real: o banco precisa
+ * rejeitar duas faturas com o mesmo {@code conta_id} e {@code mes_referencia},
+ * porque o get-or-create de {@code gerarFatura} não cobre chamadas concorrentes
+ * (ambas podem passar pelo SELECT antes de qualquer INSERT).
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@Transactional
+@DisplayName("Migration V5 (fatura única por conta e mês) - Integração com banco real")
+class FaturaUnicidadeIntegrationTests {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("app_financeiro_test")
+            .withUsername("postgres")
+            .withPassword("1234");
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private UUID contaId;
+    private UUID usuarioId;
+
+    @BeforeEach
+    void seedConta() {
+        usuarioId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO usuario (id, nome, email, senha, cpf) VALUES (?, ?, ?, ?, ?)",
+                usuarioId, "Dono Fatura", "dono-fatura@test.com", "hash", "98765432100");
+
+        contaId = criarConta("Cartão Nubank");
+    }
+
+    @Test
+    @DisplayName("rejeita segunda fatura com mesmo conta_id e mes_referencia")
+    void rejeitaFaturaDuplicadaParaMesmaContaEMes() {
+        inserirFatura(contaId, "2026-07");
+
+        assertThatThrownBy(() -> inserirFatura(contaId, "2026-07"))
+                .isInstanceOf(DuplicateKeyException.class)
+                .hasMessageContaining("uk_fatura_conta_mes");
+    }
+
+    @Test
+    @DisplayName("permite faturas da mesma conta em meses diferentes")
+    void permiteFaturasDaMesmaContaEmMesesDiferentes() {
+        inserirFatura(contaId, "2026-07");
+        inserirFatura(contaId, "2026-08");
+
+        assertThat(contarFaturas(contaId)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("permite faturas de contas diferentes no mesmo mês")
+    void permiteFaturasDeContasDiferentesNoMesmoMes() {
+        UUID outraContaId = criarConta("Cartão Inter");
+
+        inserirFatura(contaId, "2026-07");
+        inserirFatura(outraContaId, "2026-07");
+
+        assertThat(contarFaturas(contaId) + contarFaturas(outraContaId)).isEqualTo(2);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private UUID criarConta(String nome) {
+        UUID id = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO contas (id, usuario_id, nome, tipo) VALUES (?, ?, ?, ?)",
+                id, usuarioId, nome, "CARTAO_CREDITO");
+        return id;
+    }
+
+    private void inserirFatura(UUID conta, String mesReferencia) {
+        jdbcTemplate.update(
+                "INSERT INTO fatura (id, conta_id, mes_referencia, data_vencimento, valor_total, status) "
+                        + "VALUES (?, ?, ?, ?, ?, ?)",
+                UUID.randomUUID(), conta, mesReferencia, LocalDate.of(2026, 7, 28), BigDecimal.ZERO, "ABERTA");
+    }
+
+    private Integer contarFaturas(UUID conta) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM fatura WHERE conta_id = ?", Integer.class, conta);
+    }
+}

--- a/app-financeiro-front-end/src/App.tsx
+++ b/app-financeiro-front-end/src/App.tsx
@@ -12,6 +12,7 @@ import NovaTransacao from './pages/NovaTransacao';
 import EditarTransacao from './pages/EditarTransacao';
 import Categorias from './pages/Categorias';
 import Parcelamentos from './pages/Parcelamentos';
+import ExtratoFuturo from './pages/ExtratoFuturo';
 import PrimeiraConta from './pages/PrimeiraConta';
 
 function App() {
@@ -34,6 +35,7 @@ function App() {
             <Route path="/transacoes/:transacaoId/editar" element={<EditarTransacao />} />
             <Route path="/categorias" element={<Categorias />} />
             <Route path="/parcelamentos" element={<Parcelamentos />} />
+            <Route path="/extrato-futuro" element={<ExtratoFuturo />} />
             <Route path="/importacoes/nova" element={<ImportarExtrato />} />
             <Route path="/contas/primeira" element={<PrimeiraConta />} />
           </Route>

--- a/app-financeiro-front-end/src/components/layout/LayoutPrivado.tsx
+++ b/app-financeiro-front-end/src/components/layout/LayoutPrivado.tsx
@@ -15,6 +15,7 @@ const itensNavegacao = [
   { para: "/transacoes", rotulo: "Transações", icone: "transacoes" },
   { para: "/categorias", rotulo: "Categorias", icone: "categorias" },
   { para: "/parcelamentos", rotulo: "Parcelamentos", icone: "parcelamentos" },
+  { para: "/extrato-futuro", rotulo: "Extrato futuro", icone: "extrato-futuro" },
   { para: "/contas", rotulo: "Contas", icone: "contas" },
 ];
 
@@ -39,6 +40,15 @@ const IconeNavegacao = ({ nome }: { nome: string }) => {
     return (
       <svg viewBox="0 0 24 24" aria-hidden="true">
         <path d="M4 7h16M7 11h10M7 15h6M6 3h12a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+      </svg>
+    );
+  }
+
+  if (nome === "extrato-futuro") {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 17l5.5-5.5 4 4L21 7" />
+        <path d="M15 7h6v6" />
       </svg>
     );
   }

--- a/app-financeiro-front-end/src/pages/ExtratoFuturo.test.tsx
+++ b/app-financeiro-front-end/src/pages/ExtratoFuturo.test.tsx
@@ -133,6 +133,39 @@ describe('Tela de Extrato Futuro (Issue #68)', () => {
     expect(screen.getByText(/Fatura Cartão Nubank/i)).toBeInTheDocument();
     expect(screen.getByText(/Vence em 08\/07\/2026/i)).toBeInTheDocument();
     expect(screen.getByText('Aberta')).toBeInTheDocument();
+    expect(screen.getByText(/980,00/)).toBeInTheDocument();
+  });
+
+  it('deve exibir saldo previsto e totais do mês projetado', async () => {
+    vi.mocked(api.obterExtratoFuturo).mockResolvedValue(projecaoComDados);
+
+    renderExtratoFuturo();
+    await aguardarCarregamento();
+
+    // -1.230,00 no saldo previsto de julho; 1.230,00 nos débitos do mês e no "A pagar" do hero
+    expect(screen.getAllByText(/-?R\$\s?1\.230,00/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText(/Saldo previsto/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Débitos/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Créditos/i).length).toBeGreaterThan(0);
+  });
+
+  it('deve manter a projeção na tela quando o pagamento da fatura falha', async () => {
+    vi.mocked(api.obterExtratoFuturo).mockResolvedValue(projecaoComDados);
+    vi.mocked(api.pagarFatura).mockRejectedValueOnce(new Error('Falha na API'));
+
+    const usuario = userEvent.setup();
+
+    renderExtratoFuturo();
+    await aguardarCarregamento();
+
+    await usuario.click(screen.getByRole('button', { name: /Marcar paga/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Não foi possível pagar a fatura.')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Julho de 2026')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Marcar paga/i })).toBeEnabled();
   });
 
   it('deve marcar fatura como paga e recarregar a projeção', async () => {

--- a/app-financeiro-front-end/src/pages/ExtratoFuturo.test.tsx
+++ b/app-financeiro-front-end/src/pages/ExtratoFuturo.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import ExtratoFuturo from './ExtratoFuturo';
+import * as api from '../services/api';
+
+vi.mock('../hooks/useAutenticacao', () => ({
+  useAutenticacao: () => ({
+    usuario: { id: 'user-123', nome: 'Usuário Teste', email: 'teste@teste.com' },
+    autenticado: true,
+    sair: vi.fn(),
+  }),
+}));
+
+vi.mock('../services/api', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../services/api')>();
+  return {
+    ...original,
+    obterExtratoFuturo: vi.fn(),
+    pagarFatura: vi.fn(),
+    obterMensagemErroApi: vi.fn((_err: unknown, fallback: string) => fallback),
+  };
+});
+
+const mesVazio = (ano: number, mes: number): api.ProjecaoMensalResponse => ({
+  ano,
+  mes,
+  dataInicio: `${ano}-${String(mes).padStart(2, '0')}-01`,
+  dataFim: `${ano}-${String(mes).padStart(2, '0')}-28`,
+  saldoPrevisto: 0,
+  totalDebitos: 0,
+  totalCreditos: 0,
+  faturas: [],
+  transacoes: [],
+});
+
+const projecaoVazia = [mesVazio(2026, 6), mesVazio(2026, 7), mesVazio(2026, 8)];
+
+const parcelaJulho: api.TransacaoResponse = {
+  transacaoId: 'tx-parcela',
+  valor: 250,
+  data: '2026-07-10',
+  descricao: 'Notebook 2/10',
+  tipoTransacao: 'DEBITO',
+  formaPagamento: 'CARTAO_CREDITO',
+  categoriaId: null,
+  contaId: 'conta-1',
+  categorizada: false,
+};
+
+const faturaJulho: api.FaturaResumoResponse = {
+  faturaId: 'fat-1',
+  contaId: 'conta-1',
+  contaNome: 'Cartão Nubank',
+  mesReferencia: '2026-06',
+  dataVencimento: '2026-07-08',
+  valorTotal: 980,
+  status: 'ABERTA',
+};
+
+const projecaoComDados: api.ProjecaoMensalResponse[] = [
+  mesVazio(2026, 6),
+  {
+    ...mesVazio(2026, 7),
+    saldoPrevisto: -1230,
+    totalDebitos: 1230,
+    faturas: [faturaJulho],
+    transacoes: [parcelaJulho],
+  },
+  mesVazio(2026, 8),
+];
+
+const renderExtratoFuturo = () =>
+  render(
+    <MemoryRouter initialEntries={['/extrato-futuro']}>
+      <ExtratoFuturo />
+    </MemoryRouter>,
+  );
+
+const aguardarCarregamento = async () => {
+  await waitFor(() => {
+    expect(screen.queryByText(/Carregando extrato futuro/i)).not.toBeInTheDocument();
+  });
+};
+
+describe('Tela de Extrato Futuro (Issue #68)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.obterExtratoFuturo).mockReset();
+    vi.mocked(api.pagarFatura).mockReset();
+    vi.mocked(api.obterExtratoFuturo).mockResolvedValue(projecaoVazia);
+  });
+
+  it('deve exibir loading e depois o resumo da projeção', async () => {
+    renderExtratoFuturo();
+
+    expect(screen.getByText(/Carregando extrato futuro/i)).toBeInTheDocument();
+
+    await aguardarCarregamento();
+
+    expect(api.obterExtratoFuturo).toHaveBeenCalledWith(3);
+    expect(screen.getByLabelText(/Resumo da projeção/i)).toBeInTheDocument();
+  });
+
+  it('deve exibir estado vazio informativo quando não há movimentações futuras', async () => {
+    renderExtratoFuturo();
+    await aguardarCarregamento();
+
+    expect(screen.getByText(/Nada projetado por aqui/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Registrar transação futura/i }),
+    ).toHaveAttribute('href', '/transacoes/nova');
+  });
+
+  it('deve listar parcelas futuras no mês correspondente', async () => {
+    vi.mocked(api.obterExtratoFuturo).mockResolvedValue(projecaoComDados);
+
+    renderExtratoFuturo();
+    await aguardarCarregamento();
+
+    expect(screen.getByText('Julho de 2026')).toBeInTheDocument();
+    expect(screen.getByText('Notebook 2/10')).toBeInTheDocument();
+    expect(screen.getByText(/Parcela no cartão/i)).toBeInTheDocument();
+  });
+
+  it('deve exibir fatura com vencimento, status e valor', async () => {
+    vi.mocked(api.obterExtratoFuturo).mockResolvedValue(projecaoComDados);
+
+    renderExtratoFuturo();
+    await aguardarCarregamento();
+
+    expect(screen.getByText(/Fatura Cartão Nubank/i)).toBeInTheDocument();
+    expect(screen.getByText(/Vence em 08\/07\/2026/i)).toBeInTheDocument();
+    expect(screen.getByText('Aberta')).toBeInTheDocument();
+  });
+
+  it('deve marcar fatura como paga e recarregar a projeção', async () => {
+    vi.mocked(api.obterExtratoFuturo).mockResolvedValue(projecaoComDados);
+    vi.mocked(api.pagarFatura).mockResolvedValue({ ...faturaJulho, status: 'PAGA' });
+
+    const usuario = userEvent.setup();
+
+    renderExtratoFuturo();
+    await aguardarCarregamento();
+
+    await usuario.click(screen.getByRole('button', { name: /Marcar paga/i }));
+
+    await waitFor(() => {
+      expect(api.pagarFatura).toHaveBeenCalledWith('fat-1');
+      expect(screen.getByText('Fatura marcada como paga.')).toBeInTheDocument();
+    });
+
+    expect(api.obterExtratoFuturo).toHaveBeenCalledTimes(2);
+  });
+
+  it('deve solicitar novo horizonte ao alterar a quantidade de meses', async () => {
+    const usuario = userEvent.setup();
+
+    renderExtratoFuturo();
+    await aguardarCarregamento();
+
+    const seletor = screen.getByRole('combobox', { name: /Quantidade de meses projetados/i });
+    await usuario.selectOptions(seletor, '6');
+
+    await waitFor(() => {
+      expect(api.obterExtratoFuturo).toHaveBeenLastCalledWith(6);
+    });
+  });
+
+  it('deve exibir erro quando a API falhar', async () => {
+    vi.mocked(api.obterExtratoFuturo).mockRejectedValueOnce(new Error('Falha na API'));
+
+    renderExtratoFuturo();
+    await aguardarCarregamento();
+
+    expect(screen.getByText('Não foi possível carregar o extrato futuro.')).toBeInTheDocument();
+  });
+});

--- a/app-financeiro-front-end/src/pages/ExtratoFuturo.tsx
+++ b/app-financeiro-front-end/src/pages/ExtratoFuturo.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import LayoutPrivado from '../components/layout/LayoutPrivado';
 import EstadoVazio from '../components/ui/EstadoVazio';
+import MensagemAlerta from '../components/ui/MensagemAlerta';
 import {
   obterExtratoFuturo,
   obterMensagemErroApi,
@@ -39,6 +40,7 @@ const ExtratoFuturo = () => {
   const [projecao, setProjecao] = useState<ProjecaoMensalResponse[]>([]);
   const [horizonte, setHorizonte] = useState(3);
   const [carregando, setCarregando] = useState(true);
+  const [erroCarregamento, setErroCarregamento] = useState('');
   const [erro, setErro] = useState('');
   const [mensagem, setMensagem] = useState('');
   const [faturaPagandoId, setFaturaPagandoId] = useState<string | null>(null);
@@ -49,13 +51,15 @@ const ExtratoFuturo = () => {
 
     const carregar = async () => {
       setCarregando(true);
-      setErro('');
+      setErroCarregamento('');
 
       try {
         const dados = await obterExtratoFuturo(horizonte);
         if (ativo) setProjecao(dados);
       } catch (erroApi) {
-        if (ativo) setErro(obterMensagemErroApi(erroApi, 'Não foi possível carregar o extrato futuro.'));
+        if (ativo) {
+          setErroCarregamento(obterMensagemErroApi(erroApi, 'Não foi possível carregar o extrato futuro.'));
+        }
       } finally {
         if (ativo) setCarregando(false);
       }
@@ -91,7 +95,7 @@ const ExtratoFuturo = () => {
 
   const semMovimentacoesFuturas =
     !carregando &&
-    !erro &&
+    !erroCarregamento &&
     projecao.every((mes) => mes.transacoes.length === 0 && mes.faturas.length === 0);
 
   const ultimoMes = projecao.at(-1);
@@ -103,28 +107,16 @@ const ExtratoFuturo = () => {
       titulo="Extrato futuro"
       subtitulo="Projeção de parcelas, boletos e faturas dos próximos meses."
     >
-      {mensagem && (
-        <div className="sb-alert sb-alert-success" role="status">
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M20 6 9 17l-5-5" />
-          </svg>
-          {mensagem}
-        </div>
+      <MensagemAlerta mensagem={mensagem} tipo="success" />
+      <MensagemAlerta mensagem={erroCarregamento || erro} tipo="danger" />
+
+      {carregando && (
+        <p className="loading-inline" aria-live="polite">
+          Carregando extrato futuro…
+        </p>
       )}
 
-      {erro && (
-        <div className="sb-alert sb-alert-danger" role="alert">
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" />
-            <path d="M12 8v4M12 16h.01" />
-          </svg>
-          {erro}
-        </div>
-      )}
-
-      {carregando && <p className="loading-inline">Carregando extrato futuro…</p>}
-
-      {!carregando && !erro && (
+      {!carregando && !erroCarregamento && (
         <>
           <section className="future-hero" aria-label="Resumo da projeção">
             <div className="future-hero-glow" aria-hidden="true" />

--- a/app-financeiro-front-end/src/pages/ExtratoFuturo.tsx
+++ b/app-financeiro-front-end/src/pages/ExtratoFuturo.tsx
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import LayoutPrivado from '../components/layout/LayoutPrivado';
+import EstadoVazio from '../components/ui/EstadoVazio';
+import {
+  obterExtratoFuturo,
+  obterMensagemErroApi,
+  pagarFatura,
+  type ProjecaoMensalResponse,
+  type StatusFatura,
+  type TipoPagamento,
+} from '../services/api';
+import { formatarData, formatarMoeda } from '../utils/formatacao';
+
+const NOMES_MESES = [
+  'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho',
+  'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro',
+];
+
+const ROTULOS_PAGAMENTO: Record<TipoPagamento, string> = {
+  PIX: 'Pix',
+  CARTAO_DEBITO: 'Cartão de débito',
+  CARTAO_CREDITO: 'Parcela no cartão',
+  DINHEIRO: 'Dinheiro',
+  BOLETO: 'Boleto',
+  TED_DOC: 'TED/DOC',
+};
+
+const ROTULOS_STATUS: Record<StatusFatura, string> = {
+  ABERTA: 'Aberta',
+  FECHADA: 'Fechada',
+  PAGA: 'Paga',
+};
+
+const rotuloMes = (projecao: ProjecaoMensalResponse) =>
+  `${NOMES_MESES[projecao.mes - 1]} de ${projecao.ano}`;
+
+const ExtratoFuturo = () => {
+  const [projecao, setProjecao] = useState<ProjecaoMensalResponse[]>([]);
+  const [horizonte, setHorizonte] = useState(3);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+  const [mensagem, setMensagem] = useState('');
+  const [faturaPagandoId, setFaturaPagandoId] = useState<string | null>(null);
+  const [recarregar, setRecarregar] = useState(0);
+
+  useEffect(() => {
+    let ativo = true;
+
+    const carregar = async () => {
+      setCarregando(true);
+      setErro('');
+
+      try {
+        const dados = await obterExtratoFuturo(horizonte);
+        if (ativo) setProjecao(dados);
+      } catch (erroApi) {
+        if (ativo) setErro(obterMensagemErroApi(erroApi, 'Não foi possível carregar o extrato futuro.'));
+      } finally {
+        if (ativo) setCarregando(false);
+      }
+    };
+
+    void carregar();
+
+    return () => {
+      ativo = false;
+    };
+  }, [horizonte, recarregar]);
+
+  useEffect(() => {
+    if (!mensagem) return;
+    const temporizador = setTimeout(() => setMensagem(''), 3000);
+    return () => clearTimeout(temporizador);
+  }, [mensagem]);
+
+  const marcarFaturaComoPaga = useCallback(async (faturaId: string) => {
+    setFaturaPagandoId(faturaId);
+    setErro('');
+
+    try {
+      await pagarFatura(faturaId);
+      setMensagem('Fatura marcada como paga.');
+      setRecarregar((atual) => atual + 1);
+    } catch (erroApi) {
+      setErro(obterMensagemErroApi(erroApi, 'Não foi possível pagar a fatura.'));
+    } finally {
+      setFaturaPagandoId(null);
+    }
+  }, []);
+
+  const semMovimentacoesFuturas =
+    !carregando &&
+    !erro &&
+    projecao.every((mes) => mes.transacoes.length === 0 && mes.faturas.length === 0);
+
+  const ultimoMes = projecao.at(-1);
+  const totalAReceber = projecao.reduce((soma, mes) => soma + mes.totalCreditos, 0);
+  const totalAPagar = projecao.reduce((soma, mes) => soma + mes.totalDebitos, 0);
+
+  return (
+    <LayoutPrivado
+      titulo="Extrato futuro"
+      subtitulo="Projeção de parcelas, boletos e faturas dos próximos meses."
+    >
+      {mensagem && (
+        <div className="sb-alert sb-alert-success" role="status">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+          {mensagem}
+        </div>
+      )}
+
+      {erro && (
+        <div className="sb-alert sb-alert-danger" role="alert">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 8v4M12 16h.01" />
+          </svg>
+          {erro}
+        </div>
+      )}
+
+      {carregando && <p className="loading-inline">Carregando extrato futuro…</p>}
+
+      {!carregando && !erro && (
+        <>
+          <section className="future-hero" aria-label="Resumo da projeção">
+            <div className="future-hero-glow" aria-hidden="true" />
+
+            <header className="future-hero-header">
+              <div>
+                <p className="future-hero-eyebrow">Horizonte de projeção</p>
+                <h2>O seu dinheiro, alguns meses à frente</h2>
+              </div>
+
+              <label className="future-horizon">
+                <span>Meses</span>
+                <select
+                  value={horizonte}
+                  onChange={(evento) => setHorizonte(Number(evento.target.value))}
+                  aria-label="Quantidade de meses projetados"
+                >
+                  <option value={3}>3 meses</option>
+                  <option value={6}>6 meses</option>
+                  <option value={12}>12 meses</option>
+                </select>
+              </label>
+            </header>
+
+            <dl className="future-hero-stats">
+              <div className="future-hero-stat">
+                <dt>Saldo previsto {ultimoMes ? `em ${rotuloMes(ultimoMes)}` : ''}</dt>
+                <dd className={ultimoMes && ultimoMes.saldoPrevisto < 0 ? 'negativo' : ''}>
+                  {formatarMoeda(ultimoMes?.saldoPrevisto ?? 0)}
+                </dd>
+              </div>
+              <div className="future-hero-stat">
+                <dt>A receber no período</dt>
+                <dd className="positivo">{formatarMoeda(totalAReceber)}</dd>
+              </div>
+              <div className="future-hero-stat">
+                <dt>A pagar no período</dt>
+                <dd className="negativo">{formatarMoeda(totalAPagar)}</dd>
+              </div>
+            </dl>
+          </section>
+
+          {semMovimentacoesFuturas ? (
+            <EstadoVazio
+              titulo="Nada projetado por aqui — ainda"
+              descricao="Parcelamentos, boletos a vencer e faturas de cartão em aberto aparecem nesta linha do tempo assim que forem registrados."
+              acao={
+                <NavLink className="sb-button sb-button-primary" to="/transacoes/nova">
+                  Registrar transação futura
+                </NavLink>
+              }
+            />
+          ) : (
+            <ol className="future-timeline" aria-label="Projeção mês a mês">
+              {projecao.map((mes, indice) => (
+                <li
+                  key={`${mes.ano}-${mes.mes}`}
+                  className="future-month"
+                  style={{ animationDelay: `${indice * 90}ms` }}
+                >
+                  <div className="future-month-marker" aria-hidden="true">
+                    <span className={indice === 0 ? 'future-dot future-dot-atual' : 'future-dot'} />
+                  </div>
+
+                  <article className="future-month-card">
+                    <header className="future-month-header">
+                      <div>
+                        <h3>{rotuloMes(mes)}</h3>
+                        {indice === 0 && <span className="future-month-tag">Mês atual</span>}
+                      </div>
+                      <p
+                        className={
+                          mes.saldoPrevisto < 0
+                            ? 'future-month-saldo negativo'
+                            : 'future-month-saldo'
+                        }
+                      >
+                        <span>Saldo previsto</span>
+                        <strong>{formatarMoeda(mes.saldoPrevisto)}</strong>
+                      </p>
+                    </header>
+
+                    <div className="future-month-totais">
+                      <p>
+                        <span>Créditos</span>
+                        <strong className="amount-positive">{formatarMoeda(mes.totalCreditos)}</strong>
+                      </p>
+                      <p>
+                        <span>Débitos</span>
+                        <strong className="amount-negative">{formatarMoeda(mes.totalDebitos)}</strong>
+                      </p>
+                    </div>
+
+                    {mes.faturas.length > 0 && (
+                      <ul className="future-faturas" aria-label={`Faturas com vencimento em ${rotuloMes(mes)}`}>
+                        {mes.faturas.map((fatura) => (
+                          <li key={fatura.faturaId} className="future-fatura">
+                            <div className="future-fatura-icone" aria-hidden="true">
+                              <svg viewBox="0 0 24 24">
+                                <rect x="2" y="5" width="20" height="14" rx="3" />
+                                <path d="M2 10h20" />
+                              </svg>
+                            </div>
+                            <div className="future-fatura-info">
+                              <strong>Fatura {fatura.contaNome ?? 'do cartão'}</strong>
+                              <small>
+                                Vence em{' '}
+                                {fatura.dataVencimento ? formatarData(fatura.dataVencimento) : 'data não informada'}
+                              </small>
+                            </div>
+                            <span className={`future-status future-status-${fatura.status.toLowerCase()}`}>
+                              {ROTULOS_STATUS[fatura.status]}
+                            </span>
+                            <strong className="future-fatura-valor">{formatarMoeda(fatura.valorTotal)}</strong>
+                            {fatura.status !== 'PAGA' && (
+                              <button
+                                type="button"
+                                className="sb-button sb-button-secondary sb-button-xs"
+                                disabled={faturaPagandoId === fatura.faturaId}
+                                onClick={() => void marcarFaturaComoPaga(fatura.faturaId)}
+                              >
+                                {faturaPagandoId === fatura.faturaId ? 'Pagando…' : 'Marcar paga'}
+                              </button>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+
+                    {mes.transacoes.length > 0 ? (
+                      <ul className="future-transacoes" aria-label={`Lançamentos futuros de ${rotuloMes(mes)}`}>
+                        {mes.transacoes.map((transacao) => (
+                          <li key={transacao.transacaoId} className="future-transacao">
+                            <span
+                              className={
+                                transacao.tipoTransacao === 'CREDITO'
+                                  ? 'transaction-dot positive'
+                                  : 'transaction-dot negative'
+                              }
+                              aria-hidden="true"
+                            />
+                            <div className="future-transacao-info">
+                              <strong>{transacao.descricao || 'Sem descrição'}</strong>
+                              <small>
+                                {formatarData(transacao.data)}
+                                {transacao.formaPagamento
+                                  ? ` · ${ROTULOS_PAGAMENTO[transacao.formaPagamento]}`
+                                  : ''}
+                              </small>
+                            </div>
+                            <strong
+                              className={
+                                transacao.tipoTransacao === 'CREDITO' ? 'amount-positive' : 'amount-negative'
+                              }
+                            >
+                              {transacao.tipoTransacao === 'CREDITO' ? '+' : '−'}
+                              {formatarMoeda(transacao.valor)}
+                            </strong>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      mes.faturas.length === 0 && (
+                        <p className="future-month-vazio">Nenhum lançamento projetado para este mês.</p>
+                      )
+                    )}
+                  </article>
+                </li>
+              ))}
+            </ol>
+          )}
+        </>
+      )}
+    </LayoutPrivado>
+  );
+};
+
+export default ExtratoFuturo;

--- a/app-financeiro-front-end/src/services/api.ts
+++ b/app-financeiro-front-end/src/services/api.ts
@@ -137,6 +137,30 @@ export interface CategorizarTransacaoResponse{
   categoriaId: string;
 }
 
+export type StatusFatura = 'ABERTA' | 'FECHADA' | 'PAGA';
+
+export interface FaturaResumoResponse {
+  faturaId: string;
+  contaId: string;
+  contaNome?: string | null;
+  mesReferencia?: string | null;
+  dataVencimento?: string | null;
+  valorTotal: number;
+  status: StatusFatura;
+}
+
+export interface ProjecaoMensalResponse {
+  ano: number;
+  mes: number;
+  dataInicio: string;
+  dataFim: string;
+  saldoPrevisto: number;
+  totalDebitos: number;
+  totalCreditos: number;
+  faturas: FaturaResumoResponse[];
+  transacoes: TransacaoResponse[];
+}
+
 interface ErroApiPayload {
   erro?: unknown;
   message?: unknown;
@@ -256,6 +280,26 @@ export const listarTransacoes = async (params: FiltroTransacoesParams = {}) => {
   if (params.tipo) query.tipo = params.tipo;
 
   const { data } = await api.get<PaginaResponse<TransacaoResponse>>('/transacoes', { params: query });
+  return data;
+};
+
+export const obterExtratoFuturo = async (meses = 3) => {
+  const { data } = await api.get<ProjecaoMensalResponse[]>('/extrato-futuro', { params: { meses } });
+  return data;
+};
+
+export const listarFaturasDaConta = async (contaId: string) => {
+  const { data } = await api.get<FaturaResumoResponse[]>(`/contas/${contaId}/faturas`);
+  return data;
+};
+
+export const buscarFatura = async (faturaId: string) => {
+  const { data } = await api.get<FaturaResumoResponse>(`/faturas/${faturaId}`);
+  return data;
+};
+
+export const pagarFatura = async (faturaId: string) => {
+  const { data } = await api.patch<FaturaResumoResponse>(`/faturas/${faturaId}/pagar`);
   return data;
 };
 

--- a/app-financeiro-front-end/src/services/api.ts
+++ b/app-financeiro-front-end/src/services/api.ts
@@ -288,16 +288,6 @@ export const obterExtratoFuturo = async (meses = 3) => {
   return data;
 };
 
-export const listarFaturasDaConta = async (contaId: string) => {
-  const { data } = await api.get<FaturaResumoResponse[]>(`/contas/${contaId}/faturas`);
-  return data;
-};
-
-export const buscarFatura = async (faturaId: string) => {
-  const { data } = await api.get<FaturaResumoResponse>(`/faturas/${faturaId}`);
-  return data;
-};
-
 export const pagarFatura = async (faturaId: string) => {
   const { data } = await api.patch<FaturaResumoResponse>(`/faturas/${faturaId}/pagar`);
   return data;

--- a/app-financeiro-front-end/src/styles/global.css
+++ b/app-financeiro-front-end/src/styles/global.css
@@ -1710,3 +1710,440 @@ button:disabled {
   margin: 0 0 16px;
   color: var(--sb-text-muted);
 }
+
+/* ===== Extrato futuro ===== */
+
+.future-hero {
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 26px;
+  padding: 26px clamp(20px, 3vw, 34px) 28px;
+  border-radius: 26px;
+  background: var(--sb-gradient);
+  color: #F4FBF8;
+  box-shadow: 0 24px 50px rgba(14, 22, 36, 0.28);
+}
+
+.future-hero-glow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(420px 180px at 85% -20%, rgba(255, 200, 61, 0.22), transparent 70%),
+    radial-gradient(520px 240px at -10% 120%, rgba(108, 197, 178, 0.25), transparent 72%);
+}
+
+.future-hero-header {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.future-hero-eyebrow {
+  margin: 0 0 4px;
+  color: var(--sb-accent);
+  font-size: 0.74rem;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.future-hero-header h2 {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.4vw, 1.6rem);
+  letter-spacing: -0.03em;
+  color: #FFFFFF;
+}
+
+.future-horizon {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.future-horizon span {
+  color: rgba(244, 251, 248, 0.66);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.future-horizon select {
+  min-height: 40px;
+  padding: 0 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(244, 251, 248, 0.28);
+  background: rgba(14, 22, 36, 0.35);
+  color: #FFFFFF;
+  outline: none;
+}
+
+.future-horizon select:focus {
+  border-color: var(--sb-accent);
+  box-shadow: 0 0 0 4px rgba(255, 200, 61, 0.18);
+}
+
+.future-hero-stats {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 22px 0 0;
+}
+
+.future-hero-stat {
+  padding: 16px 18px;
+  border: 1px solid rgba(244, 251, 248, 0.16);
+  border-radius: 18px;
+  background: rgba(14, 22, 36, 0.28);
+  backdrop-filter: blur(6px);
+}
+
+.future-hero-stat dt {
+  margin: 0 0 6px;
+  color: rgba(244, 251, 248, 0.66);
+  font-size: 0.78rem;
+  font-weight: 750;
+}
+
+.future-hero-stat dd {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.4vw, 1.7rem);
+  font-weight: 850;
+  letter-spacing: -0.03em;
+  color: #FFFFFF;
+}
+
+.future-hero-stat dd.positivo {
+  color: #8FE3CD;
+}
+
+.future-hero-stat dd.negativo {
+  color: #FFB4A8;
+}
+
+.future-timeline {
+  margin: 0;
+  padding: 6px 0 0;
+  list-style: none;
+}
+
+.future-month {
+  position: relative;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 6px;
+  opacity: 0;
+  animation: future-rise 0.5s ease forwards;
+}
+
+.future-month-marker {
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+
+.future-month-marker::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(47, 169, 143, 0.45), rgba(47, 169, 143, 0.08));
+}
+
+.future-month:last-child .future-month-marker::before {
+  background: linear-gradient(180deg, rgba(47, 169, 143, 0.45), transparent 80%);
+}
+
+.future-dot {
+  position: relative;
+  z-index: 1;
+  width: 14px;
+  height: 14px;
+  margin-top: 26px;
+  border-radius: 999px;
+  background: var(--sb-primary);
+  box-shadow: 0 0 0 4px rgba(47, 169, 143, 0.18);
+}
+
+.future-dot-atual {
+  background: var(--sb-accent);
+  box-shadow: 0 0 0 4px rgba(255, 200, 61, 0.26);
+}
+
+.future-month-card {
+  margin: 0 0 18px;
+  padding: 20px 22px;
+  border: 1px solid var(--sb-border);
+  border-radius: 24px;
+  background: var(--sb-surface);
+  box-shadow: var(--sb-shadow);
+}
+
+.future-month-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.future-month-header h3 {
+  margin: 0;
+  color: var(--sb-primary-dark);
+  font-size: 1.12rem;
+  letter-spacing: -0.02em;
+}
+
+.future-month-tag {
+  display: inline-block;
+  margin-top: 5px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: var(--sb-warning-soft);
+  color: var(--sb-warning);
+  font-size: 0.7rem;
+  font-weight: 850;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.future-month-saldo {
+  margin: 0;
+  text-align: right;
+}
+
+.future-month-saldo span {
+  display: block;
+  color: var(--sb-text-muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.future-month-saldo strong {
+  display: block;
+  margin-top: 3px;
+  color: var(--sb-success);
+  font-size: 1.18rem;
+  letter-spacing: -0.02em;
+}
+
+.future-month-saldo.negativo strong {
+  color: var(--sb-danger);
+}
+
+.future-month-totais {
+  display: flex;
+  gap: 26px;
+  margin: 14px 0 0;
+  padding: 12px 16px;
+  border-radius: 16px;
+  background: var(--sb-surface-soft);
+}
+
+.future-month-totais p {
+  margin: 0;
+}
+
+.future-month-totais span {
+  display: block;
+  color: var(--sb-text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.future-month-totais strong {
+  display: block;
+  margin-top: 2px;
+  font-size: 0.98rem;
+}
+
+.future-faturas,
+.future-transacoes {
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.future-fatura {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 200, 61, 0.4);
+  border-radius: 16px;
+  background: var(--sb-warning-soft);
+}
+
+.future-fatura-icone {
+  width: 38px;
+  height: 38px;
+  flex: 0 0 38px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: var(--sb-primary-dark);
+  color: var(--sb-accent);
+}
+
+.future-fatura-icone svg {
+  width: 19px;
+  height: 19px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.future-fatura-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.future-fatura-info strong {
+  display: block;
+  color: var(--sb-primary-dark);
+  font-size: 0.95rem;
+}
+
+.future-fatura-info small {
+  display: block;
+  margin-top: 2px;
+  color: var(--sb-text-muted);
+  font-weight: 650;
+}
+
+.future-fatura-valor {
+  color: var(--sb-primary-dark);
+  font-size: 0.98rem;
+  white-space: nowrap;
+}
+
+.future-status {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 850;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.future-status-aberta {
+  background: var(--sb-info-soft);
+  color: var(--sb-info);
+}
+
+.future-status-fechada {
+  background: var(--sb-warning-soft);
+  color: var(--sb-warning);
+  border: 1px solid rgba(154, 106, 0, 0.25);
+}
+
+.future-status-paga {
+  background: var(--sb-success-soft);
+  color: var(--sb-success);
+}
+
+.future-transacao {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 14px;
+  border: 1px solid var(--sb-border);
+  border-radius: 16px;
+  background: #FAFCFB;
+}
+
+.future-transacao-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.future-transacao-info strong {
+  display: block;
+  color: var(--sb-primary-dark);
+  font-size: 0.95rem;
+}
+
+.future-transacao-info small {
+  display: block;
+  margin-top: 2px;
+  color: var(--sb-text-muted);
+  font-weight: 650;
+}
+
+.future-month-vazio {
+  margin: 14px 0 0;
+  color: var(--sb-text-muted);
+  font-size: 0.9rem;
+}
+
+@keyframes future-rise {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .future-month {
+    opacity: 1;
+    animation: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .future-hero-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .future-horizon {
+    width: 100%;
+  }
+
+  .future-horizon select {
+    width: 100%;
+  }
+
+  .future-month {
+    grid-template-columns: 22px minmax(0, 1fr);
+  }
+
+  .future-fatura {
+    flex-wrap: wrap;
+  }
+
+  .future-fatura .sb-button {
+    width: 100%;
+  }
+
+  .future-month-header {
+    flex-direction: column;
+  }
+
+  .future-month-saldo {
+    text-align: left;
+  }
+
+  .future-month-totais {
+    justify-content: space-between;
+  }
+}

--- a/app-financeiro-front-end/src/styles/global.css
+++ b/app-financeiro-front-end/src/styles/global.css
@@ -1765,7 +1765,7 @@ button:disabled {
 }
 
 .future-horizon span {
-  color: rgba(244, 251, 248, 0.66);
+  color: rgba(244, 251, 248, 0.88);
   font-size: 0.72rem;
   font-weight: 800;
   text-transform: uppercase;
@@ -1805,7 +1805,7 @@ button:disabled {
 
 .future-hero-stat dt {
   margin: 0 0 6px;
-  color: rgba(244, 251, 248, 0.66);
+  color: rgba(244, 251, 248, 0.88);
   font-size: 0.78rem;
   font-weight: 750;
 }
@@ -2016,6 +2016,7 @@ button:disabled {
   display: block;
   color: var(--sb-primary-dark);
   font-size: 0.95rem;
+  overflow-wrap: anywhere;
 }
 
 .future-fatura-info small {
@@ -2076,6 +2077,7 @@ button:disabled {
   display: block;
   color: var(--sb-primary-dark);
   font-size: 0.95rem;
+  overflow-wrap: anywhere;
 }
 
 .future-transacao-info small {


### PR DESCRIPTION
## O que mudou

**Backend**
- `ExtratoFuturoService` + `GET /extrato-futuro?meses=` (default 3, máx 12): projeção mês a mês com saldo previsto, total de débitos, total de créditos, lista de faturas com vencimento no mês e lançamentos futuros (parcelas e boletos).
- `FaturaService` (`gerarFatura`, `buscarPorConta`, `buscarPorId`, `calcularTotal`, `pagar`) + `FaturaController`: `GET /contas/{id}/faturas`, `GET /faturas/{id}`, `PATCH /faturas/{id}/pagar`.
- `CartaoCreditoService` (`associar`, `buscarPorConta`), `FaturaMapper`, DTOs (`ProjecaoMensalDTO`, `FaturaResumoDTO`, `CartaoCreditoRequestDTO`) e queries novas nos repositories de fatura, cartão e transação.

**Frontend**
- Nova tela `/extrato-futuro` (item "Extrato futuro" no menu): hero com resumo do período (saldo previsto no fim do horizonte, total a receber/pagar) e seletor de horizonte (3/6/12 meses); linha do tempo por mês com saldo previsto, créditos/débitos, faturas (vencimento, status e ação de marcar como paga) e lançamentos futuros; estado vazio informativo.
- Novas funções/tipos em `api.ts`: `obterExtratoFuturo` e `pagarFatura`.

## Por quê

Closes #68 — extrato futuro é o diferencial do SmartBudget: projetar os próximos meses com base em parcelamentos, boletos a vencer e faturas de cartão abertas.

## Como testar

1. Backend: `cd app-financeiro-back-end && ./gradlew test` (suíte completa verde).
2. Frontend: `cd app-financeiro-front-end && npm ci && npm run build && npm test` (77 testes verdes, lint limpo).
3. Manual: logar, registrar transações com data futura (boleto e parcela no cartão) e acessar **Extrato futuro** no menu — cada lançamento aparece no mês correspondente; sem lançamentos futuros, aparece o estado vazio.

## Auto-review (checklist)

- [x] Critérios de aceitação da issue cobertos (parcelas por mês, boletos no mês correspondente, faturas com valor/vencimento, 3 meses por padrão, saldo previsto + totais + faturas por mês, estado vazio)
- [x] Ownership validado em todos os endpoints novos (403 para conta/fatura de outro usuário)
- [x] Testes novos: `ExtratoFuturoServiceTest`, `FaturaServiceTest`, `CartaoCreditoServiceTest`, `ExtratoFuturoControllerTest` (web layer / contrato JSON), `ExtratoFuturo.test.tsx`
- [x] Passou por rodada de self-review com agentes (correção backend, frontend/a11y, contrato API/testes) — ajustes nos 2 últimos commits
- [x] Layout responsivo (media queries ≤720px) e `prefers-reduced-motion` respeitado
- [x] Sem migração de banco necessária (tabelas `fatura` e `cartao_credito` já existem na V1)

## Comentários técnicos

- Pós-#176 não existem mais tipos PARCELAMENTO/BOLETO em `TipoTransacao`; a projeção considera transações com `data > hoje` (parcelas = `CARTAO_CREDITO`, boletos = `BOLETO` em `formaPagamento`), conforme os critérios da issue reinterpretados para o modelo atual.
- **Sem dupla contagem:** lançamentos vinculados a fatura (compras e estornos) entram pelo `valorTotal` da fatura no mês do vencimento, não pelo lançamento individual — tanto nos totais projetados quanto no saldo histórico (lançamento de fatura em aberto só sai do caixa no vencimento). O lançamento continua visível na lista do mês da compra.
- **Saldo previsto é acumulado:** parte do saldo histórico real (transações até hoje) e propaga mês a mês com créditos − débitos projetados.
- **Fatura atrasada** (não paga, vencida antes da janela) pesa no primeiro mês projetado, em vez de sumir da projeção.
- `gerarFatura` é get-or-create por conta+mês; vencimento derivado de `dia_vencimento`/`dia_fechamento` do cartão (vence no mês seguinte quando o dia de vencimento ≤ dia de fechamento; dia ajustado ao tamanho do mês).
- `PATCH /faturas/{id}/pagar` retorna 409 para fatura já paga.
- `CartaoCreditoService.associar`, `gerarFatura` e `calcularTotal` ainda não têm chamadores no fluxo de produção — são a base para o fluxo de importação/fatura (escopo incremental; a issue não pede controller de cartão nem geração automática de fatura).
